### PR TITLE
Accommodate the case where someone embedding PMIx code in their library needs to link libpmix against another library

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -156,6 +156,18 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_RENAME)
     AC_CONFIG_FILES(pmix_config_prefix[include/pmix_rename.h])
 
+    # Add any extra lib?
+    AC_ARG_WITH([pmix-extra-lib],
+                AC_HELP_STRING([--with-pmix-extra-lib=LIB],
+                               [Link the output PMIx library to this extra lib (used in embedded mode)]))
+    AC_MSG_CHECKING([for extra lib])
+    AS_IF([test ! -z "$with_pmix_extra_lib"],
+          [AC_MSG_RESULT([$with_pmix_extra_lib])
+           PMIX_EXTRA_LIB=$with_pmix_extra_lib],
+          [AC_MSG_RESULT([no])
+           PMIX_EXTRA_LIB=])
+    AC_SUBST(PMIX_EXTRA_LIB)
+
     # GCC specifics.
     if test "x$GCC" = "xyes"; then
         PMIX_GCC_CFLAGS="-Wall -Wmissing-prototypes -Wundef"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -45,7 +45,8 @@ dist_pmixdata_DATA =
 
 libpmix_la_LIBADD = \
 	mca/base/libpmix_mca_base.la \
-	$(MCA_pmix_FRAMEWORK_LIBS)
+	$(MCA_pmix_FRAMEWORK_LIBS) \
+	$(PMIX_EXTRA_LIB)
 libpmix_la_DEPENDENCIES = $(libpmix_la_LIBADD)
 
 if PMIX_EMBEDDED_MODE


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>