### PR TITLE
GDS Fixes

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -524,16 +524,13 @@ static void _getnbfn(int fd, short flags, void *cbdata)
         }
     }
 
-    /* if we are looking for data from ourselves, then
-     * check the internal storage first */
-    if (proc.rank == pmix_globals.myid.rank) {
-        cb->proc = &proc;
-        cb->copy = true;
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
-        if (PMIX_SUCCESS == rc) {
-            rc = process_values(&val, cb);
-            goto respond;
-        }
+    /* check the internal storage first */
+    cb->proc = &proc;
+    cb->copy = true;
+    PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+    if (PMIX_SUCCESS == rc) {
+        rc = process_values(&val, cb);
+        goto respond;
     }
 
     /* if the key is NULL or starts with "pmix", then they are looking

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -391,10 +391,10 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
            /* we have the data for this proc - see if we can find the key */
             cb->proc = &proc;
             cb->scope = PMIX_SCOPE_UNDEF;
-            /* fetch the data from my peer module - since we are passing
+            /* fetch the data from server peer module - since it is passing
              * it back to the user, we need a copy of it */
             cb->copy = true;
-            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+            PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
             if (PMIX_SUCCESS == rc) {
                 if (1 != pmix_list_get_size(&cb->kvs)) {
                     rc = PMIX_ERR_INVALID_VAL;

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2848,8 +2848,6 @@ static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
     pmix_kval_t *kv;
     pmix_peer_t *peer;
 
-    return PMIX_SUCCESS;
-
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:dstore:store_modex for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
@@ -2895,7 +2893,7 @@ static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
     while (PMIX_SUCCESS == rc) {
         /* don't store blobs to the sm dstore from local clients */
         if (_my_client(proc.nspace, proc.rank)) {
-            continue;
+            break;
         }
         /* store this in the hash table */
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, PMIX_REMOTE, kv);

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2483,13 +2483,8 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
                     PMIX_ERROR_LOG(rc);
                     goto done;
                 }
-
                 strncpy(info[kval_cnt - 1].key, ESH_KNAME_PTR(addr), ESH_KNAME_LEN((char *)addr));
-                PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void**)&(info[kval_cnt - 1]), &val, PMIX_VALUE);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    goto done;
-                }
+                pmix_value_xfer(&info[kval_cnt - 1].value, &val);
                 PMIX_VALUE_DESTRUCT(&val);
                 buffer.base_ptr = NULL;
                 buffer.bytes_used = 0;
