### PR TITLE
Allow a user to disable backward compatibility for PMI-1/2 as these c…

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -844,6 +844,21 @@ fi
 AC_DEFINE_UNQUOTED([PMIX_ENABLE_TIMING], [$WANT_TIMING],
                    [Whether we want developer-level timing support or not])
 
+#
+# Install backward compatibility support for PMI-1 and PMI-2
+#
+AC_MSG_CHECKING([if want backward compatibility for PMI-1 and PMI-2])
+AC_ARG_ENABLE(pmi-backward-compatibility,
+              AC_HELP_STRING([--enable-pmi-backward-compatibility],
+                             [enable PMIx support for PMI-1 and PMI-2 (default: enabled)]))
+if test "$enable_pmi_backward_compatibility" = "no"; then
+    AC_MSG_RESULT([no])
+    WANT_PMI_BACKWARD=0
+else
+    AC_MSG_RESULT([yes])
+    WANT_PMI_BACKWARD=1
+fi
+
 ])dnl
 
 # Specify the symbol prefix
@@ -860,6 +875,7 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([PMIX_WANT_MUNGE], [test "$pmix_munge_support" = "1"])
         AM_CONDITIONAL([PMIX_WANT_SASL], [test "$pmix_sasl_support" = "1"])
         AM_CONDITIONAL([WANT_DSTORE],[test "x$enable_dstore" != "xno"])
+        AM_CONDITIONAL(WANT_PMI_BACKWARD, test "$WANT_PMI_BACKWARD" = 1)
     ])
     pmix_did_am_conditionals=yes
 ])dnl

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 #
 # $COPYRIGHT$
@@ -16,9 +16,13 @@ if ! PMIX_EMBEDDED_MODE
 include_HEADERS = \
         include/pmix.h \
         include/pmix_server.h \
-        include/pmi.h \
-        include/pmi2.h \
         include/pmix_version.h.in
+
+if WANT_PMI_BACKWARD
+include_HEADERS += \
+        include/pmi.h \
+        include/pmi2.h
+endif
 
 include_pmixdir = $(includedir)/pmix
 include_pmix_HEADERS = \

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2015 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
 #                         All rights reserved.
 # $COPYRIGHT$
@@ -20,7 +20,7 @@ sources += \
         src/client/pmix_client_spawn.c \
         src/client/pmix_client_connect.c
 
-if !PMIX_EMBEDDED_MODE
+if WANT_PMI_BACKWARD
 sources += \
         src/client/pmi1.c \
         src/client/pmi2.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -31,8 +31,14 @@ headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/src/api
 
+noinst_PROGRAMS =
+
 noinst_SCRIPTS = pmix_client_otheruser.sh
-noinst_PROGRAMS = pmi_client pmi2_client
+
+if WANT_PMI_BACKWARD
+noinst_PROGRAMS += pmi_client pmi2_client
+endif
+
 if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
 endif
@@ -43,6 +49,7 @@ pmix_test_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmix_test_LDADD = \
 	$(top_builddir)/libpmix.la
 
+if WANT_PMI_BACKWARD
 pmi_client_SOURCES = $(headers) \
         pmi_client.c
 pmi_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
@@ -54,6 +61,7 @@ pmi2_client_SOURCES = $(headers) \
 pmi2_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi2_client_LDADD = \
 	$(top_builddir)/libpmix.la
+endif
 
 pmix_client_SOURCES = $(headers) \
         pmix_client.c test_fence.c test_common.c test_publish.c test_spawn.c \


### PR DESCRIPTION
…an conflict with system-based equivalent libraries

Signed-off-by: Ralph Castain <rhc@open-mpi.org>