### PR TITLE
Run the lost_connection events thru an aggregator window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ test/simple/simpft
 test/simple/simpdyn
 test/simple/test_pmix
 test/simple/simptool
+test/simple/simpdie
 
 # coverity
 cov-int

--- a/src/buffer_ops/pack.c
+++ b/src/buffer_ops/pack.c
@@ -560,6 +560,11 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
                 return ret;
             }
             break;
+        case PMIX_POINTER:
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.ptr, 1, PMIX_POINTER))) {
+                return ret;
+            }
+            break;
         case PMIX_SCOPE:
             if (PMIX_SUCCESS != (ret = pmix_bfrop_pack_buffer(buffer, &p->data.scope, 1, PMIX_SCOPE))) {
                 return ret;

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -632,7 +632,7 @@ pmix_status_t pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             break;
         case PMIX_PROC:
             /* this field is now a pointer, so we must allocate storage for it */
-            PMIX_PROC_CREATE(val->data.proc, 1);
+            PMIX_PROC_CREATE(val->data.proc, m);
             if (NULL == val->data.proc) {
                 return PMIX_ERR_NOMEM;
             }
@@ -653,6 +653,11 @@ pmix_status_t pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             break;
         case PMIX_PERSIST:
             if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.proc, &m, PMIX_PROC))) {
+                return ret;
+            }
+            break;
+        case PMIX_POINTER:
+            if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_buffer(buffer, &val->data.ptr, &m, PMIX_POINTER))) {
                 return ret;
             }
             break;

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -948,6 +948,24 @@ static bool check_range(pmix_range_trkr_t *rng,
     return false;
 }
 
+void pmix_event_timeout_cb(int fd, short flags, void *arg)
+{
+    pmix_event_chain_t *ch = (pmix_event_chain_t*)arg;
+
+    ch->timer_active = false;
+
+    /* remove it from the list */
+    pmix_list_remove_item(&pmix_globals.cached_events, &ch->super);
+
+    /* process this event thru the regular channels */
+    if (PMIX_PROC_SERVER == pmix_globals.proc_type) {
+        pmix_server_notify_client_of_event(ch->status, &ch->source,
+                                           ch->range, ch->info, ch->ninfo,
+                                           ch->final_cbfunc, ch->final_cbdata);
+    } else {
+        pmix_invoke_local_event_hdlr(ch);
+    }
+}
 
 /****    CLASS INSTANTIATIONS    ****/
 
@@ -1021,6 +1039,7 @@ PMIX_CLASS_INSTANCE(pmix_events_t,
 
 static void chcon(pmix_event_chain_t *p)
 {
+    p->timer_active = false;
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN+1);
     p->source.rank = PMIX_RANK_UNDEF;
     p->nondefault = false;
@@ -1036,6 +1055,9 @@ static void chcon(pmix_event_chain_t *p)
 }
 static void chdes(pmix_event_chain_t *p)
 {
+    if (p->timer_active) {
+        pmix_event_del(&p->ev);
+    }
     if (NULL != p->info) {
         PMIX_INFO_FREE(p->info, p->ninfo);
     }
@@ -1044,5 +1066,5 @@ static void chdes(pmix_event_chain_t *p)
     }
 }
 PMIX_CLASS_INSTANCE(pmix_event_chain_t,
-                    pmix_object_t,
+                    pmix_list_item_t,
                     chcon, chdes);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -234,6 +234,8 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
             active->code = PMIX_MAX_ERR_CONSTANT;
             active->nregs = 1;
             pmix_list_append(&pmix_globals.events.actives, &active->super);
