### PR TITLE
Resolve the visibility problem

### DIFF
--- a/config/pmix_check_visibility.m4
+++ b/config/pmix_check_visibility.m4
@@ -12,6 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2009-2011 Oracle and/or its affiliates.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -86,7 +87,7 @@ AC_DEFUN([PMIX_CHECK_VISIBILITY],[
         unset pmix_add
     fi
 
-    AC_DEFINE_UNQUOTED([PMIX_C_HAVE_VISIBILITY], [$WANT_VISIBILITY],
+    AC_DEFINE_UNQUOTED([PMIX_HAVE_VISIBILITY], [$WANT_VISIBILITY],
             [Whether C compiler supports symbol visibility or not])
     AM_CONDITIONAL([WANT_HIDDEN],[test "$WANT_VISIBILITY" = "1"])
 ])

--- a/include/pmi.h
+++ b/include/pmi.h
@@ -48,6 +48,12 @@
 #ifndef PMI_H
 #define PMI_H
 
+#ifdef PMIX_HAVE_VISIBILITY
+#define PMIX_EXPORT __attribute__((__visibility__("default")))
+#else
+#define PMIX_EXPORT
+#endif
+
 /* prototypes for the PMI interface in MPICH2 */
 
 #if defined(__cplusplus)
@@ -119,7 +125,7 @@ this process was created by 'PMI_Spawn_multiple'.  'spawned' will be 'PMI_TRUE' 
 this process group has a parent and 'PMI_FALSE' if it does not.
 
 @*/
-int PMI_Init( int *spawned );
+PMIX_EXPORT int PMI_Init( int *spawned );
 
 /*@
 PMI_Initialized - check if PMI has been initialized
@@ -139,7 +145,7 @@ On successful output, initialized will either be 'PMI_TRUE' or 'PMI_FALSE'.
 - PMI_FALSE - initialize has not been called or previously failed.
 
 @*/
-int PMI_Initialized( PMI_BOOL *initialized );
+PMIX_EXPORT int PMI_Initialized( PMI_BOOL *initialized );
 
 /*@
 PMI_Finalize - finalize the Process Manager Interface
@@ -152,7 +158,7 @@ Notes:
  Finalize PMI for this process group.
 
 @*/
-int PMI_Finalize( void );
+PMIX_EXPORT int PMI_Finalize( void );
 
 /*@
 PMI_Get_size - obtain the size of the process group
@@ -170,7 +176,7 @@ This function returns the size of the process group to which the local process
 belongs.
 
 @*/
-int PMI_Get_size( int *size );
+PMIX_EXPORT int PMI_Get_size( int *size );
 
 /*@
 PMI_Get_rank - obtain the rank of the local process in the process group
@@ -187,7 +193,7 @@ Notes:
 This function returns the rank of the local process in its process group.
 
 @*/
-int PMI_Get_rank( int *rank );
+PMIX_EXPORT int PMI_Get_rank( int *rank );
 
 /*@
 PMI_Get_universe_size - obtain the universe size
@@ -202,7 +208,7 @@ Return values:
 
 
 @*/
-int PMI_Get_universe_size( int *size );
+PMIX_EXPORT int PMI_Get_universe_size( int *size );
 
 /*@
 PMI_Get_appnum - obtain the application number
@@ -217,7 +223,7 @@ Return values:
 
 
 @*/
-int PMI_Get_appnum( int *appnum );
+PMIX_EXPORT int PMI_Get_appnum( int *appnum );
 
 /*@
 PMI_Publish_name - publish a name
@@ -233,7 +239,7 @@ Return values:
 
 
 @*/
-int PMI_Publish_name( const char service_name[], const char port[] );
+PMIX_EXPORT int PMI_Publish_name( const char service_name[], const char port[] );
 
 /*@
 PMI_Unpublish_name - unpublish a name
@@ -248,7 +254,7 @@ Return values:
 
 
 @*/
-int PMI_Unpublish_name( const char service_name[] );
+PMIX_EXPORT int PMI_Unpublish_name( const char service_name[] );
 
 /*@
 PMI_Lookup_name - lookup a service by name
@@ -266,7 +272,7 @@ Return values:
 
 
 @*/
-int PMI_Lookup_name( const char service_name[], char port[] );
+PMIX_EXPORT int PMI_Lookup_name( const char service_name[], char port[] );
 
 /*@
 PMI_Get_id - obtain the id of the process group
@@ -289,7 +295,7 @@ that the local process belongs to.  The string passed in must be at least
 as long as the number returned by 'PMI_Get_id_length_max()'.
 
 @*/
-int PMI_Get_id( char id_str[], int length );
+PMIX_EXPORT int PMI_Get_id( char id_str[], int length );
 
 /*@
 PMI_Get_kvs_domain_id - obtain the id of the PMI domain
@@ -312,7 +318,7 @@ where keyval spaces can be shared.  The string passed in must be at least
 as long as the number returned by 'PMI_Get_id_length_max()'.
 
 @*/
-int PMI_Get_kvs_domain_id( char id_str[], int length );
+PMIX_EXPORT int PMI_Get_kvs_domain_id( char id_str[], int length );
 
 /*@
 PMI_Get_id_length_max - obtain the maximum length of an id string
@@ -329,7 +335,7 @@ Notes:
 This function returns the maximum length of a process group id string.
 
 @*/
-int PMI_Get_id_length_max( int *length );
+PMIX_EXPORT int PMI_Get_id_length_max( int *length );
 
 /*@
 PMI_Barrier - barrier across the process group
@@ -344,7 +350,7 @@ the local process belongs to.  It will not return until all the processes
 have called 'PMI_Barrier()'.
 
 @*/
-int PMI_Barrier( void );
+PMIX_EXPORT int PMI_Barrier( void );
 
 /*@
 PMI_Get_clique_size - obtain the number of processes on the local node
@@ -364,7 +370,7 @@ function to distinguish between processes that can communicate through IPC
 mechanisms (e.g., shared memory) and other network mechanisms.
 
 @*/
-int PMI_Get_clique_size( int *size );
+PMIX_EXPORT int PMI_Get_clique_size( int *size );
 
 /*@
 PMI_Get_clique_ranks - get the ranks of the local processes in the process group
@@ -389,7 +395,7 @@ communicate through IPC mechanisms (e.g., shared memory) and other network
 mechanisms.
 
 @*/
-int PMI_Get_clique_ranks( int ranks[], int length);
+PMIX_EXPORT int PMI_Get_clique_ranks( int ranks[], int length);
 
 /*@
 PMI_Abort - abort the process group associated with this process
@@ -401,7 +407,7 @@ Input Parameters:
 Return values:
 . none - this function should not return
 @*/
-int PMI_Abort(int exit_code, const char error_msg[]);
+PMIX_EXPORT int PMI_Abort(int exit_code, const char error_msg[]);
 
 /* PMI Keymap functions */
 /*@
@@ -426,7 +432,7 @@ kvsname, must be at least as long as the value returned by
 'PMI_KVS_Get_name_length_max()'.
 
 @*/
-int PMI_KVS_Get_my_name( char kvsname[], int length );
+PMIX_EXPORT int PMI_KVS_Get_my_name( char kvsname[], int length );
 
 /*@
 PMI_KVS_Get_name_length_max - obtain the length necessary to store a kvsname
@@ -448,7 +454,7 @@ different implementations may allow different maximum lengths; by using a
 routine here, we can interface with a variety of implementations of PMI.
 
 @*/
-int PMI_KVS_Get_name_length_max( int *length );
+PMIX_EXPORT int PMI_KVS_Get_name_length_max( int *length );
 
 /*@
 PMI_KVS_Get_key_length_max - obtain the length necessary to store a key
@@ -465,7 +471,7 @@ Notes:
 This function returns the string length required to store a key.
 
 @*/
-int PMI_KVS_Get_key_length_max( int *length );
+PMIX_EXPORT int PMI_KVS_Get_key_length_max( int *length );
 
 /*@
 PMI_KVS_Get_value_length_max - obtain the length necessary to store a value
@@ -483,7 +489,7 @@ This function returns the string length required to store a value from a
 keyval space.
 
 @*/
-int PMI_KVS_Get_value_length_max( int *length );
+PMIX_EXPORT int PMI_KVS_Get_value_length_max( int *length );
 
 /*@
 PMI_KVS_Create - create a new keyval space
@@ -508,7 +514,7 @@ parameter, kvsname, must be at least as long as the value returned by
 'PMI_KVS_Get_name_length_max()'.
 
 @*/
-int PMI_KVS_Create( char kvsname[], int length );
+PMIX_EXPORT int PMI_KVS_Create( char kvsname[], int length );
 
 /*@
 PMI_KVS_Destroy - destroy keyval space
@@ -525,7 +531,7 @@ Notes:
 This function destroys a keyval space created by 'PMI_KVS_Create()'.
 
 @*/
-int PMI_KVS_Destroy( const char kvsname[] );
+PMIX_EXPORT int PMI_KVS_Destroy( const char kvsname[] );
 
 /*@
 PMI_KVS_Put - put a key/value pair in a keyval space
@@ -551,7 +557,7 @@ space must be unique to the keyval space.  You may not put more than once
 with the same key.
 
 @*/
-int PMI_KVS_Put( const char kvsname[], const char key[], const char value[]);
+PMIX_EXPORT int PMI_KVS_Put( const char kvsname[], const char key[], const char value[]);
 
 /*@
 PMI_KVS_Commit - commit all previous puts to the keyval space
@@ -569,7 +575,7 @@ This function commits all previous puts since the last 'PMI_KVS_Commit()' into
 the specified keyval space. It is a process local operation.
 
 @*/
-int PMI_KVS_Commit( const char kvsname[] );
+PMIX_EXPORT int PMI_KVS_Commit( const char kvsname[] );
 
 /*@
 PMI_KVS_Get - get a key/value pair from a keyval space
@@ -594,7 +600,7 @@ Notes:
 This function gets the value of the specified key in the keyval space.
 
 @*/
-int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length);
+PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[], int length);
 
 /*@
 PMI_KVS_Iter_first - initialize the iterator and get the first value
@@ -625,7 +631,7 @@ the values returned by 'PMI_KVS_Get_key_length_max()' and
 'PMI_KVS_Get_value_length_max()'.
 
 @*/
