### PR TITLE
Check for incorrect install locations and no usable components

### DIFF
--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -179,9 +179,12 @@ static int file_exists(const char *filename, const char *ext)
 
 int pmix_mca_base_component_repository_add (const char *path)
 {
+    int rc=PMIX_SUCCESS;
+
 #if PMIX_HAVE_PDL_SUPPORT
     char *path_to_use = NULL, *dir, *ctx;
     const char sep[] = {PMIX_ENV_SEP, '\0'};
+    bool found_one = false;
 
     if (NULL == path) {
         /* nothing to do */
@@ -200,16 +203,37 @@ int pmix_mca_base_component_repository_add (const char *path)
             dir = pmix_mca_base_system_default_path;
         }
 
-        if (0 != pmix_pdl_foreachfile(dir, process_repository_item, NULL)) {
-            break;
+        rc = pmix_pdl_foreachfile(dir, process_repository_item, NULL);
+        if (PMIX_SUCCESS == rc) {
+            found_one = true;
         }
     } while (NULL != (dir = strtok_r (NULL, sep, &ctx)));
 
     free (path_to_use);
 
+    if (found_one) {
+        return PMIX_SUCCESS;
+    } else {
+        /* we were unable to find even one available directory
+         * in this search path. This typically means that the
+         * user has pointed us to an incorrect location. We
+         * cannot use show_help as the show_help file is quite
+         * likely also not going to be found, so let's print
+         * a helpful error message as we know we are going
+         * to exit out in this case */
+        fprintf(stderr, "\n-------------------------------------------------------\n");
+        fprintf(stderr, "No usable directories were found in the provided path\n");
+        fprintf(stderr, "when searching for available plugins. This usually indicates\n");
+        fprintf(stderr, "either that the PMIx installation was moved, or that the\n");
+        fprintf(stderr, "PMIX_INSTALL_PREFIX environmental variable is set and pointing\n");
+        fprintf(stderr, "to an incorrect or non-existent location.\n\n");
+        fprintf(stderr, "Please correct the situation and try again.\n");
+        fprintf(stderr, "-------------------------------------------------------\n\n");
+        rc = PMIX_ERR_SILENT;
+    }
 #endif /* PMIX_HAVE_PDL_SUPPORT */
 
-    return PMIX_SUCCESS;
+    return rc;
 }
 
 

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -224,9 +224,10 @@ int pmix_mca_base_component_repository_add (const char *path)
         fprintf(stderr, "\n-------------------------------------------------------\n");
         fprintf(stderr, "No usable directories were found in the provided path\n");
         fprintf(stderr, "when searching for available plugins. This usually indicates\n");
-        fprintf(stderr, "either that the PMIx installation was moved, or that the\n");
-        fprintf(stderr, "PMIX_INSTALL_PREFIX environmental variable is set and pointing\n");
-        fprintf(stderr, "to an incorrect or non-existent location.\n\n");
+        fprintf(stderr, "that the PMIx installation was moved, or the PMIX_INSTALL_PREFIX\n");
+        fprintf(stderr, "environmental variable or \"mca_base_component_path\"\n");
+        fprintf(stderr, "MCA parameter is set and pointing to an incorrect or \n");
+        fprintf(stderr, "non-existent location.\n\n");
         fprintf(stderr, "Please correct the situation and try again.\n");
         fprintf(stderr, "-------------------------------------------------------\n\n");
         rc = PMIX_ERR_SILENT;

--- a/src/mca/bfrops/base/bfrop_base_select.c
+++ b/src/mca/bfrops/base/bfrop_base_select.c
@@ -24,6 +24,8 @@
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
+#include "src/util/error.h"
+#include "src/util/show_help.h"
 
 #include "src/mca/bfrops/base/base.h"
 
@@ -106,6 +108,12 @@ int pmix_bfrop_base_select(void)
             /* must be lowest priority - add to end */
             pmix_list_append(&pmix_bfrops_globals.actives, &newmodule->super);
         }