+            /* ensure we register it */
+            need_register = true;
         }
     } else {
         for (n=0; n < cd->ncodes; n++) {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -375,6 +375,8 @@ typedef struct {
     pmix_list_t nspaces;                // list of pmix_nspace_t for the nspaces we know about
     pmix_buffer_t *cache_local;         // data PUT by me to local scope
     pmix_buffer_t *cache_remote;        // data PUT by me to remote scope
+    struct timeval event_window;
+    pmix_list_t cached_events;          // events waiting in the window prior to processing
     pmix_ring_buffer_t notifications;   // ring buffer of pending notifications
 } pmix_globals_t;
 

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -114,6 +114,7 @@ void pmix_rte_finalize(void)
         PMIX_RELEASE(pmix_globals.cache_remote);
     }
     PMIX_DESTRUCT(&pmix_globals.events);
+    PMIX_LIST_DESTRUCT(&pmix_globals.cached_events);
 
     /* now safe to release the event base */
     if (!pmix_globals.external_evbase) {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -153,6 +153,9 @@ int pmix_rte_init(pmix_proc_type_t type,
     memset(&pmix_globals.myid, 0, sizeof(pmix_proc_t));
     PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_globals.events, pmix_events_t);
+    pmix_globals.event_window.tv_sec = pmix_event_caching_window;
+    pmix_globals.event_window.tv_usec = 0;
+    PMIX_CONSTRUCT(&pmix_globals.cached_events, pmix_list_t);
     /* get our effective id's */
     pmix_globals.uid = geteuid();
     pmix_globals.gid = getegid();

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -43,6 +43,7 @@ bool pmix_timing_overhead = true;
 
 static bool pmix_register_done = false;
 char *pmix_net_private_ipv4 = NULL;
+int pmix_event_caching_window;
 
 pmix_status_t pmix_register_params(void)
 {
@@ -89,6 +90,14 @@ pmix_status_t pmix_register_params(void)
     if (0 > ret) {
         return ret;
     }
+
+    pmix_event_caching_window = 3;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", NULL, "event_caching_window",
+                                  "Time (in seconds) to cache events before reporting them - this "
+                                  "allows for event aggregation",
+                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                  PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                  &pmix_event_caching_window);
 
     return PMIX_SUCCESS;
 }

--- a/src/runtime/pmix_rte.h
+++ b/src/runtime/pmix_rte.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
  * Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -46,6 +46,7 @@ extern bool pmix_timing_overhead;
 
 extern int pmix_initialized;
 extern char *pmix_net_private_ipv4;
+extern int pmix_event_caching_window;
 
 /** version string of pmix */
 extern const char pmix_version_string[];

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,7 +21,7 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex test_pmix simptool
+noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex test_pmix simptool simpdie
 
 simptest_SOURCES = \
         simptest.c
@@ -69,4 +69,10 @@ simptool_SOURCES = \
         simptool.c
 simptool_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptool_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpdie_SOURCES = \
+        simpdie.c
+simpdie_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpdie_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/simpdie.c
+++ b/test/simple/simpdie.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "src/class/pmix_object.h"
+#include "src/buffer_ops/types.h"
+#include "src/util/argv.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+static pmix_proc_t myproc;
+static bool completed;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    size_t n;
+
+    pmix_output(0, "Client %s:%d NOTIFIED with status %d source %s:%d and %d info",
+                myproc.nspace, myproc.rank, status, source->nspace, source->rank, (int)ninfo);
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_PROCID, PMIX_MAX_KEYLEN) &&
+            PMIX_PROC == info[n].value.type) {
+            pmix_output(0, "[%s:%d] added proc: %s:%d", myproc.nspace, myproc.rank,
+                        info[n].value.data.proc->nspace, info[n].value.data.proc->rank);
+        } else {
+            pmix_output(0, "[%s:%d] key: %s", myproc.nspace, myproc.rank, info[n].key);
+        }
+    }
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+    completed = true;
+}
+
+static void op_callbk(pmix_status_t status,
+                      void *cbdata)
+{
+    pmix_output(0, "CLIENT: OP CALLBACK CALLED WITH STATUS %d", status);
+}
+
+static void errhandler_reg_callbk (pmix_status_t status,
+                                   size_t errhandler_ref,
+                                   void *cbdata)
+{
+    pmix_output(0, "Client: ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
+                status, (unsigned long)errhandler_ref);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc;
+    uint32_t nprocs;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
+        exit(0);
+    }
+    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+
+    /* get our universe size */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %d", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
+    completed = false;
+
+    /* register our errhandler */
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, errhandler_reg_callbk, NULL);
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Fence failed: %d", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+
+    /* rank=0 dies */
+    if (4 < nprocs) {
+        /* have two exit */
+        if (myproc.rank < 2) {
+            pmix_output(0, "Client ns %s rank %d: bye-bye!", myproc.nspace, myproc.rank);
+            exit(1);
+        }
+    } else if (0 == myproc.rank) {
+        pmix_output(0, "Client ns %s rank %d: bye-bye!", myproc.nspace, myproc.rank);
+        exit(1);
+    }
+    /* everyone simply waits */
+    while (!completed) {
+        struct timespec ts;
+        ts.tv_sec = 0;
+        ts.tv_nsec = 100000;
+        nanosleep(&ts, NULL);
+    }
+
+ done:
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    PMIx_Deregister_event_handler(1, op_callbk, NULL);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}


### PR DESCRIPTION
Run the lost_connection events thru an aggregator window to damp out notification "ring" when the local RM kills the procs without deregistering them first. This causes the PMIx server to see every process lose its connection, but we only want one notification from it. Set a default window size of 3 seconds, controlled by an MCA parameter "pmix_event_caching_window"

Signed-off-by: Ralph Castain <rhc@open-mpi.org>