@@ -2549,9 +2544,6 @@ done:
 
     if( rc != PMIX_SUCCESS ){
         if( NULL == key ) {
-            if( NULL != kval ) {
-                PMIX_VALUE_RELEASE(kval);
-            }
             if( NULL != info ) {
                 PMIX_INFO_FREE(info, ninfo);
             }
@@ -2591,19 +2583,36 @@ static pmix_status_t dstore_fetch(const pmix_proc_t *proc,
     rc = _dstore_fetch(proc->nspace, proc->rank, key, &val);
     if (PMIX_SUCCESS == rc) {
         if( NULL == key ) {
-            if (PMIX_DATA_ARRAY != val->type ||
-                NULL == val->data.darray ||
-                PMIX_INFO != val->data.darray->type) {
-                PMIX_ERROR_LOG(PMIX_ERR_INVALID_VAL);
-                PMIX_VALUE_RELEASE(val);
-                return PMIX_ERR_INVALID_VAL;
+            pmix_info_t *info;
+            size_t n, ninfo;
+
+            if (NULL == val->data.darray ||
+                PMIX_INFO != val->data.darray->type ||
+                0 == val->data.darray->size) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+                return PMIX_ERR_NOT_FOUND;
             }
-            PMIX_INFO_UNLOAD(rc, val, kvs);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_VALUE_RELEASE(val);
-                return rc;
+            info = (pmix_info_t*)val->data.darray->array;
+            ninfo = val->data.darray->size;
+
+            for (n = 0; n < ninfo; n++){
+                kv = PMIX_NEW(pmix_kval_t);
+                if (NULL == kv) {
+                    rc = PMIX_ERR_NOMEM;
+                    PMIX_VALUE_RELEASE(val);
+                    return rc;
+                }
+                kv->key = strdup(info[n].key);
+                PMIX_VALUE_XFER(rc, kv->value, &info[n].value);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(kv);
+                    PMIX_VALUE_RELEASE(val);
+                    return rc;
+                }
+                pmix_list_append(kvs, &kv->super);
             }
+
             return PMIX_SUCCESS;
         }
         /* just return the value */

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -71,6 +71,37 @@ typedef pmix_status_t (*pmix_gds_base_assign_module_fn_t)(pmix_info_t *info,
                                                           size_t ninfo,
                                                           int *priority);
 
+/* SERVER FN: assemble the keys buffer for server answer */
+typedef pmix_status_t (*pmix_gds_base_module_assemb_kvs_req_fn_t)(const pmix_proc_t *proc,
+                                                            pmix_list_t *kvs,
+                                                            pmix_buffer_t *buf,
+                                                            void *cbdata);
+
+/* define a macro for server keys answer based on peer */
+#define PMIX_GDS_ASSEMB_KVS_REQ(s, p, r, k, b, c)                           \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                 \
+        (s) = PMIX_SUCCESS;                                                 \
+        if (NULL != _g->assemb_kvs_req) {                                   \
+            (s) = _g->assemb_kvs_req(r, k, b, (void*)c);                    \
+        }                                                                   \
+    } while(0)
+
+
+/* CLIENT FN: unpack buffer and key processing */
+typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t *buf);
+
+/* define a macro for client key processing from a server response based on peer */
+#define PMIX_GDS_ACCEPT_KVS_RESP(s, p, b)                                   \
+    do {                                                                    \
+        pmix_gds_base_module_t *_g = (p)->nptr->compat.gds;                 \
+        (s) = PMIX_SUCCESS;                                                 \
+        if (NULL != _g->accept_kvs_resp) {                                  \
+            (s) = _g->accept_kvs_resp(b);                                   \
+        }                                                                   \
+    } while (0)
+
+
 /* SERVER FN: cache job-level info in the server's GDS until client
  * procs connect and we discover which GDS module to use for them.
  * Note that this is essentially the same function as store_job_info,
@@ -350,6 +381,8 @@ typedef struct {
     pmix_gds_base_module_setup_fork_fn_t            setup_fork;
     pmix_gds_base_module_add_nspace_fn_t            add_nspace;
     pmix_gds_base_module_del_nspace_fn_t            del_nspace;
+    pmix_gds_base_module_assemb_kvs_req_fn_t        assemb_kvs_req;
+    pmix_gds_base_module_accept_kvs_resp_fn_t       accept_kvs_resp;
 
 } pmix_gds_base_module_t;
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -678,6 +678,12 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
         return rc;
     }
 
+    if ((PMIX_LOCAL == scope) && !found) {
+        /* pass PMIX_ERR_NOT_FOUND for local request if it's not found*/
+        cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, cbdata, NULL, NULL);
+        return PMIX_SUCCESS;
+    }
+
     return PMIX_ERR_NOT_FOUND;
 }
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -122,10 +122,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_dmdx_local_t *lcd;
     bool local;
     bool localonly = false;
-    pmix_buffer_t pbkt;
+    pmix_buffer_t pbkt, pkt;
     pmix_byte_object_t bo;
     pmix_cb_t cb;
-    pmix_kval_t *kv;
     pmix_proc_t proc;
     char *data;
     size_t sz, n;
@@ -277,7 +276,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * can retrieve the info from that GDS. Otherwise,
          * we need to retrieve it from our own */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
-            peer = pmix_globals.mypeer;
+        peer = pmix_globals.mypeer;
         /* this data is for a local client, so give the gds the
          * option of returning a complete copy of the data,
          * or returning a pointer to local storage */
@@ -289,29 +288,17 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             PMIX_DESTRUCT(&cb);
             return rc;
         }
-        /* we do have it, so let's pack it for return */
-        PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-        /* start with the proc name */
-        PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &proc, 1, PMIX_PROC);
+        PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
+        /* assemble the provided data into a byte object */
+        PMIX_GDS_ASSEMB_KVS_REQ(rc, peer, &proc, &cb.kvs, &pkt, cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&pbkt);
             PMIX_DESTRUCT(&cb);
             return rc;
         }