+    }
+
+    /* if no modules were found, then that's an error as we require at least one */
+    if (0 == pmix_list_get_size(&pmix_bfrops_globals.actives)) {
+        pmix_show_help("help-pmix-runtime.txt", "no-plugins", true, "BFROPS");
+        return PMIX_ERR_SILENT;
     }
 
     if (4 < pmix_output_get_verbosity(pmix_bfrops_base_framework.framework_output)) {

--- a/src/mca/gds/base/gds_base_select.c
+++ b/src/mca/gds/base/gds_base_select.c
@@ -23,6 +23,8 @@
 #include <string.h>
 
 #include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/show_help.h"
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
 
@@ -104,6 +106,12 @@ int pmix_gds_base_select(pmix_info_t info[], size_t ninfo)
             /* must be lowest priority - add to end */
             pmix_list_append(&pmix_gds_globals.actives, &newmodule->super);
         }
+    }
+
+    /* if no modules were found, then that's an error as we require at least one */
+    if (0 == pmix_list_get_size(&pmix_gds_globals.actives)) {
+        pmix_show_help("help-pmix-runtime.txt", "no-plugins", true, "GDS");
+        return PMIX_ERR_SILENT;
     }
 
     /* setup the list of all module names */

--- a/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
+++ b/src/mca/pdl/pdlopen/pdl_pdlopen_module.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/mca/pinstalldirs/pinstalldirs.h
+++ b/src/mca/pinstalldirs/pinstalldirs.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2006-2015 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,7 +21,7 @@
 BEGIN_C_DECLS
 
 /*
- * Most of this file is just for ompi_info.  The only public interface
+ * Most of this file is just for pmix_info.  The only public interface
  * once pmix_init has been called is the pmix_pinstall_dirs structure
  * and the pmix_pinstall_dirs_expand() call */
 struct pmix_pinstall_dirs_t {
@@ -40,18 +40,9 @@ struct pmix_pinstall_dirs_t {
     char* infodir;
     char* mandir;
 
-    /* Note that the following fields intentionally have an "ompi"
-       prefix, even though they're down in the PMIX layer.  This is
-       not abstraction break because the "ompi" they're referring to
-       is for the build system of the overall software tree -- not an
-       individual project within that overall tree.
-
-       Rather than using pkg{data,lib,includedir}, use our own
-       ompi{data,lib,includedir}, which is always set to
-       {datadir,libdir,includedir}/pmix. This will keep us from
-       having help files in prefix/share/open-rte when building
-       without PMIX, but in prefix/share/pmix when building
-       with PMIX.
+    /* Rather than using pkg{data,lib,includedir}, use our own
+       pmix{data,lib,includedir}, which is always set to
+       {datadir,libdir,includedir}/pmix.
 
        Note that these field names match macros set by configure that
        are used in Makefile.am files.  E.g., project help files are

--- a/src/mca/preg/base/preg_base_select.c
+++ b/src/mca/preg/base/preg_base_select.c
@@ -24,6 +24,8 @@
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
+#include "src/util/error.h"
+#include "src/util/show_help.h"
 
 #include "src/mca/preg/base/base.h"
 
@@ -98,6 +100,12 @@ int pmix_preg_base_select(void)
             /* must be lowest priority - add to end */
             pmix_list_append(&pmix_preg_globals.actives, &newmodule->super);
         }
+    }
+
+    /* if no modules were found, then that's an error as we require at least one */
+    if (0 == pmix_list_get_size(&pmix_preg_globals.actives)) {
+        pmix_show_help("help-pmix-runtime.txt", "no-plugins", true, "PREG");
+        return PMIX_ERR_SILENT;
     }
 
     if (4 < pmix_output_get_verbosity(pmix_preg_base_framework.framework_output)) {

--- a/src/mca/psec/base/psec_base_select.c
+++ b/src/mca/psec/base/psec_base_select.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -24,6 +24,8 @@
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
+#include "src/util/error.h"
+#include "src/util/show_help.h"
 
 #include "src/mca/psec/base/base.h"
 
@@ -98,6 +100,12 @@ int pmix_psec_base_select(void)
             /* must be lowest priority - add to end */
             pmix_list_append(&pmix_psec_globals.actives, &newmodule->super);
         }
