### PR TITLE
Add a retain/release to the pmix recv struct to ensure that a recvd m…

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -167,7 +167,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer,
 }
 
 
-pmix_client_globals_t pmix_client_globals = {{{0}}};
+pmix_client_globals_t pmix_client_globals = {0};
 pmix_mutex_t pmix_client_bootstrap_mutex = PMIX_MUTEX_STATIC_INIT;
 
 /* callback for wait completion */
@@ -371,7 +371,10 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
     /* setup the globals */
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_client_globals.myserver, pmix_peer_t);
+    pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);
+    if (NULL == pmix_client_globals.myserver) {
+        return PMIX_ERR_NOMEM;
+    }
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: init called");
@@ -411,7 +414,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         return PMIX_ERR_INIT;
     }
     /* the server will be using the same */
-    pmix_client_globals.myserver.compat.psec = pmix_globals.mypeer->compat.psec;
+    pmix_client_globals.myserver->compat.psec = pmix_globals.mypeer->compat.psec;
 
     /* setup the shared memory support */
 #if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
@@ -422,7 +425,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
 #endif /* PMIX_ENABLE_DSTORE */
 
     /* connect to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.connect_to_peer(&pmix_client_globals.myserver, info, ninfo))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.connect_to_peer(pmix_client_globals.myserver, info, ninfo))){
         pmix_mutex_unlock(&pmix_client_bootstrap_mutex);
         return rc;
     }
@@ -440,7 +443,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* send to the server */
     PMIX_CONSTRUCT(&cb, pmix_cb_t);
     cb.active = true;
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, req, job_data, (void*)&cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, req, job_data, (void*)&cb))){
         PMIX_DESTRUCT(&cb);
         pmix_mutex_unlock(&pmix_client_bootstrap_mutex);
         return rc;
@@ -523,7 +526,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
     /* mark that I called finalize */
     pmix_globals.mypeer->finalized = true;
 
-    if ( 0 <= pmix_client_globals.myserver.sd ) {
+    if ( 0 <= pmix_client_globals.myserver->sd ) {
         /* check to see if we are supposed to execute a
          * blocking fence prior to actually finalizing */
         if (NULL != info && 0 < ninfo) {
@@ -561,8 +564,8 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
                              "pmix:client sending finalize sync to server");
 
         /* send to the server */
-        active = true;;
-        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg,
+        active = true;
+        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg,
                                                      wait_cbfunc, (void*)&active))){
             return rc;
         }
@@ -584,8 +587,6 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
         (void)pmix_progress_thread_pause(NULL);
     }
 
-    PMIX_DESTRUCT(&pmix_client_globals.myserver);
-
 #if defined(PMIX_ENABLE_DSTORE) && (PMIX_ENABLE_DSTORE == 1)
     if (0 > (rc = pmix_dstore_nspace_del(pmix_globals.myid.nspace))) {
         PMIX_ERROR_LOG(rc);
@@ -595,9 +596,13 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
 
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
 
-    if (0 <= pmix_client_globals.myserver.sd) {
-        CLOSE_THE_SOCKET(pmix_client_globals.myserver.sd);
+    if (0 <= pmix_client_globals.myserver->sd) {
+        CLOSE_THE_SOCKET(pmix_client_globals.myserver->sd);
     }
+    if (NULL != pmix_client_globals.myserver) {
+        PMIX_RELEASE(pmix_client_globals.myserver);
+    }
+
 
     pmix_rte_finalize();
 
@@ -665,7 +670,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
 
     /* send to the server */
     active = true;
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, bfr,
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, bfr,
                                                  wait_cbfunc, (void*)&active))){
         return rc;
     }
@@ -854,7 +859,7 @@ static void _commitfn(int sd, short args, void *cbdata)
 
     /* always send, even if we have nothing to contribute, so the server knows
      * that we contributed whatever we had */
