### PR TITLE
Adjust the event aggregation window so there is less trial-and-error.

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -181,6 +181,9 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             PMIX_INFO_FREE(ch->info, ch->ninfo);                                    \
             ch->info = info;                                                        \
             ch->ninfo = ninfo;                                                      \
+            /* reset the timer */                                                   \
+            pmix_event_del(&ch->ev);                                                \
+            pmix_event_add(&ch->ev, &pmix_globals.event_window);                    \
         }                                                                           \
     } while(0)
 

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -43,7 +43,7 @@ bool pmix_timing_overhead = true;
 
 static bool pmix_register_done = false;
 char *pmix_net_private_ipv4 = NULL;
-int pmix_event_caching_window = 3;
+int pmix_event_caching_window = 1;
 bool pmix_suppress_missing_data_warning = false;
 
 pmix_status_t pmix_register_params(void)
@@ -93,8 +93,8 @@ pmix_status_t pmix_register_params(void)
     }
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", NULL, "event_caching_window",
-                                  "Time (in seconds) to cache events before reporting them - this "
-                                  "allows for event aggregation",
+                                  "Time (in seconds) to aggregate events before reporting them - this "
+                                  "suppresses event cascades when processes abnormally terminate",
                                   PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                   PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                   &pmix_event_caching_window);

--- a/test/simple/simpdie.c
+++ b/test/simple/simpdie.c
@@ -123,8 +123,12 @@ int main(int argc, char **argv)
 
     /* rank=0 dies */
     if (4 < nprocs) {
-        /* have two exit */
-        if (myproc.rank < 2) {
+        /* have one exit */
+        if (0 == myproc.rank) {
+            pmix_output(0, "Client ns %s rank %d: bye-bye!", myproc.nspace, myproc.rank);
+            exit(1);
+        } else if (1 == myproc.rank) {
+            usleep(500000);
             pmix_output(0, "Client ns %s rank %d: bye-bye!", myproc.nspace, myproc.rank);
             exit(1);
         }


### PR DESCRIPTION
Have the window be the time between events to allow for aggregation, instead of the total size of the window.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>