### PR TITLE
Fixed provide the unpacked status of fence

### DIFF
--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -183,7 +183,7 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
     }
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "client:unpack fence received status %d", ret);
-    return PMIX_SUCCESS;
+    return ret;
 }
 
 static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd,


### PR DESCRIPTION
The error status is not detected for clients when server
responded with error message for Fence request.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit bd52c32fc129cdf3892f164c9eb2730c662e7ef7)

Corresponds to #459