### PR TITLE
Fix a bug in the PMIx_Get logic

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -124,6 +124,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CONNECT_SYSTEM_FIRST           "pmix.cnct.sys.first"   // (bool) Preferentially look for a system-level PMIx server first
 #define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_SERVER_ENABLE_MONITORING       "pmix.srv.monitor"      // (bool) Enable PMIx internal monitoring by server
+#define PMIX_SERVER_NSPACE                  "pmix.srv.nspace"       // (char*) Name of the nspace to use for this server
+#define PMIX_SERVER_RANK                    "pmix.srv.rank"         // (pmix_rank_t) Rank of this server
 
 
 /* identification attributes */

--- a/src/buffer_ops/copy.c
+++ b/src/buffer_ops/copy.c
@@ -425,7 +425,7 @@ PMIX_EXPORT pmix_status_t pmix_value_xfer(pmix_value_t *p, pmix_value_t *src)
             break;
         }
         /* allocate space and do the copy */
-        switch (src->type) {
+        switch (src->data.darray->type) {
             case PMIX_UINT8:
             case PMIX_INT8:
             case PMIX_BYTE:

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -6,7 +6,7 @@
  *                         reserved.
  * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -106,6 +106,9 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
     pmix_kval_t *hv;
     uint64_t id;
     char *node;
+    pmix_info_t *info;
+    size_t ninfo, n;
+    pmix_value_t *val;
 
     pmix_output_verbose(10, pmix_globals.debug_output,
                         "HASH:FETCH rank %d key %s",
@@ -143,7 +146,36 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
         if (NULL == key) {
             /* we will return the data as an array of pmix_info_t
              * in the kvs pmix_value_t */
-
+            val = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            if (NULL == val) {
+                return PMIX_ERR_NOMEM;
+            }
+            val->type = PMIX_DATA_ARRAY;
+            val->data.darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
+            if (NULL == val->data.darray) {
+                PMIX_VALUE_RELEASE(val);
+                return PMIX_ERR_NOMEM;
+            }
+            val->data.darray->type = PMIX_INFO;
+            val->data.darray->size = 0;
+            val->data.darray->array = NULL;
+            ninfo = pmix_list_get_size(&proc_data->data);
+            PMIX_INFO_CREATE(info, ninfo);
+            if (NULL == info) {
+                PMIX_VALUE_RELEASE(val);
+                return PMIX_ERR_NOMEM;
+            }
+            /* copy the list elements */
+            n=0;
+            PMIX_LIST_FOREACH(hv, &proc_data->data, pmix_kval_t) {
+                (void)strncpy(info[n].key, hv->key, PMIX_MAX_KEYLEN);
+                pmix_value_xfer(&info[n].value, hv->value);
+                ++n;
+            }
+            val->data.darray->size = ninfo;
+            val->data.darray->array = info;
+            *kvs = val;
+            return PMIX_SUCCESS;
         } else {
             /* find the value from within this proc_data object */
             hv = lookup_keyval(&proc_data->data, key);

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -202,19 +202,49 @@ int main(int argc, char **argv)
                 PMIX_VALUE_RELEASE(val);
                 free(tmp);
 
-                (void)asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
-                if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                    /* this data should _not_ be found as we are on the same node
-                     * and the data was "put" with a PMIX_REMOTE scope */
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
-                    continue;
+                if (n != myproc.rank) {
+                    (void)asprintf(&tmp, "%s-%d-remote-%d", proc.nspace, n, j);
+                    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
+                        /* this data should _not_ be found as we are on the same node
+                         * and the data was "put" with a PMIX_REMOTE scope */
+                        pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
+                        continue;
+                    }
+                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned remote data for a local proc",
+                                myproc.nspace, myproc.rank, j, tmp);
+                    PMIX_VALUE_RELEASE(val);
+                    free(tmp);
                 }
-                pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned remote data for a local proc",
-                            myproc.nspace, myproc.rank, j, tmp);
-                PMIX_VALUE_RELEASE(val);
-                free(tmp);
             }
         }
+    }
+
+    /* now get the data blob for myself */
+    pmix_output(0, "Client ns %s rank %d testing internal modex blob",
+                myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS == (rc = PMIx_Get(&myproc, NULL, NULL, 0, &val))) {
+        if (PMIX_DATA_ARRAY != val->type) {
+            pmix_output(0, "Client ns %s rank %d did not return an array for its internal modex blob",
+                        myproc.nspace, myproc.rank);
+            PMIX_VALUE_RELEASE(val);
+        } else if (PMIX_INFO != val->data.darray->type) {
+            pmix_output(0, "Client ns %s rank %d returned an internal modex array of type %s instead of PMIX_INFO",
+                        myproc.nspace, myproc.rank, PMIx_Data_type_string(val->data.darray->type));
+            PMIX_VALUE_RELEASE(val);
+        } else if (0 == val->data.darray->size) {
+            pmix_output(0, "Client ns %s rank %d returned an internal modex array of zero length",
+                        myproc.nspace, myproc.rank);
+            PMIX_VALUE_RELEASE(val);
+        } else {
+            pmix_info_t *iptr = (pmix_info_t*)val->data.darray->array;
+            for (n=0; n < val->data.darray->size; n++) {
+                pmix_output(0, "\tKey: %s", iptr[n].key);
+            }
+            PMIX_VALUE_RELEASE(val);
+        }
+    } else {
+        pmix_output(0, "Client ns %s rank %d internal modex blob FAILED with error %s(%d)",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc), rc);
     }
 
     /* log something */


### PR DESCRIPTION
If we are looking for all the data that we "put" ourselves, then it won't be in the dstore. It will be in our own hash table, so allow us to look there. Also fix a bug in the bfrops copy routines when copying a data array - need to look at the type stored in the data array, not the type of the value object (as that is already known to be data array).

Signed-off-by: Ralph Castain <rhc@open-mpi.org>