### PR TITLE
v2.0: Per 08/10/2017 telecon: enable test suite build when visibility is ON.

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -38,9 +38,7 @@ if WANT_PMI_BACKWARD
 noinst_PROGRAMS += pmi_client pmi2_client
 endif
 
-if !WANT_HIDDEN
 noinst_PROGRAMS += pmix_test pmix_client pmix_regex
-endif
 
 pmix_test_SOURCES = $(headers) \
         pmix_test.c test_common.c cli_stages.c server_callbacks.c utils.c


### PR DESCRIPTION
Now pmix utility functions like containers (lists) and opal-like OS functions
are exported to allow plugins to work. This means that tests are ok with
enabled visibility.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>
(cherry picked from commit 7d55b080230c39d06df882fad629e96e0bd21c94)