### PR TITLE
Minor correction to allow libpmix to be installed in embedded scenarios when --with-devel-headers is given

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -51,9 +51,20 @@ libpmix_la_LIBADD = \
 libpmix_la_DEPENDENCIES = $(libpmix_la_LIBADD)
 
 if PMIX_EMBEDDED_MODE
+
+if WANT_INSTALL_HEADERS
+
+lib_LTLIBRARIES = libpmix.la
+libpmix_la_SOURCES = $(headers) $(sources)
+libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
+
+else
+
 noinst_LTLIBRARIES = libpmix.la
 libpmix_la_SOURCES = $(headers) $(sources)
 libpmix_la_LDFLAGS =
+
+endif
 
 else
 


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>