-int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len);
+PMIX_EXPORT int PMI_KVS_Iter_first(const char kvsname[], char key[], int key_len, char val[], int val_len);
 
 /*@
 PMI_KVS_Iter_next - get the next keyval pair from the keyval space
@@ -656,7 +662,7 @@ key and val, must be at least as long as the values returned by
 'PMI_KVS_Get_key_length_max()' and 'PMI_KVS_Get_value_length_max()'.
 
 @*/
-int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len);
+PMIX_EXPORT int PMI_KVS_Iter_next(const char kvsname[], char key[], int key_len, char val[], int val_len);
 
 /* PMI Process Creation functions */
 
@@ -710,15 +716,15 @@ maxprocs.  The acceptable number of processes spawned may be controlled by
 mpiexec in the MPI-2 standard.  Environment variables may be passed to the
 spawned processes through PMI implementation specific 'info_keyval' parameters.
 @*/
-int PMI_Spawn_multiple(int count,
-                       const char * cmds[],
-                       const char ** argvs[],
-                       const int maxprocs[],
-                       const int info_keyval_sizesp[],
-                       const PMI_keyval_t * info_keyval_vectors[],
-                       int preput_keyval_size,
-                       const PMI_keyval_t preput_keyval_vector[],
-                       int errors[]);
+PMIX_EXPORT int PMI_Spawn_multiple(int count,
+                                   const char * cmds[],
+                                   const char ** argvs[],
+                                   const int maxprocs[],
+                                   const int info_keyval_sizesp[],
+                                   const PMI_keyval_t * info_keyval_vectors[],
+                                   int preput_keyval_size,
+                                   const PMI_keyval_t preput_keyval_vector[],
+                                   int errors[]);
 
 
 /*@
@@ -752,7 +758,7 @@ arguments in the args array, this function may parse more than one argument as l
 as the options are contiguous in the args array.
 
 @*/
