### PR TITLE
atomics/powerpc: Fix WMB instruction

### DIFF
--- a/src/atomics/sys/powerpc/atomic.h
+++ b/src/atomics/sys/powerpc/atomic.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2010-2017 IBM Corporation.  All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2017      Intel, Inc. All rights reserved.
@@ -30,10 +30,8 @@
 
 #define PMIXMB()  __asm__ __volatile__ ("sync" : : : "memory")
 #define PMIXRMB() __asm__ __volatile__ ("lwsync" : : : "memory")
-#define PMIXWMB() __asm__ __volatile__ ("eieio" : : : "memory")
+#define PMIXWMB() __asm__ __volatile__ ("lwsync" : : : "memory")
 #define PMIXISYNC() __asm__ __volatile__ ("isync" : : : "memory")
-#define PMIXSMP_SYNC  "sync \n\t"
-#define PMIXSMP_ISYNC "\n\tisync"
 
 
 /**********************************************************************


### PR DESCRIPTION
 * `lwsync` is a write memory barrier.
    - `eieio` is really not meant for this type of operation.
 * `lwsync` can also be used for the read memory barrier according to
   my reading of the of the Power 8 ISA docs (v2.07)
    - https://www-01.ibm.com/marketing/iwm/iwm/web/reg/download.do?source=swg-opower&S_PKG=dl&lang=en_US&cp=UTF-8
