### PR TITLE
Silence coverity CIDs 1416397, 1416398

### DIFF
--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2266,7 +2266,7 @@ inline pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank, const c
     pmix_status_t rc = PMIX_ERROR, lock_rc;
     ns_track_elem_t *elem;
     rank_meta_info *rinfo = NULL;
-    size_t kval_cnt;
+    size_t kval_cnt = 0;
     seg_desc_t *meta_seg, *data_seg;
     uint8_t *addr;
     pmix_buffer_t buffer;
@@ -2549,7 +2549,9 @@ done:
             if( NULL != info ) {
                 PMIX_INFO_FREE(info, ninfo);
             }
-            PMIX_VALUE_RELEASE(kval);
+            if( NULL != kval ) {
+                PMIX_VALUE_RELEASE(kval);
+            }
         }
         return rc;
     }


### PR DESCRIPTION
*** CID 1416397:  Null pointer dereferences  (FORWARD_NULL)
*** CID 1416398:  Uninitialized variables  (UNINIT)

Signed-off-by: Boris Karasev <karasev.b@gmail.com>

This one was noted as ignored:
*** CID 1375986:  Security best practices violations  (TOCTOU)