-int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
+PMIX_EXPORT int PMI_Parse_option(int num_args, char *args[], int *num_parsed, PMI_keyval_t **keyvalp, int *size);
 
 /*@
 PMI_Args_to_keyval - create keyval structures from command line arguments
@@ -779,7 +785,7 @@ not be used to free this array as there is no requirement that the array be
 allocated with 'malloc()'.
 
 @*/
-int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
+PMIX_EXPORT int PMI_Args_to_keyval(int *argcp, char *((*argvp)[]), PMI_keyval_t **keyvalp, int *size);
 
 /*@
 PMI_Free_keyvals - free the keyval structures created by PMI_Args_to_keyval
@@ -798,7 +804,7 @@ Notes:
  Using this routine instead of 'free' allows the PMI package to track
  allocation of storage or to use interal storage as it sees fit.
 @*/
-int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size);
+PMIX_EXPORT int PMI_Free_keyvals(PMI_keyval_t keyvalp[], int size);
 
 /*@
 PMI_Get_options - get a string of command line argument descriptions that may be printed to the user
@@ -820,7 +826,7 @@ Return values:
 Notes:
  This function returns the command line options specific to the pmi implementation
 @*/
-int PMI_Get_options(char *str, int *length);
+PMIX_EXPORT int PMI_Get_options(char *str, int *length);
 
 #if defined(__cplusplus)
 }

--- a/include/pmi2.h
+++ b/include/pmi2.h
@@ -7,6 +7,12 @@
 #ifndef PMI2_H_INCLUDED
 #define PMI2_H_INCLUDED
 
+#ifdef PMIX_HAVE_VISIBILITY
+#define PMIX_EXPORT __attribute__((__visibility__("default")))
+#else
+#define PMIX_EXPORT
+#endif
+
 #define PMI2_MAX_KEYLEN 64
 #define PMI2_MAX_VALLEN 1024
 #define PMI2_MAX_ATTRVALUE 1024
@@ -117,7 +123,7 @@ typedef struct PMI2_Connect_comm {
   iff this process group has a parent.
 
 @*/
-int PMI2_Init(int *spawned, int *size, int *rank, int *appnum);
+PMIX_EXPORT int PMI2_Init(int *spawned, int *size, int *rank, int *appnum);
 
 /*@
   PMI2_Finalize - finalize the Process Manager Interface
@@ -129,7 +135,7 @@ int PMI2_Init(int *spawned, int *size, int *rank, int *appnum);
   Finalize PMI for this job.
 
 @*/
-int PMI2_Finalize(void);
+PMIX_EXPORT int PMI2_Finalize(void);
 
 /*@
   PMI2_Initialized - check if PMI has been initialized
@@ -138,7 +144,7 @@ int PMI2_Finalize(void);
   Non-zero if PMI2_Initialize has been called successfully, zero otherwise.
 
 @*/
-int PMI2_Initialized(void);
+PMIX_EXPORT int PMI2_Initialized(void);
 
 /*@
   PMI2_Abort - abort the process group associated with this process
@@ -152,7 +158,7 @@ int PMI2_Initialized(void);
   error code otherwise.
 
 @*/
-int PMI2_Abort(int flag, const char msg[]);
+PMIX_EXPORT int PMI2_Abort(int flag, const char msg[]);
 
 /*@
   PMI2_Spawn - spawn a new set of processes
@@ -191,15 +197,15 @@ int PMI2_Abort(int flag, const char msg[]);
   mpiexec in the MPI-2 standard.  Environment variables may be passed to the
   spawned processes through PMI implementation specific 'info_keyval' parameters.
 @*/
-int PMI2_Job_Spawn(int count, const char * cmds[],
-                   int argcs[], const char ** argvs[],
-                   const int maxprocs[],
-                   const int info_keyval_sizes[],
-                   const PMI_keyval_t *info_keyval_vectors[],
-                   int preput_keyval_size,
-                   const PMI_keyval_t *preput_keyval_vector[],
-                   char jobId[], int jobIdSize,
-                   int errors[]);
+PMIX_EXPORT int PMI2_Job_Spawn(int count, const char * cmds[],
+                               int argcs[], const char ** argvs[],
+                               const int maxprocs[],
+                               const int info_keyval_sizes[],
+                               const PMI_keyval_t *info_keyval_vectors[],
+                               int preput_keyval_size,
+                               const PMI_keyval_t *preput_keyval_vector[],
+                               char jobId[], int jobIdSize,
+                               int errors[]);
 
 /*@
   PMI2_Job_GetId - get job id of this job
@@ -214,7 +220,7 @@ int PMI2_Job_Spawn(int count, const char * cmds[],
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Job_GetId(char jobid[], int jobid_size);
+PMIX_EXPORT int PMI2_Job_GetId(char jobid[], int jobid_size);
 
 /*@
   PMI2_Job_GetRank - get rank of this job
@@ -223,7 +229,7 @@ int PMI2_Job_GetId(char jobid[], int jobid_size);
   Return values:
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 @*/
-int PMI2_Job_GetRank(int* rank);
+PMIX_EXPORT int PMI2_Job_GetRank(int* rank);
 
 /*@
   PMI2_Info_GetSize - get the number of processes on the node
@@ -232,7 +238,7 @@ int PMI2_Job_GetRank(int* rank);
   Return values:
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 @*/
-int PMI2_Info_GetSize(int* size);
+PMIX_EXPORT int PMI2_Info_GetSize(int* size);
 
 /*@
   PMI2_Job_Connect - connect to the parallel job with ID jobid
@@ -256,7 +262,7 @@ int PMI2_Info_GetSize(int* size);
   side. Processes that are already connected may call this routine.
 
 @*/
-int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn);
+PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn);
 
 /*@
   PMI2_Job_Disconnect - disconnects from the job with ID jobid
@@ -268,7 +274,7 @@ int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn);
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Job_Disconnect(const char jobid[]);
+PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[]);
 
 /*@
   PMI2_KVS_Put - put a key/value pair in the keyval space for this job
@@ -287,7 +293,7 @@ int PMI2_Job_Disconnect(const char jobid[]);
   is not defined.
 
 @*/