-    if (PMIX_SUCCESS == (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msgout,
+    if (PMIX_SUCCESS == (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msgout,
                                                  wait_cbfunc, (void*)&cb->active))){
         cb->pstatus = PMIX_SUCCESS;
         return;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -170,7 +170,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -280,7 +280,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -160,7 +160,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -254,4 +254,3 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     cb->status = status;
     cb->active = false;
 }
-

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -740,7 +740,7 @@ request:
     /* track the callback object */
     pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);
     /* send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, _getnb_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, _getnb_cbfunc, (void*)cb))){
         pmix_list_remove_item(&pmix_client_globals.pending_requests, &cb->super);
         rc = PMIX_ERROR;
         goto respond;

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -20,7 +20,7 @@
 BEGIN_C_DECLS
 
 typedef struct {
-    pmix_peer_t myserver;           // messaging support to/from my server
+    pmix_peer_t *myserver;          // messaging support to/from my server
     pmix_list_t pending_requests;   // list of pmix_cb_t pending data requests
 } pmix_client_globals_t;
 

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -166,7 +166,7 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     cb->active = true;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -296,7 +296,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys,
     cb->cbdata = cbdata;
 
     /* send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_lookup_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_lookup_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -402,7 +402,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
     cb->active = true;
 
     /* send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -171,7 +171,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, wait_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -178,7 +178,7 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }
@@ -267,7 +267,7 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -126,7 +126,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
 
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:query sending to server");
-        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, log_cbfunc, (void*)cd))){
+        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, log_cbfunc, (void*)cd))){
             PMIX_RELEASE(cd);
         }
     }

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -157,7 +157,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         }
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:query sending to server");
-        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, query_cbfunc, (void*)cd))){
+        if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, query_cbfunc, (void*)cd))){
             PMIX_RELEASE(cd);
         }
     }
@@ -240,7 +240,7 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
     cb->cbdata = cbdata;
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, query_cbfunc, (void*)cb))){
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
     }

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -165,6 +165,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             ch->timer_active = true;                                                \
             pmix_event_assign(&ch->ev, pmix_globals.evbase, -1, 0,                  \
                               pmix_event_timeout_cb, ch);                           \
+            PMIX_POST_OBJECT(ch);                                                   \
             pmix_event_add(&ch->ev, &pmix_globals.event_window);                    \
         } else {                                                                    \
             /* add this peer to the array of sources */                             \
@@ -183,6 +184,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             ch->ninfo = ninfo;                                                      \
             /* reset the timer */                                                   \
             pmix_event_del(&ch->ev);                                                \
+            PMIX_POST_OBJECT(ch);                                                   \
             pmix_event_add(&ch->ev, &pmix_globals.event_window);                    \
         }                                                                           \
     } while(0)

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -225,7 +225,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "client: notifying server %s:%d - sending",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank);
-        rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, notify_event_cbfunc, cb);
+        rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, notify_event_cbfunc, cb);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(cb);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -197,7 +197,7 @@ static pmix_status_t _send_to_server(pmix_rshift_caddy_t *rcd)
             return rc;
         }
     }
-    rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, regevents_cbfunc, rcd);
+    rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, regevents_cbfunc, rcd);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
@@ -928,7 +928,7 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
   report:
     if (NULL != msg) {
         /* send to the server */
-        rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg, NULL, NULL);
+        rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg, NULL, NULL);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
         }

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -82,9 +82,11 @@ static pmix_status_t pmix_ptl_close(void)
     /* ensure the listen thread has been shut down */
     pmix_ptl.stop_listening();
 