+    }
+
+    /* if no modules were found, then that's an error as we require at least one */
+    if (0 == pmix_list_get_size(&pmix_psec_globals.actives)) {
+        pmix_show_help("help-pmix-runtime.txt", "no-plugins", true, "PSEC");
+        return PMIX_ERR_SILENT;
     }
 
     if (4 < pmix_output_get_verbosity(pmix_psec_base_framework.framework_output)) {

--- a/src/mca/ptl/base/ptl_base_select.c
+++ b/src/mca/ptl/base/ptl_base_select.c
@@ -24,6 +24,8 @@
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
+#include "src/util/error.h"
+#include "src/util/show_help.h"
 
 #include "src/mca/ptl/base/base.h"
 
@@ -79,6 +81,12 @@ int pmix_ptl_base_select(void)
             /* must be lowest priority - add to end */
             pmix_list_append(&pmix_ptl_globals.actives, &newactive->super);
         }
+    }
+
+    /* if no modules were found, then that's an error as we require at least one */
+    if (0 == pmix_list_get_size(&pmix_ptl_globals.actives)) {
+        pmix_show_help("help-pmix-runtime.txt", "no-plugins", true, "PTL");
+        return PMIX_ERR_SILENT;
     }
 
     if (4 < pmix_output_get_verbosity(pmix_ptl_base_framework.framework_output)) {

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -40,3 +40,20 @@ a fatal situation, but may negatively impact your launch performance.
 If you feel you have received this warning in error, or wish to ignore
 it in the future, you can disable it by setting the PMIx MCA parameter
 "pmix_suppress_missing_data_warning=1"
+#
+[no-plugins]
+We were unable to find any usable plugins for the %s framework. This PMIx
+framework requires at least one plugin in order to operate. This can be caused
+by any of the following:
+
+* we were unable to build any of the plugins due to some combination
+  of configure directives and available system support
+
+* no plugin was selected due to some combination of MCA parameter
+  directives versus built plugins (i.e., you excluded all the plugins
+  that were built and/or could execute)
+
+* the PMIX_INSTALL_PREFIX is pointing to a location that doesn't include
+  any plugins for this framework.
+
+Please check your installation and environment.

--- a/src/runtime/help-pmix-runtime.txt
+++ b/src/runtime/help-pmix-runtime.txt
@@ -53,7 +53,8 @@ by any of the following:
   directives versus built plugins (i.e., you excluded all the plugins
   that were built and/or could execute)
 
-* the PMIX_INSTALL_PREFIX is pointing to a location that doesn't include
-  any plugins for this framework.
+* the PMIX_INSTALL_PREFIX environment variable, or the MCA parameter
+  "mca_base_component_path", is set and doesn't point to any location
+  that includes at least one usable plugin for this framework.
 
 Please check your installation and environment.

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -285,9 +285,11 @@ int pmix_rte_init(pmix_proc_type_t type,
 
     return PMIX_SUCCESS;
 
- return_error:
-    pmix_show_help( "help-pmix-runtime.txt",
-                    "pmix_init:startup:internal-failure", true,
-                    error, ret );
+  return_error:
+    if (PMIX_ERR_SILENT != ret) {
+        pmix_show_help( "help-pmix-runtime.txt",
+                        "pmix_init:startup:internal-failure", true,
+                        error, ret );
+    }
     return ret;
 }


### PR DESCRIPTION
Check for failure to find any usable components in frameworks that require at least one, print an informative error message, and return an error.

If the user provides us with a PMIX_INSTALL_PREFIX that points to an unusable location (either nonexistent or not available to us), or none of the default search locations exist (because the installation was moved), then provide a nice message so they know what is wrong and return an error.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>