-        PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-            PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, kv, 1, PMIX_KVAL);
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-                PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&cb);
-                return rc;
-            }
-        }
-        PMIX_DESTRUCT(&cb);
-        /* extract the byte object */
-        PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
-        PMIX_DESTRUCT(&pbkt);
+        PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
+        PMIX_DESTRUCT(&pkt);
         /* pack it into the payload */
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
@@ -513,7 +500,6 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
     pmix_rank_info_t *iptr;
     pmix_proc_t proc;
     pmix_cb_t cb;
-    pmix_kval_t *kv;
     pmix_peer_t *peer;
     pmix_byte_object_t bo;
     char *data = NULL;
@@ -596,21 +582,14 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
         peer = pmix_globals.mypeer;
         PMIX_GDS_FETCH_KV(rc, peer, &cb);
         if (PMIX_SUCCESS == rc) {
-            /* assemble the provided data into a byte object */
             PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-            PMIX_BFROPS_PACK(rc, cd->peer, &pkt, &proc, 1, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
+            /* assemble the provided data into a byte object */
+            PMIX_GDS_ASSEMB_KVS_REQ(rc, peer, &proc, &cb.kvs, &pkt, cd);
+            if (rc != PMIX_SUCCESS) {
+                PMIX_DESTRUCT(&pkt);
                 PMIX_DESTRUCT(&pbkt);
                 PMIX_DESTRUCT(&cb);
                 return rc;
-            }
-            PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-                PMIX_BFROPS_PACK(rc, cd->peer, &pkt, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_DESTRUCT(&pkt);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
             }
             PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
             PMIX_DESTRUCT(&pkt);
@@ -641,21 +620,14 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
         PMIX_GDS_FETCH_KV(rc, peer, &cb);
         if (PMIX_SUCCESS == rc) {
             found = true;
-            /* assemble the provided data into a byte object */
             PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
-            PMIX_BFROPS_PACK(rc, cd->peer, &pkt, &proc, 1, PMIX_PROC);
-            if (PMIX_SUCCESS != rc) {
+            /* assemble the provided data into a byte object */
+            PMIX_GDS_ASSEMB_KVS_REQ(rc, peer, &proc, &cb.kvs, &pkt, cd);
+            if (rc != PMIX_SUCCESS) {
+                PMIX_DESTRUCT(&pkt);
                 PMIX_DESTRUCT(&pbkt);
                 PMIX_DESTRUCT(&cb);
                 return rc;
-            }
-            PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-                PMIX_BFROPS_PACK(rc, cd->peer, &pkt, kv, 1, PMIX_KVAL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_DESTRUCT(&pkt);
-                    PMIX_DESTRUCT(&cb);
-                    return rc;
-                }
             }
             PMIX_UNLOAD_BUFFER(&pkt, bo.bytes, bo.size);
             PMIX_DESTRUCT(&pkt);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -183,7 +183,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, peer, &b2, kp, &cnt, PMIX_KVAL);
         while (PMIX_SUCCESS == rc) {
-            if( PMIX_LOCAL == scope ){
+            if( PMIX_LOCAL == scope || PMIX_GLOBAL == scope){
                 PMIX_GDS_STORE_KV(rc, peer, &proc, scope, kp);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
@@ -191,7 +191,8 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
                     PMIX_DESTRUCT(&b2);
                     return rc;
                 }
-            } else {
+            }
+            if (PMIX_REMOTE == scope || PMIX_GLOBAL == scope) {
                 PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, scope, kp);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);


### PR DESCRIPTION
This PR fixes a modex problems, which appears for more than two nodes.
Refs [#3787](https://github.com/open-mpi/ompi/pull/3787)
There are our MTT results with `dstore` used: 
```
   Phase    Section           MPI Version   Duration Pass Fail Time  Skip
                                                               Out
   Test Run atest             topic/pmix210 22:21    41        1
   Test Run ctxalloc          topic/pmix210 00:03    2
   Test Run trivial           topic/pmix210 20:16    11        1
   Test Run mpi-test-suite    topic/pmix210 00:13    2
   Test Run fp-sum-test       topic/pmix210 02:10    2
   Test Run mpi-small-tests   topic/pmix210 43:25    50

Totals

    Tests            Failed           Passed           Duration
    116              2                114              01:51:42
```
_Note:_ tests uses both modex methods (full/direct)

The results without `dstore` are passed all of tests. I will investigate a `dstore` hangs.