-    if (0 <= pmix_client_globals.myserver.sd) {
-        CLOSE_THE_SOCKET(pmix_client_globals.myserver.sd);
-        pmix_client_globals.myserver.sd = -1;
+    if (NULL != pmix_client_globals.myserver) {
+        if (0 <= pmix_client_globals.myserver->sd) {
+            CLOSE_THE_SOCKET(pmix_client_globals.myserver->sd);
+            pmix_client_globals.myserver->sd = -1;
+        }
     }
 
     /* the components will cleanup when closed */
@@ -105,7 +107,6 @@ static pmix_status_t pmix_ptl_open(pmix_mca_base_open_flag_t flags)
     PMIX_CONSTRUCT(&pmix_ptl_globals.unexpected_msgs, pmix_list_t);
     pmix_ptl_globals.listen_thread_active = false;
     PMIX_CONSTRUCT(&pmix_ptl_globals.listeners, pmix_list_t);
-    pmix_client_globals.myserver.sd = -1;
 
     /* Open up all available components */
     return pmix_mca_base_framework_components_open(&pmix_ptl_base_framework, flags);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -142,6 +142,7 @@ PMIX_CLASS_INSTANCE(pmix_ptl_send_t,
 
 static void rcon(pmix_ptl_recv_t *p)
 {
+    p->peer = NULL;
     memset(&p->hdr, 0, sizeof(pmix_ptl_hdr_t));
     p->hdr.tag = UINT32_MAX;
     p->hdr.nbytes = 0;
@@ -150,9 +151,15 @@ static void rcon(pmix_ptl_recv_t *p)
     p->rdptr = NULL;
     p->rdbytes = 0;
 }
+static void rdes(pmix_ptl_recv_t *p)
+{
+    if (NULL != p->peer) {
+        PMIX_RELEASE(p->peer);
+    }
+}
 PMIX_CLASS_INSTANCE(pmix_ptl_recv_t,
                     pmix_list_item_t,
-                    rcon, NULL);
+                    rcon, rdes);
 
 static void prcon(pmix_ptl_posted_recv_t *p)
 {

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -397,6 +397,7 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
             pmix_output(0, "sptl:base:recv_handler: unable to allocate recv message\n");
             goto err_close;
         }
+        PMIX_RETAIN(peer);
         peer->recv_msg->peer = peer;  // provide a handle back to the peer object
         /* start by reading the header */
         peer->recv_msg->rdptr = (char*)&peer->recv_msg->hdr;
@@ -486,7 +487,8 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
     }
     /* success */
     return;
- err_close:
+
+  err_close:
     /* stop all events */
     if (peer->recv_ev_active) {
         pmix_event_del(&peer->recv_event);

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -173,7 +173,7 @@ static void lost_connection(pmix_peer_t *peer, pmix_status_t err)
         PMIX_DESTRUCT(&buf);
         /* if I called finalize, then don't generate an event */
         if (!pmix_globals.mypeer->finalized) {
-            PMIX_REPORT_EVENT(err, &pmix_client_globals.myserver, PMIX_RANGE_LOCAL, _notify_complete);
+            PMIX_REPORT_EVENT(err, pmix_client_globals.myserver, PMIX_RANGE_LOCAL, _notify_complete);
         }
     }
 }
@@ -183,6 +183,7 @@ static pmix_status_t send_msg(int sd, pmix_ptl_send_t *msg)
     struct iovec iov[2];
     int iov_count;
     ssize_t remain = msg->sdbytes, rc;
+
     iov[0].iov_base = msg->sdptr;
     iov[0].iov_len = msg->sdbytes;
     if (!msg->hdr_sent && NULL != msg->data) {
@@ -297,7 +298,7 @@ static pmix_status_t read_bytes(int sd, char **buf, size_t *remain)
         ptr += rc;
     }
     /* we read the full data block */
-exit:
+  exit:
     *buf = ptr;
     return ret;
 }
@@ -335,6 +336,9 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
             /* exit this event and let the event lib progress */
             pmix_output_verbose(2, pmix_globals.debug_output,
                                 "ptl:base:send_handler RES BUSY OR WOULD BLOCK");
+            /* ensure we post the modified peer object before another thread
+             * picks it back up */
+            PMIX_POST_OBJECT(peer);
             return;
         } else {
             // report the error
@@ -343,6 +347,9 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
             PMIX_RELEASE(msg);
             peer->send_msg = NULL;
             lost_connection(peer, rc);
+            /* ensure we post the modified peer object before another thread
+             * picks it back up */
+            PMIX_POST_OBJECT(peer);
             return;
         }
 
@@ -361,6 +368,9 @@ void pmix_ptl_base_send_handler(int sd, short flags, void *cbdata)
         pmix_event_del(&peer->send_event);
         peer->send_ev_active = false;
     }
+    /* ensure we post the modified peer object before another thread
+     * picks it back up */
+    PMIX_POST_OBJECT(peer);
 }
 
 /*
@@ -471,10 +481,16 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
             /* post it for delivery */
             PMIX_ACTIVATE_POST_MSG(peer->recv_msg);
             peer->recv_msg = NULL;
