### PR TITLE
Change the error to a warning if --enable-builtin-atomics is given and builtin atomics aren't available, and default to the inline atomics

### DIFF
--- a/config/pmix_config_asm.m4
+++ b/config/pmix_config_asm.m4
@@ -923,7 +923,7 @@ AC_DEFUN([PMIX_CONFIG_ASM],[
     AS_IF([test "$pmix_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_builtin_atomics" != "no"],
           [PMIX_CHECK_SYNC_BUILTINS([pmix_cv_asm_builtin="BUILTIN_SYNC"], [])])
     AS_IF([test "$pmix_cv_asm_builtin" = "BUILTIN_NO" && test "$enable_builtin_atomics" = "yes"],
-          [AC_MSG_ERROR([__sync builtin atomics requested but not found.])])
+          [AC_MSG_WARN([__sync builtin atomics requested but not found - proceeding with inline atomics])])
 
         PMIX_CHECK_ASM_PROC
         PMIX_CHECK_ASM_TEXT


### PR DESCRIPTION
Per recommendation from upstream

Signed-off-by: Ralph Castain <rhc@open-mpi.org>