-int PMI2_KVS_Put(const char key[], const char value[]);
+PMIX_EXPORT int PMI2_KVS_Put(const char key[], const char value[]);
 /*@
   PMI2_KVS_Fence - commit all PMI2_KVS_Put calls made before this fence
 
@@ -307,7 +313,7 @@ int PMI2_KVS_Put(const char key[], const char value[]);
   implementations.
 
 @*/
-int PMI2_KVS_Fence(void);
+PMIX_EXPORT int PMI2_KVS_Fence(void);
 
 /*@
   PMI2_KVS_Get - returns the value associated with key in the key-value
@@ -331,7 +337,7 @@ int PMI2_KVS_Fence(void);
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_KVS_Get(const char *jobid, int src_pmi_id, const char key[], char value [], int maxvalue, int *vallen);
+PMIX_EXPORT int PMI2_KVS_Get(const char *jobid, int src_pmi_id, const char key[], char value [], int maxvalue, int *vallen);
 
 /*@
   PMI2_Info_GetNodeAttr - returns the value of the attribute associated
@@ -371,7 +377,7 @@ int PMI2_KVS_Get(const char *jobid, int src_pmi_id, const char key[], char value
     file.  Returned as a string.
 
 @*/
-int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *found, int waitfor);
+PMIX_EXPORT int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *found, int waitfor);
 
 /*@
   PMI2_Info_GetNodeAttrIntArray - returns the value of the attribute associated
@@ -405,7 +411,7 @@ int PMI2_Info_GetNodeAttr(const char name[], char value[], int valuelen, int *fo
     cartesian.
 
 @*/
-int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[], int arraylen, int *outlen, int *found);
+PMIX_EXPORT int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[], int arraylen, int *outlen, int *found);
 
 /*@
   PMI2_Info_PutNodeAttr - stores the value of the named attribute
@@ -423,7 +429,7 @@ int PMI2_Info_GetNodeAttrIntArray(const char name[], int array[], int arraylen, 
   processes on the same SMP node.
 
 @*/
-int PMI2_Info_PutNodeAttr(const char name[], const char value[]);
+PMIX_EXPORT int PMI2_Info_PutNodeAttr(const char name[], const char value[]);
 
 /*@
   PMI2_Info_GetJobAttr - returns the value of the attribute associated
@@ -441,7 +447,7 @@ int PMI2_Info_PutNodeAttr(const char name[], const char value[]);
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *found);
+PMIX_EXPORT int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *found);
 
 /*@
   PMI2_Info_GetJobAttrIntArray - returns the value of the attribute associated
@@ -506,7 +512,7 @@ int PMI2_Info_GetJobAttr(const char name[], char value[], int valuelen, int *fou
     underlying data models.
 
 @*/
-int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], int arraylen, int *outlen, int *found);
+PMIX_EXPORT int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], int arraylen, int *outlen, int *found);
 
 /*@
   PMI2_Nameserv_publish - publish a name
@@ -520,7 +526,7 @@ int PMI2_Info_GetJobAttrIntArray(const char name[], int array[], int arraylen, i
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_ptr, const char port[]);
+PMIX_EXPORT int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_ptr, const char port[]);
 
 /*@
   PMI2_Nameserv_lookup - lookup a service by name
@@ -537,8 +543,8 @@ int PMI2_Nameserv_publish(const char service_name[], const PMI_keyval_t *info_pt
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr,
-                        char port[], int portLen);
+PMIX_EXPORT int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr,
+                                     char port[], int portLen);
 /*@
   PMI2_Nameserv_unpublish - unpublish a name
 
@@ -550,8 +556,8 @@ int PMI2_Nameserv_lookup(const char service_name[], const PMI_keyval_t *info_ptr
   Returns 'PMI2_SUCCESS' on success and an PMI error code on failure.
 
 @*/
-int PMI2_Nameserv_unpublish(const char service_name[],
-                           const PMI_keyval_t *info_ptr);
+PMIX_EXPORT int PMI2_Nameserv_unpublish(const char service_name[],
+                                        const PMI_keyval_t *info_ptr);
 
 
 

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -80,8 +80,8 @@ extern "C" {
  * and subsequent operations. Pass a _NULL_ value for the array pointer
  * is supported if no directives are desired.
  */
- pmix_status_t PMIx_Init(pmix_proc_t *proc,
-                         pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
+                                    pmix_info_t info[], size_t ninfo);
 
 /* Finalize the PMIx client, closing the connection to the local server.
  * An error code will be returned if, for some reason, the connection
@@ -94,14 +94,14 @@ extern "C" {
  * internal barrier operation. This attribute directs PMIx_Finalize to
  * execute a barrier as part of the finalize operation.
  */
- pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo);
 
 
 /* Returns _true_ if the PMIx client has been successfully initialized,
  * returns _false_ otherwise. Note that the function only reports the
  * internal state of the PMIx client - it does not verify an active
  * connection with the server, nor that the server is functional. */
- int PMIx_Initialized(void);
+PMIX_EXPORT int PMIx_Initialized(void);
 
 
 /* Request that the provided array of procs be aborted, returning the
@@ -121,22 +121,22 @@ extern "C" {
  * caused by multiple processes calling PMIx_Abort are left to the
  * server implementation to resolve with regard to which status is
  * returned and what messages (if any) are printed. */
- pmix_status_t PMIx_Abort(int status, const char msg[],
-                          pmix_proc_t procs[], size_t nprocs);
+PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
+                                     pmix_proc_t procs[], size_t nprocs);
 
 
 /* Push a value into the client's namespace. The client library will cache
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
- pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
  * This is an asynchronous operation - the library will immediately
  * return to the caller while the data is transmitted to the local
  * server in the background */
- pmix_status_t PMIx_Commit(void);
+PMIX_EXPORT pmix_status_t PMIx_Commit(void);
 
 
 /* Execute a blocking barrier across the processes identified in the
@@ -174,14 +174,14 @@ extern "C" {
  *     the timeout parameter can help avoid "hangs" due to programming errors
  *     that prevent one or more procs from reaching the "fence".
  */
- pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
-                          const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
+                                     const pmix_info_t info[], size_t ninfo);
 
 /* Non-blocking version of PMIx_Fence. Note that the function will return
  * an error if a _NULL_ callback function is given. */
- pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
-                             const pmix_info_t info[], size_t ninfo,
-                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs,
+                                        const pmix_info_t info[], size_t ninfo,
+                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Retrieve information for the specified _key_ as published by the process
@@ -200,17 +200,17 @@ extern "C" {
  *     an error. The timeout parameter can help avoid "hangs" due to programming
  *     errors that prevent the target proc from ever exposing its data.
  */
- pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
-                        const pmix_info_t info[], size_t ninfo,
-                        pmix_value_t **val);
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
+                                   const pmix_info_t info[], size_t ninfo,
+                                   pmix_value_t **val);
 
 /* A non-blocking operation version of PMIx_Get - the callback function will
  * be executed once the specified data has been _PMIx_Put_
  * by the identified process and retrieved by the local server. The info
  * array is used as described above for the blocking form of this call. */
- pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
-                           const pmix_info_t info[], size_t ninfo,
-                           pmix_value_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_value_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Publish the data in the info array for lookup. By default,
@@ -232,9 +232,9 @@ extern "C" {
  * return immediately, executing the callback when the server confirms
  * availability of the data.
  */
- pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo);
- pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
-                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Publish(const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Lookup information published by this or another process. By default,
@@ -273,8 +273,8 @@ extern "C" {
  * (b) PMIX_TIMEOUT - max time to wait for data to become available.
  *
  */
- pmix_status_t PMIx_Lookup(pmix_pdata_t data[], size_t ndata,
-                           const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Lookup(pmix_pdata_t data[], size_t ndata,
+                                      const pmix_info_t info[], size_t ninfo);
 
 /* Non-blocking form of the _PMIx_Lookup_ function. Data for
  * the provided NULL-terminated keys array will be returned
@@ -282,8 +282,8 @@ extern "C" {
  * behavior is to _not_ wait for data to be published. The
  * info keys can be used to modify the behavior as previously
  * described */
- pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], size_t ninfo,
-                              pmix_lookup_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys, const pmix_info_t info[], size_t ninfo,
+                                         pmix_lookup_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Unpublish data posted by this process using the given keys.
@@ -294,15 +294,15 @@ extern "C" {
  * By default, the range is assumed to be PMIX_SESSION. Changes
  * to the range, and any additional directives, can be provided
  * in the pmix_info_t array */
- pmix_status_t PMIx_Unpublish(char **keys,
-                              const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Unpublish(char **keys,
+                                         const pmix_info_t info[], size_t ninfo);
 
 /* Non-blocking form of the _PMIx_Unpublish_ function. The
  * callback function will be executed once the server confirms
  * removal of the specified data. */
- pmix_status_t PMIx_Unpublish_nb(char **keys,
-                                 const pmix_info_t info[], size_t ninfo,
-                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
+                                            const pmix_info_t info[], size_t ninfo,
+                                            pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 /* Spawn a new job. The assigned namespace of the spawned applications
@@ -335,17 +335,17 @@ extern "C" {
  * (c) PMIX_NOTIFY_COMPLETION - notify the parent process when the
  *     child job terminates, either normally or with error
  */
- pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
-                          const pmix_app_t apps[], size_t napps,
-                          char nspace[]);
+PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
+                                     const pmix_app_t apps[], size_t napps,
+                                     char nspace[]);
 
 
 /* Non-blocking form of the _PMIx_Spawn_ function. The callback
  * will be executed upon launch of the specified applications,
  * or upon failure to launch any of them. */
- pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
-                             const pmix_app_t apps[], size_t napps,
-                             pmix_spawn_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t ninfo,
+                                        const pmix_app_t apps[], size_t napps,
+                                        pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 
 /* Record the specified processes as "connected". Both blocking and non-blocking
  * versions are provided. This means that the resource manager should treat the
@@ -367,12 +367,12 @@ extern "C" {
  * user-level directives regarding the algorithm to be used for the collective
  * operation involved in the "connect", timeout constraints, and other options
  * available from the host RM */
- pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
-                            const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
+                                       const pmix_info_t info[], size_t ninfo);
 
- pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
-                               const pmix_info_t info[], size_t ninfo,
-                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Disconnect a previously connected set of processes. An error will be returned
  * if the specified set of procs was not previously "connected". As above, a process
@@ -380,12 +380,12 @@ extern "C" {
  * is not allowed to reconnect to a set of procs that has not fully completed
  * disconnect - i.e., you have to fully disconnect before you can reconnect to the
  * _same_ group of processes. The info array is used as above. */
- pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
-                               const pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
+                                          const pmix_info_t info[], size_t ninfo);
 
- pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t ranges[], size_t nprocs,
-                                  const pmix_info_t info[], size_t ninfo,
-                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t ranges[], size_t nprocs,
+                                             const pmix_info_t info[], size_t ninfo,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Given a node name, return an array of processes within the specified nspace
  * on that node. If the nspace is NULL, then all processes on the node will
@@ -394,15 +394,15 @@ extern "C" {
  * for releasing the array when done with it - the PMIX_PROC_FREE macro is
  * provided for this purpose.
  */
- pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
-                                  pmix_proc_t **procs, size_t *nprocs);
+PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
+                                             pmix_proc_t **procs, size_t *nprocs);
 
 
 /* Given an nspace, return the list of nodes hosting processes within
  * that nspace. The returned string will contain a comma-delimited list
  * of nodenames. The caller is responsible for releasing the string
  * when done with it */
- pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist);
+PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist);
 
 /* Query information about the system in general - can include
  * a list of active nspaces, network topology, etc. Also can be
@@ -420,8 +420,8 @@ extern "C" {
  * PMIX_ERR_PARTIAL_SUCCESS - some of the data has been returned
  * PMIX_ERR_NOT_SUPPORTED - the host RM does not support this function
  */
-pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
-                                 pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
+                                             pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Log data to a central data service/store, subject to the
  * services offered by the host resource manager. The data to
@@ -433,9 +433,9 @@ pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nqueries,
  * has been completed. The data array must be maintained until
  * the callback is provided
  */
-pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
-                          const pmix_info_t directives[], size_t ndirs,
-                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
+                                      const pmix_info_t directives[], size_t ndirs,
+                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Request an allocation operation from the host resource manager.
  * Several broad categories are envisioned, including the ability to:
@@ -469,9 +469,9 @@ pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
  *   lieue of preemption. A corresponding ability to "reacquire" resources
  *   previously released is included.
  */
-pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t directive,
-                                         pmix_info_t *info, size_t ninfo,
-                                         pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t directive,
+                                                     pmix_info_t *info, size_t ninfo,
+                                                     pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Request a job control action. The targets array identifies the
  * processes to which the requested job control action is to be applied.
@@ -487,9 +487,9 @@ pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t directive,
  * when the callback function completes - this will be used to release
  * any provided pmix_info_t array.
  */
-pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_t ntargets,
-                                  const pmix_info_t directives[], size_t ndirs,
-                                  pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_t ntargets,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Request that something be monitored - e.g., that the server monitor
  * this process for periodic heartbeats as an indication that the process
@@ -518,9 +518,9 @@ pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_t ntargets,
  *
  * Note: a process can send a heartbeat to the server using the PMIx_Heartbeat
  * macro provided below*/
-pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pmix_status_t error,
-                                      const pmix_info_t directives[], size_t ndirs,
-                                      pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pmix_status_t error,
+                                                  const pmix_info_t directives[], size_t ndirs,
+                                                  pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* define a special macro to simplify sending of a heartbeat */
 #define PMIx_Heartbeat()                                                    \

--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -60,6 +60,13 @@
 #include <sys/time.h> /* for struct timeval */
 #include <unistd.h> /* for uid_t and gid_t */
 #include <sys/types.h> /* for uid_t and gid_t */
+
+#ifdef PMIX_HAVE_VISIBILITY
+#define PMIX_EXPORT __attribute__((__visibility__("default")))
+#else
+#define PMIX_EXPORT
+#endif
+
 #include <pmix_rename.h>
 #include <pmix_version.h>
 
@@ -1532,19 +1539,19 @@ typedef void (*pmix_info_cbfunc_t)(pmix_status_t status,
  * using a new set of info values.
  *
  * See pmix_common.h for a description of the notification function */
-void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
-                                 pmix_info_t info[], size_t ninfo,
-                                 pmix_notification_fn_t evhdlr,
-                                 pmix_evhdlr_reg_cbfunc_t cbfunc,
-                                 void *cbdata);
+PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
+                                             pmix_info_t info[], size_t ninfo,
+                                             pmix_notification_fn_t evhdlr,
+                                             pmix_evhdlr_reg_cbfunc_t cbfunc,
+                                             void *cbdata);
 
 /* Deregister an event handler
  * evhdlr_ref is the reference returned by PMIx from the call to
  * PMIx_Register_event_handler. If non-NULL, the provided cbfunc
  * will be called to confirm removal of the designated handler */
-void PMIx_Deregister_event_handler(size_t evhdlr_ref,
-                                   pmix_op_cbfunc_t cbfunc,
-                                   void *cbdata);
+PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
+                                               pmix_op_cbfunc_t cbfunc,
+                                               void *cbdata);
 
 /* Report an event to a process for notification via any
  * registered evhdlr. The evhdlr registration can be
@@ -1576,11 +1583,11 @@ void PMIx_Deregister_event_handler(size_t evhdlr_ref,
  * time. Note that the caller is required to maintain the input
  * data until the callback function has been executed!
 */
-pmix_status_t PMIx_Notify_event(pmix_status_t status,
-                                const pmix_proc_t *source,
-                                pmix_data_range_t range,
-                                pmix_info_t info[], size_t ninfo,
-                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
+                                            const pmix_proc_t *source,
+                                            pmix_data_range_t range,
+                                            pmix_info_t info[], size_t ninfo,
+                                            pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Provide a string representation for several types of value. Note
  * that the provided string is statically defined and must NOT be
@@ -1594,24 +1601,24 @@ pmix_status_t PMIx_Notify_event(pmix_status_t status,
  * - pmix_data_type_t   (PMIX_DATA_TYPE)
  * - pmix_alloc_directive_t  (PMIX_ALLOC_DIRECTIVE)
  */
-const char* PMIx_Error_string(pmix_status_t status);
-const char* PMIx_Proc_state_string(pmix_proc_state_t state);
-const char* PMIx_Scope_string(pmix_scope_t scope);
-const char* PMIx_Persistence_string(pmix_persistence_t persist);
-const char* PMIx_Data_range_string(pmix_data_range_t range);
-const char* PMIx_Info_directives_string(pmix_info_directives_t directives);
-const char* PMIx_Data_type_string(pmix_data_type_t type);
-const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
+PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t status);
+PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
+PMIX_EXPORT const char* PMIx_Scope_string(pmix_scope_t scope);
+PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist);
+PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
+PMIX_EXPORT const char* PMIx_Info_directives_string(pmix_info_directives_t directives);
+PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
+PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */
-const char* PMIx_Get_version(void);
+PMIX_EXPORT const char* PMIx_Get_version(void);
 
 /* Store some data locally for retrieval by other areas of the
  * proc. This is data that has only internal scope - it will
  * never be "pushed" externally */
-pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                  const char *key, pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
+                                              const char *key, pmix_value_t *val);
 
 
 /**
@@ -1665,9 +1672,9 @@ pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
  * status_code = PMIx_Data_pack(buffer, &src, 1, PMIX_INT32);
  * @endcode
  */
-pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
-                             void *src, int32_t num_vals,
-                             pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
+                                         void *src, int32_t num_vals,
+                                         pmix_data_type_t type);
 
 /**
  * Unpack values from a buffer.
@@ -1761,9 +1768,9 @@ pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
  *
  * @endcode
  */
-pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
-                               int32_t *max_num_values,
-                               pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
+                                           int32_t *max_num_values,
+                                           pmix_data_type_t type);
 
 /**
  * Copy a data value from one location to another.
@@ -1788,7 +1795,8 @@ pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
  * @retval PMIX_ERROR(s) An appropriate error code.
  *
  */
-pmix_status_t PMIx_Data_copy(void **dest, void *src, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t PMIx_Data_copy(void **dest, void *src,
+                                         pmix_data_type_t type);
 
 /**
  * Print a data value.
@@ -1801,8 +1809,8 @@ pmix_status_t PMIx_Data_copy(void **dest, void *src, pmix_data_type_t type);
  *
  * @retval PMIX_ERROR(s) An appropriate error code.
  */
-pmix_status_t PMIx_Data_print(char **output, char *prefix,
-                              void *src, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t PMIx_Data_print(char **output, char *prefix,
+                                          void *src, pmix_data_type_t type);
 
 /**
  * Copy a payload from one buffer to another
@@ -1813,8 +1821,8 @@ pmix_status_t PMIx_Data_print(char **output, char *prefix,
  * source buffer's payload will remain intact, as will any pre-existing
  * payload in the destination's buffer.
  */
-pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
-                                     pmix_data_buffer_t *src);
+PMIX_EXPORT pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
+                                                 pmix_data_buffer_t *src);
 
 
 /* Key-Value pair management macros */

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -378,13 +378,13 @@ typedef struct pmix_server_module_2_0_0_t {
  * also may include the PMIX_SERVER_TOOL_SUPPORT key, thereby
  * indicating that the daemon is willing to accept connection
  * requests from tools */
-pmix_status_t PMIx_server_init(pmix_server_module_t *module,
-                               pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
+                                           pmix_info_t info[], size_t ninfo);
 
 /* Finalize the server support library. If internal comm is
  * in-use, the server will shut it down at this time. All
  * memory usage is released */
-pmix_status_t PMIx_server_finalize(void);
+PMIX_EXPORT pmix_status_t PMIx_server_finalize(void);
 
 /* given a semicolon-separated list of input values, generate
  * a regex that can be passed down to the client for parsing.
@@ -402,7 +402,7 @@ pmix_status_t PMIx_server_finalize(void);
  * parsing the provided regex. Other parsers may be supported - see
  * the pmix_client.h header for a list.
  */
-pmix_status_t PMIx_generate_regex(const char *input, char **regex);
+PMIX_EXPORT pmix_status_t PMIx_generate_regex(const char *input, char **regex);
 
 /* The input is expected to consist of a comma-separated list
  * of ranges. Thus, an input of:
@@ -415,7 +415,7 @@ pmix_status_t PMIx_generate_regex(const char *input, char **regex);
  * parsing the provided regex. Other parsers may be supported - see
  * the pmix_client.h header for a list.
  */
-pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
+PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
 
 /* Setup the data about a particular nspace so it can
  * be passed to any child process upon startup. The PMIx
@@ -442,7 +442,7 @@ pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
  * for the PMIx server library to correctly handle collectives
  * as a collective operation call can occur before all the
  * procs have been started */
-pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
+PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 
@@ -451,8 +451,8 @@ pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
  * intended to support persistent PMIx servers by providing
  * an opportunity for the host RM to tell the PMIx server
  * library to release all memory for a completed job */
-void PMIx_server_deregister_nspace(const char nspace[],
-                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[],
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Register a client process with the PMIx server library. The
  * expected user ID and group ID of the child process helps the
@@ -467,24 +467,24 @@ void PMIx_server_deregister_nspace(const char nspace[],
  * return that object when the client calls "finalize", thus
  * allowing the host server to access the object without
  * performing a lookup. */
-pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
-                                          uid_t uid, gid_t gid,
-                                          void *server_object,
-                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
+                                                      uid_t uid, gid_t gid,
+                                                      void *server_object,
+                                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Deregister a client and purge all data relating to it. The
  * deregister_nspace API will automatically delete all client
  * info for that nspace - this API is therefore intended solely
  * for use in exception cases */
-void PMIx_server_deregister_client(const pmix_proc_t *proc,
-                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT void PMIx_server_deregister_client(const pmix_proc_t *proc,
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Setup the environment of a child process to be forked
  * by the host so it can correctly interact with the PMIx
  * server. The PMIx client needs some setup information
  * so it can properly connect back to the server. This function
  * will set appropriate environmental variables for this purpose. */
-pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char ***env);
+PMIX_EXPORT pmix_status_t PMIx_server_setup_fork(const pmix_proc_t *proc, char ***env);
 
 /* Define a callback function the PMIx server will use to return
  * direct modex requests to the host server. The PMIx server
@@ -502,9 +502,9 @@ typedef void (*pmix_dmodex_response_fn_t)(pmix_status_t status,
  * request into the PMIx server. The PMIx server will return a blob
  * (once it becomes available) via the cbfunc - the host
  * server shall send the blob back to the original requestor */
-pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
-                                         pmix_dmodex_response_fn_t cbfunc,
-                                         void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
+                                                     pmix_dmodex_response_fn_t cbfunc,
+                                                     void *cbdata);
 
 /* define a callback function for the setup_application API. The returned info
  * array is owned by the PMIx server library and will be free'd when the
@@ -521,18 +521,18 @@ typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
  * is defined as a non-blocking operation in case network
  * libraries need to perform some action before responding. The
  * returned env will be distributed along with the application */
-pmix_status_t PMIx_server_setup_application(const char nspace[],
-                                            pmix_info_t info[], size_t ninfo,
-                                            pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
+                                                        pmix_info_t info[], size_t ninfo,
+                                                        pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
 
 /* Provide a function by which the local PMIx server can perform
  * any application-specific operations prior to spawning local
  * clients of a given application. For example, a network library
  * might need to setup the local driver for "instant on" addressing.
  */
-pmix_status_t PMIx_server_setup_local_support(const char nspace[],
-                                              pmix_info_t info[], size_t ninfo,
-                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const char nspace[],
+                                                          pmix_info_t info[], size_t ninfo,
+                                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_tool.h
+++ b/include/pmix_tool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -87,8 +87,8 @@ extern "C" {
  * and subsequent operations. Passing a _NULL_ value for the array pointer
  * is supported if no directives are desired.
  */
-pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
-                             pmix_info_t info[], size_t ninfo);
+PMIX_EXPORT pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
+                                         pmix_info_t info[], size_t ninfo);
 
 /* Finalize the PMIx tool library, closing the connection to the local server.
  * An error code will be returned if, for some reason, the connection
@@ -96,7 +96,7 @@ pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
  *
  * The info array is used to pass user requests regarding the finalize
  * operation. */
-pmix_status_t PMIx_tool_finalize(void);
+PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/src/class/pmix_object.h
+++ b/src/class/pmix_object.h
@@ -121,6 +121,7 @@
 #define PMIX_OBJECT_H
 
 #include <src/include/pmix_config.h>
+#include <pmix_common.h>
 
 #include <assert.h>
 #ifdef HAVE_STDLIB_H

--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -325,12 +325,6 @@
 #    define __pmix_attribute_unused__
 #endif
 
-#if PMIX_HAVE_ATTRIBUTE_VISIBILITY
-#    define __pmix_attribute_visibility__(a) __attribute__((__visibility__(a)))
-#else
-#    define __pmix_attribute_visibility__(a)
-#endif
-
 #if PMIX_HAVE_ATTRIBUTE_WARN_UNUSED_RESULT
 #    define __pmix_attribute_warn_unused_result__ __attribute__((__warn_unused_result__))
 #else
@@ -341,16 +335,6 @@
 #    define __pmix_attribute_destructor__    __attribute__((__destructor__))
 #else
 #    define __pmix_attribute_destructor__
-#endif
-
-#ifdef PMIX_C_HAVE_VISIBILITY
-# if PMIX_C_HAVE_VISIBILITY
-#  define PMIX_EXPORT __pmix_attribute_visibility__("default")
-# else
-#  define PMIX_EXPORT
-# endif
-#else
-# define PMIX_EXPORT
 #endif
 
 /*

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -179,12 +179,9 @@ static int file_exists(const char *filename, const char *ext)
 
 int pmix_mca_base_component_repository_add (const char *path)
 {
-    int rc=PMIX_SUCCESS;
-
 #if PMIX_HAVE_PDL_SUPPORT
     char *path_to_use = NULL, *dir, *ctx;
     const char sep[] = {PMIX_ENV_SEP, '\0'};
-    bool found_one = false;
 
     if (NULL == path) {
         /* nothing to do */
@@ -203,38 +200,16 @@ int pmix_mca_base_component_repository_add (const char *path)
             dir = pmix_mca_base_system_default_path;
         }
 
-        rc = pmix_pdl_foreachfile(dir, process_repository_item, NULL);
-        if (PMIX_SUCCESS == rc) {
-            found_one = true;
+        if (0 != pmix_pdl_foreachfile(dir, process_repository_item, NULL)) {
+            break;
         }
     } while (NULL != (dir = strtok_r (NULL, sep, &ctx)));
 
     free (path_to_use);
 
-    if (found_one) {
-        return PMIX_SUCCESS;
-    } else {
-        /* we were unable to find even one available directory
-         * in this search path. This typically means that the
-         * user has pointed us to an incorrect location. We
-         * cannot use show_help as the show_help file is quite
-         * likely also not going to be found, so let's print
-         * a helpful error message as we know we are going
-         * to exit out in this case */
-        fprintf(stderr, "\n-------------------------------------------------------\n");
-        fprintf(stderr, "No usable directories were found in the provided path\n");
-        fprintf(stderr, "when searching for available plugins. This usually indicates\n");
-        fprintf(stderr, "that the PMIx installation was moved, or the PMIX_INSTALL_PREFIX\n");
-        fprintf(stderr, "environmental variable or \"mca_base_component_path\"\n");
-        fprintf(stderr, "MCA parameter is set and pointing to an incorrect or \n");
-        fprintf(stderr, "non-existent location.\n\n");
-        fprintf(stderr, "Please correct the situation and try again.\n");
-        fprintf(stderr, "-------------------------------------------------------\n\n");
-        rc = PMIX_ERR_SILENT;
-    }
 #endif /* PMIX_HAVE_PDL_SUPPORT */
 
-    return rc;
+    return PMIX_SUCCESS;
 }
 
 

--- a/src/util/alfg.h
+++ b/src/util/alfg.h
@@ -14,6 +14,7 @@
 #define PMIX_ALFG_H
 
 #include <src/include/pmix_config.h>
+#include <pmix_common.h>
 
 #include "src/include/pmix_stdint.h"
 

--- a/src/util/basename.h
+++ b/src/util/basename.h
@@ -27,7 +27,7 @@
 #define PMIX_BASENAME_H
 
 #include <src/include/pmix_config.h>
-
+#include <pmix_common.h>
 
 BEGIN_C_DECLS
 

--- a/src/util/os_path.h
+++ b/src/util/os_path.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -43,7 +43,7 @@
 #define PMIX_OS_PATH_H
 
 #include <src/include/pmix_config.h>
-
+#include <pmix_common.h>
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/src/util/printf.h
+++ b/src/util/printf.h
@@ -26,7 +26,7 @@
 #define PMIX_PRINTF_H
 
 #include <src/include/pmix_config.h>
-
+#include <pmix_common.h>
 
 #include <stdarg.h>
 #include <stdlib.h>

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -91,6 +91,7 @@
 #define PMIX_SHOW_HELP_H
 
 #include <src/include/pmix_config.h>
+#include <pmix_common.h>
 
 #include <stdarg.h>
 


### PR DESCRIPTION
Resolve the visibility problem by making the configury define a flag that gets used in pmix_common.h to set the attribute. Thus, use of pmix.h in an application will result in the attribute being defined to nothing, while use in building the library lets the attribute be defined to the visibility flag if the compiler supports it.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>