+            /* ensure we post the modified peer object before another thread
+             * picks it back up */
+            PMIX_POST_OBJECT(peer);
             return;
         } else if (PMIX_ERR_RESOURCE_BUSY == rc ||
                    PMIX_ERR_WOULD_BLOCK == rc) {
             /* exit this event and let the event lib progress */
+            /* ensure we post the modified peer object before another thread
+             * picks it back up */
+            PMIX_POST_OBJECT(peer);
             return;
         } else {
             /* the remote peer closed the connection - report that condition
@@ -503,6 +519,9 @@ void pmix_ptl_base_recv_handler(int sd, short flags, void *cbdata)
         peer->recv_msg = NULL;
     }
     lost_connection(peer, PMIX_ERR_UNREACH);
+    /* ensure we post the modified peer object before another thread
+     * picks it back up */
+    PMIX_POST_OBJECT(peer);
 }
 
 void pmix_ptl_base_send(int sd, short args, void *cbdata)
@@ -517,6 +536,9 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
         NULL == queue->peer->info || NULL == queue->peer->info->nptr) {
         /* this peer has lost connection */
         PMIX_RELEASE(queue);
+        /* ensure we post the object before another thread
+         * picks it back up */
+        PMIX_POST_OBJECT(queue);
         return;
     }
 
@@ -544,10 +566,12 @@ void pmix_ptl_base_send(int sd, short args, void *cbdata)
     }
     /* ensure the send event is active */
     if (!(queue->peer)->send_ev_active) {
-        pmix_event_add(&(queue->peer)->send_event, 0);
         (queue->peer)->send_ev_active = true;
+        PMIX_POST_OBJECT(queue->peer);
+        pmix_event_add(&(queue->peer)->send_event, 0);
     }
     PMIX_RELEASE(queue);
+    PMIX_POST_OBJECT(snd);
 }
 
 void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
@@ -563,6 +587,9 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     if (ms->peer->sd < 0) {
         /* this peer's socket has been closed */
         PMIX_RELEASE(ms);
+        /* ensure we post the object before another thread
+         * picks it back up */
+        PMIX_POST_OBJECT(NULL);
         return;
     }
 
@@ -608,11 +635,13 @@ void pmix_ptl_base_send_recv(int fd, short args, void *cbdata)
     }
     /* ensure the send event is active */
     if (!ms->peer->send_ev_active) {
-        pmix_event_add(&ms->peer->send_event, 0);
         ms->peer->send_ev_active = true;
+        PMIX_POST_OBJECT(snd);
+        pmix_event_add(&ms->peer->send_event, 0);
     }
     /* cleanup */
     PMIX_RELEASE(ms);
+    PMIX_POST_OBJECT(snd);
 }
 
 void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
@@ -670,4 +699,7 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
     /* it is possible that someone may post a recv for this message
      * at some point, so we have to hold onto it */
     pmix_list_append(&pmix_ptl_globals.unexpected_msgs, &msg->super);
+    /* ensure we post the modified object before another thread
+     * picks it back up */
+    PMIX_POST_OBJECT(msg);
 }

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -247,11 +247,11 @@ PMIX_CLASS_DECLARATION(pmix_listener_t);
             /* add it to the queue */                                                   \
             pmix_list_append(&(p)->send_queue, &snd->super);                            \
         }                                                                               \
-        PMIX_POST_OBJECT(snd);                                                          \
         /* ensure the send event is active */                                           \
         if (!(p)->send_ev_active && 0 <= (p)->sd) {                                     \
-            pmix_event_add(&(p)->send_event, 0);                                        \
             (p)->send_ev_active = true;                                                 \
+            PMIX_POST_OBJECT(snd);                                                      \
+            pmix_event_add(&(p)->send_event, 0);                                        \
         }                                                                               \
     } while (0)
 

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -149,12 +149,12 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         }
         *p2 = '\0';
         ++p2;
-        pmix_client_globals.myserver.info = PMIX_NEW(pmix_rank_info_t);
-        pmix_client_globals.myserver.info->nptr = PMIX_NEW(pmix_nspace_t);
-        (void)strncpy(pmix_client_globals.myserver.info->nptr->nspace, p, PMIX_MAX_NSLEN);
+        pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+        pmix_client_globals.myserver->info->nptr = PMIX_NEW(pmix_nspace_t);
+        (void)strncpy(pmix_client_globals.myserver->info->nptr->nspace, p, PMIX_MAX_NSLEN);
 
         /* set the server rank */
