### PR TITLE
Add a configure option to disable building the backward compatibility…

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -979,6 +979,21 @@ else
     WANT_INSTALL_HEADERS=0
 fi
 
+#
+# Install backward compatibility support for PMI-1 and PMI-2
+#
+AC_MSG_CHECKING([if want backward compatibility for PMI-1 and PMI-2])
+AC_ARG_ENABLE(pmix-backward-compatibility,
+              AC_HELP_STRING([--enable-pmix-backward-compatibility],
+                             [enable PMIx support for PMI-1 and PMI-2 (default: enabled)]))
+if test "$enable_pmix_backward_compatibility" = "no"; then
+    AC_MSG_RESULT([no])
+    WANT_PMIX_BACKWARD=0
+else
+    AC_MSG_RESULT([yes])
+    WANT_PMIX_BACKWARD=1
+fi
+
 AM_CONDITIONAL([WANT_INSTALL_HEADERS], [test $WANT_INSTALL_HEADERS -eq 1])
 ])dnl
 
@@ -994,6 +1009,7 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([WANT_DSTORE], [test "x$enable_dstore" != "xno"])
         AM_CONDITIONAL([WANT_PRIMARY_HEADERS], [test "x$pmix_install_primary_headers" = "xyes"])
         AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
+        AM_CONDITIONAL(WANT_PMIX_BACKWARD, test "$WANT_PMIX_BACKWARD" = 1)
     ])
     pmix_did_am_conditionals=yes
 ])dnl

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -15,9 +15,13 @@ include_HEADERS = \
         pmix.h \
         pmix_common.h \
         pmix_server.h \
-        pmi.h \
-        pmi2.h \
         pmix_tool.h
+
+if WANT_PMIX_BACKWARD
+include_HEADERS += \
+        pmi.h \
+        pmi2.h
+endif
 
 nodist_include_HEADERS = \
     pmix_version.h \

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 #
-# Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
 #                         All rights reserved.
 # Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
@@ -22,7 +22,7 @@ sources += \
         client/pmix_client_spawn.c \
         client/pmix_client_connect.c
 
-if !PMIX_EMBEDDED_MODE
+if WANT_PMIX_BACKWARD
 sources += \
         client/pmi1.c \
         client/pmi2.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -32,7 +32,12 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
 noinst_SCRIPTS = pmix_client_otheruser.sh
-noinst_PROGRAMS = pmi_client pmi2_client
+noinst_PROGRAMS =
+
+if WANT_PMIX_BACKWARD
+noinst_PROGRAMS += pmi_client pmi2_client
+endif
+
 if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
 endif
@@ -43,6 +48,7 @@ pmix_test_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_test_LDADD = \
     $(top_builddir)/src/libpmix.la
 
+if WANT_PMIX_BACKWARD
 pmi_client_SOURCES = $(headers) \
         pmi_client.c
 pmi_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -54,6 +60,7 @@ pmi2_client_SOURCES = $(headers) \
 pmi2_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi2_client_LDADD = \
     $(top_builddir)/src/libpmix.la
+endif
 
 pmix_client_SOURCES = $(headers) \
         pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c \


### PR DESCRIPTION
… support for PMI-1 and PMI-2 as these are not always desirable since they can cause conflicts with other PMI-1/2 libraries on the system.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>