### PR TITLE
With this, libs (e.g., "-ldl") are not added to the wrapper LIBS

### DIFF
--- a/src/mca/pdl/pdlopen/configure.m4
+++ b/src/mca/pdl/pdlopen/configure.m4
@@ -63,7 +63,7 @@ AC_DEFUN([MCA_pmix_pdl_pdlopen_CONFIG],[
           ])
 
     AS_IF([test "$pmix_pdl_pdlopen_happy" = "yes"],
-          [pmix_pdl_pdlopen_ADD_LIBS=$pmix_pdl_pdlopen_LIBS
+          [pdl_pdlopen_ADD_LIBS=$pmix_pdl_pdlopen_LIBS
            $1],
           [$2])
 


### PR DESCRIPTION
flags. This may work on some platforms, but on at least RHEL 7.3, it
does not (i.e., compiling MPI applications fails because it can't find
dlopen).

Backported from OMPI

Signed-off-by: Ralph Castain <rhc@open-mpi.org>