-        pmix_client_globals.myserver.info->rank = strtoull(p2, NULL, 10);
+        pmix_client_globals.myserver->info->rank = strtoull(p2, NULL, 10);
 
         /* save the URI, but do not overwrite what we may have received from
          * the info-key directives */
@@ -208,10 +208,10 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             *p2 = '\0';
             ++p2;
             /* set the server nspace */
-            pmix_client_globals.myserver.info = PMIX_NEW(pmix_rank_info_t);
-            pmix_client_globals.myserver.info->nptr = PMIX_NEW(pmix_nspace_t);
-            (void)strncpy(pmix_client_globals.myserver.info->nptr->nspace, srvr, PMIX_MAX_NSLEN);
-            pmix_client_globals.myserver.info->rank = strtoull(p2, NULL, 10);
+            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+            pmix_client_globals.myserver->info->nptr = PMIX_NEW(pmix_nspace_t);
+            (void)strncpy(pmix_client_globals.myserver->info->nptr->nspace, srvr, PMIX_MAX_NSLEN);
+            pmix_client_globals.myserver->info->rank = strtoull(p2, NULL, 10);
             /* now parse the uti itself */
             mca_ptl_tcp_component.super.uri = strdup(p);
             free(srvr);
@@ -219,7 +219,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     }
 
     /* mark that we are the active module for this server */
-    pmix_client_globals.myserver.compat.ptl = &pmix_ptl_tcp_module;
+    pmix_client_globals.myserver->compat.ptl = &pmix_ptl_tcp_module;
 
     /* setup the path to the daemon rendezvous point */
     memset(&mca_ptl_tcp_component.connection, 0, sizeof(struct sockaddr_storage));
@@ -285,7 +285,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    pmix_client_globals.myserver.sd = sd;
+    pmix_client_globals.myserver->sd = sd;
 
     /* send our identity and any authentication credentials to the server */
     if (PMIX_SUCCESS != (rc = send_connect_ack(sd))) {
@@ -310,21 +310,22 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     pmix_ptl_base_set_nonblocking(sd);
 
     /* setup recv event */
-    pmix_event_assign(&pmix_client_globals.myserver.recv_event,
+    pmix_event_assign(&pmix_client_globals.myserver->recv_event,
                       pmix_globals.evbase,
-                      pmix_client_globals.myserver.sd,
+                      pmix_client_globals.myserver->sd,
                       EV_READ | EV_PERSIST,
-                      pmix_ptl_base_recv_handler, &pmix_client_globals.myserver);
-    pmix_event_add(&pmix_client_globals.myserver.recv_event, 0);
-    pmix_client_globals.myserver.recv_ev_active = true;
+                      pmix_ptl_base_recv_handler, pmix_client_globals.myserver);
+    pmix_client_globals.myserver->recv_ev_active = true;
+    PMIX_POST_OBJECT(pmix_client_globals.myserver);
+    pmix_event_add(&pmix_client_globals.myserver->recv_event, 0);
 
     /* setup send event */
-    pmix_event_assign(&pmix_client_globals.myserver.send_event,
+    pmix_event_assign(&pmix_client_globals.myserver->send_event,
                       pmix_globals.evbase,
-                      pmix_client_globals.myserver.sd,
+                      pmix_client_globals.myserver->sd,
                       EV_WRITE|EV_PERSIST,
-                      pmix_ptl_base_send_handler, &pmix_client_globals.myserver);
-    pmix_client_globals.myserver.send_ev_active = false;
+                      pmix_ptl_base_send_handler, pmix_client_globals.myserver);
+    pmix_client_globals.myserver->send_ev_active = false;
 
     return PMIX_SUCCESS;
 }
@@ -403,7 +404,7 @@ static pmix_status_t send_connect_ack(int sd)
      * local PMIx server, if known. Now use that module to
      * get a credential, if the security system provides one. Not
      * every psec module will do so, thus we must first check */
