### PR TITLE
client/get: Fix memory race in PMIx_Get

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -690,6 +690,44 @@ typedef struct pmix_byte_object {
 } pmix_byte_object_t;
 
 
+/****    PMIX DATA BUFFER    ****/
+typedef struct pmix_data_buffer {
+    /** Start of my memory */
+    char *base_ptr;
+    /** Where the next data will be packed to (within the allocated
+        memory starting at base_ptr) */
+    char *pack_ptr;
+    /** Where the next data will be unpacked from (within the
+        allocated memory starting as base_ptr) */
+    char *unpack_ptr;
+    /** Number of bytes allocated (starting at base_ptr) */
+    size_t bytes_allocated;
+    /** Number of bytes used by the buffer (i.e., amount of data --
+        including overhead -- packed in the buffer) */
+    size_t bytes_used;
+} pmix_data_buffer_t;
+#define PMIX_DATA_BUFFER_CREATE(m)                                          \
+    do {                                                                    \
+        (m) = (pmix_data_buffer_t*)calloc(1, sizeof(pmix_data_buffer_t));   \
+    } while (0)
+#define PMIX_DATA_BUFFER_RELEASE(m)             \
+    do {                                        \
+        if (NULL != (m)->base_ptr) {            \
+            free((m)->base_ptr);                \
+        }                                       \
+        free((m));                              \
+        (m) = NULL;                             \
+    } while (0)
+#define PMIX_DATA_BUFFER_CONSTRUCT(m)       \
+    memset((m), 0, sizeof(pmix_data_buffer_t))
+#define PMIX_DATA_BUFFER_DESTRUCT(m)        \
+    do {                                    \
+        if (NULL != (m)->base_ptr) {        \
+            free((m)->base_ptr);            \
+        }                                   \
+    } while (0)
+
+
 /****    PMIX PROC OBJECT    ****/
 typedef struct pmix_proc {
     char nspace[PMIX_MAX_NSLEN+1];
@@ -700,9 +738,10 @@ typedef struct pmix_proc {
         (m) = (pmix_proc_t*)calloc((n) , sizeof(pmix_proc_t));  \
     } while (0)
 
-#define PMIX_PROC_RELEASE(m)                    \
-    do {                                        \
-        PMIX_PROC_FREE((m));                    \
+#define PMIX_PROC_RELEASE(m)    \
+    do {                        \
+        free((m));              \
+        (m) = NULL;             \
     } while (0)
 
 #define PMIX_PROC_CONSTRUCT(m)                  \
@@ -956,7 +995,6 @@ pmix_status_t pmix_setenv(const char *name, const char *value,
     pmix_argv_append_nosize(&(a), (b))
 #define PMIX_SETENV(a, b, c) \
     pmix_setenv((a), (b), true, (c))
-
 
 /****    PMIX INFO STRUCT    ****/
 struct pmix_info_t {
@@ -1490,6 +1528,209 @@ const char* PMIx_Get_version(void);
  * never be "pushed" externally */
 pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
                                   const char *key, pmix_value_t *val);
+
+
+/**
+ * Top-level interface function to pack one or more values into a
+ * buffer.
+ *
+ * The pack function packs one or more values of a specified type into
+ * the specified buffer.  The buffer must have already been
+ * initialized via the PMIX_DATA_BUFFER_CREATE or PMIX_DATA_BUFFER_CONSTRUCT
+ * call - otherwise, the pack_value function will return an error.
+ * Providing an unsupported type flag will likewise be reported as an error.
+ *
+ * Note that any data to be packed that is not hard type cast (i.e.,
+ * not type cast to a specific size) may lose precision when unpacked
+ * by a non-homogeneous recipient.  The PACK function will do its best to deal
+ * with heterogeneity issues between the packer and unpacker in such
+ * cases. Sending a number larger than can be handled by the recipient
+ * will return an error code (generated upon unpacking) -
+ * the error cannot be detected during packing.
+ *
+ * @param *buffer A pointer to the buffer into which the value is to
+ * be packed.
+ *
+ * @param *src A void* pointer to the data that is to be packed. Note
+ * that strings are to be passed as (char **) - i.e., the caller must
+ * pass the address of the pointer to the string as the void*. This
+ * allows PMIx to use a single pack function, but still allow
+ * the caller to pass multiple strings in a single call.
+ *
+ * @param num_values An int32_t indicating the number of values that are
+ * to be packed, beginning at the location pointed to by src. A string
+ * value is counted as a single value regardless of length. The values
+ * must be contiguous in memory. Arrays of pointers (e.g., string
+ * arrays) should be contiguous, although (obviously) the data pointed
+ * to need not be contiguous across array entries.
+ *
+ * @param type The type of the data to be packed - must be one of the
+ * PMIX defined data types.
+ *
+ * @retval PMIX_SUCCESS The data was packed as requested.
+ *
+ * @retval PMIX_ERROR(s) An appropriate PMIX error code indicating the
+ * problem encountered. This error code should be handled
+ * appropriately.
+ *
+ * @code
+ * pmix_data_buffer_t *buffer;
+ * int32_t src;
+ *
+ * PMIX_DATA_BUFFER_CREATE(buffer);
+ * status_code = PMIx_Data_pack(buffer, &src, 1, PMIX_INT32);
+ * @endcode
+ */
+pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
+                             void *src, int32_t num_vals,
+                             pmix_data_type_t type);
+
+/**
+ * Unpack values from a buffer.
+ *
+ * The unpack function unpacks the next value (or values) of a
+ * specified type from the specified buffer.
+ *
+ * The buffer must have already been initialized via an PMIX_DATA_BUFFER_CREATE or
+ * PMIX_DATA_BUFFER_CONSTRUCT call (and assumedly filled with some data) -
+ * otherwise, the unpack_value function will return an
+ * error. Providing an unsupported type flag will likewise be reported
+ * as an error, as will specifying a data type that DOES NOT match the
+ * type of the next item in the buffer. An attempt to read beyond the
+ * end of the stored data held in the buffer will also return an
+ * error.
+ *
+ * NOTE: it is possible for the buffer to be corrupted and that
+ * PMIx will *think* there is a proper variable type at the
+ * beginning of an unpack region - but that the value is bogus (e.g., just
+ * a byte field in a string array that so happens to have a value that
+ * matches the specified data type flag). Therefore, the data type error check
+ * is NOT completely safe. This is true for ALL unpack functions.
+ *
+ *
+ * Unpacking values is a "nondestructive" process - i.e., the values are
+ * not removed from the buffer. It is therefore possible for the caller
+ * to re-unpack a value from the same buffer by resetting the unpack_ptr.
+ *
+ * Warning: The caller is responsible for providing adequate memory
+ * storage for the requested data. As noted below, the user
+ * must provide a parameter indicating the maximum number of values that
+ * can be unpacked into the allocated memory. If more values exist in the
+ * buffer than can fit into the memory storage, then the function will unpack
+ * what it can fit into that location and return an error code indicating
+ * that the buffer was only partially unpacked.
+ *
+ * Note that any data that was not hard type cast (i.e., not type cast
+ * to a specific size) when packed may lose precision when unpacked by
+ * a non-homogeneous recipient.  PMIx will do its best to deal with
+ * heterogeneity issues between the packer and unpacker in such
+ * cases. Sending a number larger than can be handled by the recipient
+ * will return an error code generated upon unpacking - these errors
+ * cannot be detected during packing.
+ *
+ * @param *buffer A pointer to the buffer from which the value will be
+ * extracted.
+ *
+ * @param *dest A void* pointer to the memory location into which the
+ * data is to be stored. Note that these values will be stored
+ * contiguously in memory. For strings, this pointer must be to (char
+ * **) to provide a means of supporting multiple string
+ * operations. The unpack function will allocate memory for each
+ * string in the array - the caller must only provide adequate memory
+ * for the array of pointers.
+ *
+ * @param type The type of the data to be unpacked - must be one of
+ * the BFROP defined data types.
+ *
+ * @retval *max_num_values The number of values actually unpacked. In
+ * most cases, this should match the maximum number provided in the
+ * parameters - but in no case will it exceed the value of this
+ * parameter.  Note that if you unpack fewer values than are actually
+ * available, the buffer will be in an unpackable state - the function will
+ * return an error code to warn of this condition.
+ *
+ * @note The unpack function will return the actual number of values
+ * unpacked in this location.
+ *
+ * @retval PMIX_SUCCESS The next item in the buffer was successfully
+ * unpacked.
+ *
+ * @retval PMIX_ERROR(s) The unpack function returns an error code
+ * under one of several conditions: (a) the number of values in the
+ * item exceeds the max num provided by the caller; (b) the type of
+ * the next item in the buffer does not match the type specified by
+ * the caller; or (c) the unpack failed due to either an error in the
+ * buffer or an attempt to read past the end of the buffer.
+ *
+ * @code
+ * pmix_data_buffer_t *buffer;
+ * int32_t dest;
+ * char **string_array;
+ * int32_t num_values;
+ *
+ * num_values = 1;
+ * status_code = PMIx_Data_unpack(buffer, (void*)&dest, &num_values, PMIX_INT32);
+ *
+ * num_values = 5;
+ * string_array = malloc(num_values*sizeof(char *));
+ * status_code = PMIx_Data_unpack(buffer, (void*)(string_array), &num_values, PMIX_STRING);
+ *
+ * @endcode
+ */
+pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
+                               int32_t *max_num_values,
+                               pmix_data_type_t type);
+
+/**
+ * Copy a data value from one location to another.
+ *
+ * Since registered data types can be complex structures, the system
+ * needs some way to know how to copy the data from one location to
+ * another (e.g., for storage in the registry). This function, which
+ * can call other copy functions to build up complex data types, defines
+ * the method for making a copy of the specified data type.
+ *
+ * @param **dest The address of a pointer into which the
+ * address of the resulting data is to be stored.
+ *
+ * @param *src A pointer to the memory location from which the
+ * data is to be copied.
+ *
+ * @param type The type of the data to be copied - must be one of
+ * the PMIx defined data types.
+ *
+ * @retval PMIX_SUCCESS The value was successfully copied.
+ *
+ * @retval PMIX_ERROR(s) An appropriate error code.
+ *
+ */
+pmix_status_t PMIx_Data_copy(void **dest, void *src, pmix_data_type_t type);
+
+/**
+ * Print a data value.
+ *
+ * Since registered data types can be complex structures, the system
+ * needs some way to know how to print them (i.e., convert them to a string
+ * representation). Provided for debug purposes.
+ *
+ * @retval PMIX_SUCCESS The value was successfully printed.
+ *
+ * @retval PMIX_ERROR(s) An appropriate error code.
+ */
+pmix_status_t PMIx_Data_print(char **output, char *prefix,
+                              void *src, pmix_data_type_t type);
+
+/**
+ * Copy a payload from one buffer to another
+ *
+ * This function will append a copy of the payload in one buffer into
+ * another buffer.
+ * NOTE: This is NOT a destructive procedure - the
+ * source buffer's payload will remain intact, as will any pre-existing
+ * payload in the destination's buffer.
+ */
+pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
+                                     pmix_data_buffer_t *src);
 
 
 /* Key-Value pair management macros */

