### PR TITLE
Backport changes to mca base

### DIFF
--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -216,12 +216,12 @@ static void parse_verbose(char *e, pmix_output_stream_t *lds)
             have_output = true;
         }
 
-        else if (strcasecmp(ptr, "file") == 0) {
+        else if (strcasecmp(ptr, "file") == 0 || strcasecmp(ptr, "file:") == 0) {
             lds->lds_want_file = true;
             have_output = true;
         } else if (strncasecmp(ptr, "file:", 5) == 0) {
             lds->lds_want_file = true;
-            lds->lds_file_suffix = ptr + 5;
+            lds->lds_file_suffix = strdup(ptr + 5);
             have_output = true;
         } else if (strcasecmp(ptr, "fileappend") == 0) {
             lds->lds_want_file = true;

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -86,6 +86,7 @@ typedef struct {
  * Private functions
  */
 static void construct(pmix_object_t *stream);
+static void destruct(pmix_object_t *stream);
 static int do_open(int output_id, pmix_output_stream_t * lds);
 static int open_file(int i);
 static void free_descriptor(int output_id);
@@ -116,7 +117,7 @@ static bool syslog_opened = false;
 #endif
 static char *redirect_syslog_ident = NULL;
 
-PMIX_CLASS_INSTANCE(pmix_output_stream_t, pmix_object_t, construct, NULL);
+PMIX_CLASS_INSTANCE(pmix_output_stream_t, pmix_object_t, construct, destruct);
 
 /*
  * Setup the output stream infrastructure
@@ -480,6 +481,15 @@ static void construct(pmix_object_t *obj)
     stream->lds_want_file = false;
     stream->lds_want_file_append = false;
     stream->lds_file_suffix = NULL;
+}
+static void destruct(pmix_object_t *obj)
+{
+    pmix_output_stream_t *stream = (pmix_output_stream_t*) obj;
+
+    if( NULL != stream->lds_file_suffix ) {
+        free(stream->lds_file_suffix);
+        stream->lds_file_suffix = NULL;
+    }
 }
 
 /*


### PR DESCRIPTION
from (https://github.com/open-mpi/ompi/pull/3775)

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit baa2c33bf6b17bf9c58d7b116234543323056e29)