-    if (PMIX_SUCCESS != (rc = pmix_psec.create_cred(&pmix_client_globals.myserver,
+    if (PMIX_SUCCESS != (rc = pmix_psec.create_cred(pmix_client_globals.myserver,
                                                     PMIX_PROTOCOL_V2, &cred, &len))) {
         return rc;
     }
@@ -551,7 +552,7 @@ static pmix_status_t recv_connect_ack(int sd)
     if (PMIX_PROC_IS_CLIENT) {
         /* see if they want us to do the handshake */
         if (PMIX_ERR_READY_FOR_HANDSHAKE == reply) {
-            if (PMIX_SUCCESS != (rc = pmix_psec.client_handshake(&pmix_client_globals.myserver, sd))) {
+            if (PMIX_SUCCESS != (rc = pmix_psec.client_handshake(pmix_client_globals.myserver, sd))) {
                 return rc;
             }
         } else if (PMIX_SUCCESS != reply) {
@@ -588,16 +589,16 @@ static pmix_status_t recv_connect_ack(int sd)
         pmix_globals.myid.rank = 0;
 
         /* get the server's nspace and rank so we can send to it */
-        pmix_client_globals.myserver.info = PMIX_NEW(pmix_rank_info_t);
-        pmix_client_globals.myserver.info->nptr = PMIX_NEW(pmix_nspace_t);
-        pmix_ptl_base_recv_blocking(sd, (char*)pmix_client_globals.myserver.info->nptr->nspace, PMIX_MAX_NSLEN+1);
-        pmix_ptl_base_recv_blocking(sd, (char*)&(pmix_client_globals.myserver.info->rank), sizeof(int));
+        pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+        pmix_client_globals.myserver->info->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_ptl_base_recv_blocking(sd, (char*)pmix_client_globals.myserver->info->nptr->nspace, PMIX_MAX_NSLEN+1);
+        pmix_ptl_base_recv_blocking(sd, (char*)&(pmix_client_globals.myserver->info->rank), sizeof(int));
 
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix: RECV CONNECT CONFIRMATION FOR TOOL %s:%d FROM SERVER %s:%d",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                            pmix_client_globals.myserver.info->nptr->nspace,
-                            pmix_client_globals.myserver.info->rank);
+                            pmix_client_globals.myserver->info->nptr->nspace,
+                            pmix_client_globals.myserver->info->rank);
 
         /* get the returned status from the security handshake */
         pmix_ptl_base_recv_blocking(sd, (char*)&reply, sizeof(pmix_status_t));
@@ -607,7 +608,7 @@ static pmix_status_t recv_connect_ack(int sd)
                 if (NULL == pmix_psec.client_handshake) {
                     return PMIX_ERR_HANDSHAKE_FAILED;
                 }
-                if (PMIX_SUCCESS != (reply = pmix_psec.client_handshake(&pmix_client_globals.myserver, sd))) {
+                if (PMIX_SUCCESS != (reply = pmix_psec.client_handshake(pmix_client_globals.myserver, sd))) {
                     return reply;
                 }
                 /* if the handshake succeeded, then fall thru to the next step */

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -191,7 +191,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
 
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_client_globals.myserver, pmix_peer_t);
+    pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: init called");
@@ -202,10 +202,10 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         return PMIX_ERR_INIT;
     }
     /* the server will have to use the same */
-    pmix_client_globals.myserver.compat.psec = pmix_globals.mypeer->compat.psec;
+    pmix_client_globals.myserver->compat.psec = pmix_globals.mypeer->compat.psec;
 
     /* connect to the server - returns job info if successful */
-    if (PMIX_SUCCESS != (rc = pmix_ptl.connect_to_peer(&pmix_client_globals.myserver, info, ninfo))){
+    if (PMIX_SUCCESS != (rc = pmix_ptl.connect_to_peer(pmix_client_globals.myserver, info, ninfo))){
         return rc;
     }
 
@@ -507,7 +507,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 
     /* send to the server */
     active = true;;
-    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(&pmix_client_globals.myserver, msg,
+    if (PMIX_SUCCESS != (rc = pmix_ptl.send_recv(pmix_client_globals.myserver, msg,
                                                  wait_cbfunc, (void*)&active))){
         return rc;
     }
@@ -525,7 +525,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         (void)pmix_progress_thread_pause(NULL);
     }
 
-    PMIX_DESTRUCT(&pmix_client_globals.myserver);
+    PMIX_RELEASE(pmix_client_globals.myserver);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
 
     /* shutdown services */


### PR DESCRIPTION
…essage on the client side still has its peer object available to it, even if the server has gone away in the meantime. Resolves a race condition in finalize

Signed-off-by: Ralph Castain <rhc@open-mpi.org>