--- a/src/atomics/sys/gcc_builtin/atomic.h
+++ b/src/atomics/sys/gcc_builtin/atomic.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +64,8 @@ static inline void pmix_atomic_wmb(void)
 }
 
 #define PMIXMB() pmix_atomic_mb()
+#define PMIXRMB() pmix_atomic_rmb()
+#define PMIXWMB() pmix_atomic_wmb()
 
 /**********************************************************************
  *

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -190,7 +190,9 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
     if (PMIX_SUCCESS == status) {
         if (PMIX_SUCCESS != (rc = pmix_bfrop.copy((void**)&cb->value, kv, PMIX_VALUE))) {
             PMIX_ERROR_LOG(rc);
+            cb->status = rc;
         }
+        PMIXRMB();
     }
     cb->active = false;
 }

--- a/src/common/Makefile.include
+++ b/src/common/Makefile.include
@@ -14,4 +14,5 @@ sources += \
         common/pmix_strings.c \
         common/pmix_log.c \
         common/pmix_jobdata.c \
-        common/pmix_control.c
+        common/pmix_control.c \
+        common/pmix_data.c

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#include <errno.h>
+#include <stdio.h>
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+
+#include <pmix_common.h>
+#include <pmix_rename.h>
+
+#include "src/buffer_ops/buffer_ops.h"
+
+#define PMIX_EMBED_DATA_BUFFER(b, db)                   \
+    do {                                                \
+        (b)->base_ptr = (db)->base_ptr;                 \
+        (b)->pack_ptr = (db)->pack_ptr;                 \
+        (b)->unpack_ptr = (db)->unpack_ptr;             \
+        (b)->bytes_allocated = (db)->bytes_allocated;   \
+        (b)->bytes_used = (db)->bytes_used;             \
+        (db)->base_ptr = NULL;                          \
+        (db)->pack_ptr = NULL;                          \
+        (db)->unpack_ptr = NULL;                        \
+        (db)->bytes_allocated = 0;                      \
+        (db)->bytes_used = 0;                           \
+    } while (0)
+
+#define PMIX_EXTRACT_DATA_BUFFER(b, db)                 \
+    do {                                                \
+        (db)->base_ptr = (b)->base_ptr;                 \
+        (db)->pack_ptr = (b)->pack_ptr;                 \
+        (db)->unpack_ptr = (b)->unpack_ptr;             \
+        (db)->bytes_allocated = (b)->bytes_allocated;   \
+        (db)->bytes_used = (b)->bytes_used;             \
+        (b)->base_ptr = NULL;                           \
+        (b)->pack_ptr = NULL;                           \
+        (b)->unpack_ptr = NULL;                         \
+        (b)->bytes_allocated = 0;                       \
+        (b)->bytes_used = 0;                            \
+    } while (0)
+
+PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
+                                         void *src, int32_t num_vals,
+                                         pmix_data_type_t type)
+{
+    pmix_status_t rc;
+    pmix_buffer_t buf;
+
+    /* setup the host */
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+
+    /* embed the data buffer into a buffer */
+    PMIX_EMBED_DATA_BUFFER(&buf, buffer);
+
+    /* pack the value */
+    rc = pmix_bfrop.pack(&buf, src, num_vals, type);
+
+    /* extract the data buffer - the pointers may have changed */
+    PMIX_EXTRACT_DATA_BUFFER(&buf, buffer);
+
+    /* no need to cleanup as all storage was xfered */
+    return rc;
+}
+
+
+PMIX_EXPORT pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
+                                           int32_t *max_num_values,
+                                           pmix_data_type_t type)
+{
+    pmix_status_t rc;
+    pmix_buffer_t buf;
+
+    /* setup the host */
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+
+    /* embed the data buffer into a buffer */
+    PMIX_EMBED_DATA_BUFFER(&buf, buffer);
+
+    /* unpack the value */
+    rc = pmix_bfrop.unpack(&buf, dest, max_num_values, type);
+
+    /* extract the data buffer - the pointers may have changed */
+    PMIX_EXTRACT_DATA_BUFFER(&buf, buffer);
+
+    /* no need to cleanup as all storage was xfered */
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Data_copy(void **dest, void *src,
+                                         pmix_data_type_t type)
+{
+    pmix_status_t rc;
+
+    /* copy the value */
+    rc = pmix_bfrop.copy(dest, src, type);
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Data_print(char **output, char *prefix,
+                                          void *src, pmix_data_type_t type)
+{
+    pmix_status_t rc;
+
+    /* print the value */
+    rc = pmix_bfrop.print(output, prefix, src, type);
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
+                                                 pmix_data_buffer_t *src)
+{
+    pmix_status_t rc;
+    pmix_buffer_t buf1, buf2;
+
+    /* setup the hosts */
+    PMIX_CONSTRUCT(&buf1, pmix_buffer_t);
+    PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
+
+    /* embed the data buffer into a buffer */
+    PMIX_EMBED_DATA_BUFFER(&buf1, dest);
+    PMIX_EMBED_DATA_BUFFER(&buf2, src);
+
+    /* copy payload */
+    rc = pmix_bfrop.copy_payload(&buf1, &buf2);
+
+    /* extract the dest data buffer - the pointers may have changed */
+    PMIX_EXTRACT_DATA_BUFFER(&buf1, dest);
+    PMIX_EXTRACT_DATA_BUFFER(&buf2, src);
+
+    /* no need to cleanup as all storage was xfered */
+    return rc;
+}


### PR DESCRIPTION
 * Fixes Issue #347
 * A PMIx_Get operation thread shifts to perform the actual lookup.
   - Thread A: PMIx_Get() -> Thread_shift
   - Thread B: Lookup value, allocate memory, copy value, release Thread A
   - Thread A: Wakeup and read the allocated value
 * The problem is that Thread B can allocate and update the pointer, but
   due to cache effects Thread A does not see that value (instead sees
   NULL).
   - The solution is to add a memory barrier in Thread B once it has
     finished updating the value.
 * This case matches the first example ("Global thread flag") at:
   - https://www.ibm.com/developerworks/systems/articles/powerpc.html
   - As such we are using the `RWB` which corresponds to `lwsync` on PPC