### PR TITLE
Protect the PMIX_INFO_FREE macro from NULL data arrays. 

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -907,7 +907,7 @@ typedef struct pmix_value {
                 free((m)->data.bo.bytes);                                           \
             }                                                                       \
         } else if (PMIX_DATA_ARRAY == (m)->type) {                                  \
-            if (NULL != (m)->data.darray) {                                         \
+            if (NULL != (m)->data.darray && NULL != (m)->data.darray->array) {      \
                 if (PMIX_STRING == (m)->data.darray->type) {                        \
                     char **_str = (char**)(m)->data.darray->array;                  \
                     for (_n=0; _n < (m)->data.darray->size; _n++) {                 \

--- a/src/buffer_ops/unpack.c
+++ b/src/buffer_ops/unpack.c
@@ -714,8 +714,8 @@ pmix_status_t pmix_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             break;
         /********************/
         default:
-        pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
-        return PMIX_ERROR;
+            pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
+            return PMIX_ERROR;
     }
 
     return PMIX_SUCCESS;
@@ -765,9 +765,11 @@ pmix_status_t pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         m=1;
         tmp = NULL;
         if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            PMIX_ERROR_LOG(ret);
             return ret;
         }
         if (NULL == tmp) {
+            PMIX_ERROR_LOG(PMIX_ERROR);
             return PMIX_ERROR;
         }
         (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
@@ -775,6 +777,7 @@ pmix_status_t pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         /* unpack the flags */
         m=1;
         if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_infodirs(buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES))) {
+            PMIX_ERROR_LOG(ret);
             return ret;
         }
         /* unpack value - since the value structure is statically-defined
@@ -782,12 +785,14 @@ pmix_status_t pmix_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
          * avoid the malloc */
          m=1;
          if (PMIX_SUCCESS != (ret = pmix_bfrop_unpack_int(buffer, &ptr[i].value.type, &m, PMIX_INT))) {
+            PMIX_ERROR_LOG(ret);
             return ret;
         }
         pmix_output_verbose(20, pmix_globals.debug_output,
                             "pmix_bfrop_unpack: info type %d", ptr[i].value.type);
         m=1;
         if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+            PMIX_ERROR_LOG(ret);
             return ret;
         }
     }
@@ -1271,6 +1276,9 @@ pmix_status_t pmix_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
                 break;
             case PMIX_STATUS:
                 nbytes = sizeof(pmix_status_t);
+                break;
+            case PMIX_INFO:
+                nbytes = sizeof(pmix_info_t);
                 break;
             case PMIX_PROC:
                 nbytes = sizeof(pmix_proc_t);


### PR DESCRIPTION
Add missing support for pmix_info_t objects in pmix_data_array_t as these are typically returned from calls to PMIx_Query

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 8703498f5de08570d48d3b954c9e63cba3df948d)