### PR TITLE
config: make config work with older autotools

### DIFF
--- a/config/pmix_setup_cc.m4
+++ b/config/pmix_setup_cc.m4
@@ -12,7 +12,7 @@ dnl Copyright (c) 2004-2006 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2007-2009 Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2012      Los Alamos National Security, LLC. All rights
+dnl Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
 dnl                         reserved.
 dnl Copyright (c) 2015      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
@@ -38,7 +38,6 @@ AC_DEFUN([PMIX_SETUP_CC],[
     AC_REQUIRE([AM_PROG_CC_C_O])
 
     # We require a C99 compiant compiler
-    AC_PROG_CC_C99
     # The result of AC_PROG_CC_C99 is stored in ac_cv_prog_cc_c99
     if test "x$ac_cv_prog_cc_c99" = xno ; then
         AC_MSG_WARN([PMIx requires a C99 compiler])
@@ -322,7 +321,7 @@ AC_DEFUN([_PMIX_PROG_CC],[
     #
     PMIX_VAR_SCOPE_PUSH([pmix_cflags_save dummy pmix_cc_arvgv0])
     pmix_cflags_save="$CFLAGS"
-    AC_PROG_CC
+    AC_PROG_CC_C99
     BASECC="`basename $CC`"
     CFLAGS="$pmix_cflags_save"
     AC_DEFINE_UNQUOTED(PMIX_CC, "$CC", [PMIx underlying C compiler])

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2006-2008 Sun Microsystems, Inc.  All rights reserved.
-# Copyright (c) 2006-2011 Los Alamos National Security, LLC.  All rights
+# Copyright (c) 2006-2017 Los Alamos National Security, LLC.  All rights
 #                         reserved.
 # Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 # Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
@@ -178,10 +178,6 @@ PMIX_DO_AM_CONDITIONALS
 ####################################################################
 # Setup C compiler
 ####################################################################
-
-CFLAGS_save="$CFLAGS"
-AC_PROG_CC
-CFLAGS="$CFLAGS_save"
 
 AC_ARG_VAR(CC_FOR_BUILD,[build system C compiler])
 AS_IF([test -z "$CC_FOR_BUILD"],[


### PR DESCRIPTION
This commit removes the invocation of AC_PROG_CC in the top
level configure.ac script and moves the AC_PROG_CC_C99 call
into _PMIX_PROG_CC to ensure that AC_PROG_CC is never called
after AM_PROG_CC_C_O. This allows pmix to build with the
autotools triple (automake: 1.13.4, autoconf: 2.69, libtool:
2.4.2).

Signed-off-by: Nathan Hjelm <hjelmn@lanl.gov>