### PR TITLE
client/get: Fix memory race in PMIx_Get

### DIFF
--- a/src/atomics/sys/gcc_builtin/atomic.h
+++ b/src/atomics/sys/gcc_builtin/atomic.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -63,6 +64,8 @@ static inline void pmix_atomic_wmb(void)
 }
 
 #define PMIXMB() pmix_atomic_mb()
+#define PMIXRMB() pmix_atomic_rmb()
+#define PMIXWMB() pmix_atomic_wmb()
 
 /**********************************************************************
  *

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2017 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -190,7 +190,9 @@ static void _value_cbfunc(pmix_status_t status, pmix_value_t *kv, void *cbdata)
     if (PMIX_SUCCESS == status) {
         if (PMIX_SUCCESS != (rc = pmix_bfrop.copy((void**)&cb->value, kv, PMIX_VALUE))) {
             PMIX_ERROR_LOG(rc);
+            cb->status = rc;
         }
+        PMIXRMB();
     }
     cb->active = false;
 }


### PR DESCRIPTION
 * Fixes Issue #347
 * A PMIx_Get operation thread shifts to perform the actual lookup.
   - Thread A: PMIx_Get() -> Thread_shift
   - Thread B: Lookup value, allocate memory, copy value, release Thread A
   - Thread A: Wakeup and read the allocated value
 * The problem is that Thread B can allocate and update the pointer, but
   due to cache effects Thread A does not see that value (instead sees
   NULL).
   - The solution is to add a memory barrier in Thread B once it has
     finished updating the value.
 * This case matches the first example ("Global thread flag") at:
   - https://www.ibm.com/developerworks/systems/articles/powerpc.html
   - As such we are using the `RWB` which corresponds to `lwsync` on PPC