### PR TITLE
If we get an event with PMIX_RANGE_NAMESPACE, then we should set the …

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ *                          
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -847,6 +849,20 @@ pmix_status_t pmix_server_notify_client_of_event(pmix_status_t status,
                 }
             }
         }
+    }
+/*
+ * If the range is PMIX_RANGE_NAMESPACE, then they should not have set a 
+ * PMIX_EVENT_CUSTOM_RANGE info object or at least we should ignore it
+ */
+
+    if (PMIX_RANGE_NAMESPACE == cd->range) {
+       if (cd->targets) {
+         PMIX_PROC_FREE(cd->targets, cd->ntargets);
+       }
+       PMIX_PROC_CREATE(cd->targets, 1);
+       cd->ntargets = 1;
+       cd->targets[0].rank = PMIX_RANK_WILDCARD;
+       strncpy(cd->targets[0].nspace, source->nspace, PMIX_MAX_NSLEN);
     }
 
     /* pack the command */


### PR DESCRIPTION
…namespace

of the reporting proc as the target namespace for the event.

At present we ignore if the user set a custom range in the namespace, but
used PMIX_RANGE_NAMESPACE in the PMIx_Notify_event call.