### PR TITLE
Silence coverity

### DIFF
--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2396,7 +2396,7 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
         kval_cnt = rinfo->count;
 
         /*  Initialize array for all keys of rank */
-        if ((NULL == key) || (kval_cnt > 0)) {
+        if ((NULL == key) && (kval_cnt > 0)) {
             kval = (pmix_value_t*)malloc(sizeof(pmix_value_t));
             if (NULL == kval) {
                 return PMIX_ERR_NOMEM;
@@ -2543,7 +2543,7 @@ done:
     }
 
     if( rc != PMIX_SUCCESS ){
-        if( NULL == key ) {
+        if ((NULL == key) && (kval_cnt > 0)) {
             if( NULL != info ) {
                 PMIX_INFO_FREE(info, ninfo);
             }

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2304,8 +2304,10 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
         return rc;
     }
 
-    if (kvs) {
-        *kvs = NULL;
+    if (NULL == kvs) {
+        rc = PMIX_ERR_FATAL;
+        PMIX_ERROR_LOG(rc);
+        return rc;
     }
 
     if (PMIX_RANK_UNDEF == rank) {

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2403,6 +2403,7 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
             if (NULL == kval) {
                 return PMIX_ERR_NOMEM;
             }
+            PMIX_VALUE_CONSTRUCT(kval);
 
             ninfo = kval_cnt;
             PMIX_INFO_CREATE(info, ninfo);
@@ -2411,7 +2412,6 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
                 goto done;
             }
 
-            PMIX_VALUE_CONSTRUCT(kval);
             kval->type = PMIX_DATA_ARRAY;
             kval->data.darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
             if (NULL == kval->data.darray) {
@@ -2549,6 +2549,7 @@ done:
             if( NULL != info ) {
                 PMIX_INFO_FREE(info, ninfo);
             }
+            PMIX_VALUE_RELEASE(kval);
         }
         return rc;
     }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -293,7 +293,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         PMIX_GDS_ASSEMB_KVS_REQ(rc, peer, &proc, &cb.kvs, &pkt, cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            PMIX_DESTRUCT(&pbkt);
             PMIX_DESTRUCT(&cb);
             return rc;
         }


### PR DESCRIPTION
Address:
CID 1375987: Time of check time of use (TOCTOU)
CID 1415599: Resource leaks  (RESOURCE_LEAK)
CID 1415602: Null pointer dereferences  (FORWARD_NULL)
CID 1415601: Resource leaks  (RESOURCE_LEAK)    
CID 1415600: Uninitialized variables  (UNINIT)

Was marked as ignored:
CID 1375986: Security best practices violations (TOCTOU)