### PR TITLE
Backport conversion of PMIX_CMD to PMIX_COMMAND wherever it was used …

### DIFF
--- a/src/buffer_ops/print.c
+++ b/src/buffer_ops/print.c
@@ -1128,7 +1128,7 @@ pmix_status_t pmix_bfrop_print_cmd(char **output, char *prefix,
         prefx = prefix;
     }
 
-    if (0 > asprintf(output, "%sData type: PMIX_CMD\tValue: %s",
+    if (0 > asprintf(output, "%sData type: PMIX_COMMAND\tValue: %s",
                      prefx, pmix_command_string(*src))) {
         return PMIX_ERR_NOMEM;
     }

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -111,7 +111,7 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer,
     chain->final_cbdata = chain;
 
     cnt=1;
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
@@ -429,7 +429,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
      * transaction because some systems cannot handle very large
      * blocking operations and error out if we try them. */
      req = PMIX_NEW(pmix_buffer_t);
-     if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(req, &cmd, 1, PMIX_CMD))) {
+     if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(req, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(req);
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -577,7 +577,7 @@ PMIX_EXPORT pmix_status_t PMIx_Finalize(const pmix_info_t info[], size_t ninfo)
          * server that we are normally terminating */
         msg = PMIX_NEW(pmix_buffer_t);
         /* pack the cmd */
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             return rc;
@@ -672,7 +672,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int flag, const char msg[],
     /* create a buffer to hold the message */
     bfr = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(bfr, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(bfr, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(bfr);
         return rc;
@@ -857,7 +857,7 @@ static void _commitfn(int sd, short args, void *cbdata)
 
     msgout = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msgout, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msgout);
         goto done;

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -142,7 +142,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -260,7 +260,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t n
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -203,7 +203,7 @@ static pmix_status_t pack_fence(pmix_buffer_t *msg, pmix_cmd_t cmd,
     pmix_status_t rc;
 
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -214,7 +214,7 @@ static pmix_buffer_t* _pack_get(char *nspace, pmix_rank_t rank,
     /* nope - see if we can get it */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the get cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return NULL;

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -141,7 +141,7 @@ PMIX_EXPORT pmix_status_t PMIx_Publish_nb(const pmix_info_t info[], size_t ninfo
     /* create the publish cmd */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -278,7 +278,7 @@ PMIX_EXPORT pmix_status_t PMIx_Lookup_nb(char **keys,
     /* create the lookup cmd */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -408,7 +408,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
     /* create the unpublish cmd */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -139,7 +139,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -138,7 +138,7 @@ PMIX_EXPORT pmix_status_t PMIx_Job_control_nb(const pmix_proc_t targets[], size_
     /* if we are a client, then relay this request to the server */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;
@@ -234,7 +234,7 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
     /* if we are a client, then relay this request to the server */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;

--- a/src/common/pmix_log.c
+++ b/src/common/pmix_log.c
@@ -102,7 +102,7 @@ PMIX_EXPORT pmix_status_t PMIx_Log_nb(const pmix_info_t data[], size_t ndata,
         cd->cbfunc.opcbfn = cbfunc;
         cd->cbdata = cbdata;
         msg = PMIX_NEW(pmix_buffer_t);
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_RELEASE(cd);

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -142,7 +142,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         cd->cbfunc = cbfunc;
         cd->cbdata = cbdata;
         msg = PMIX_NEW(pmix_buffer_t);
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
             PMIX_ERROR_LOG(rc);
             PMIX_RELEASE(msg);
             PMIX_RELEASE(cd);
@@ -210,7 +210,7 @@ PMIX_EXPORT pmix_status_t PMIx_Allocation_request_nb(pmix_alloc_directive_t dire
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -124,7 +124,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
         msg = PMIX_NEW(pmix_buffer_t);
 
         /* pack the command */
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
@@ -973,7 +973,7 @@ pmix_status_t pmix_server_notify_client_of_event(pmix_status_t status,
     }
 
     /* pack the command */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(cd->buf, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(cd);
         return rc;

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -176,7 +176,7 @@ static pmix_status_t _send_to_server(pmix_rshift_caddy_t *rcd)
 
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }
@@ -815,7 +815,7 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
      * to remove my registration */
     if (!PMIX_PROC_IS_SERVER) {
         msg = PMIX_NEW(pmix_buffer_t);
-        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
             PMIX_RELEASE(msg);
             goto cleanup;
         }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -52,28 +52,27 @@ BEGIN_C_DECLS
 /****   ENUM DEFINITIONS    ****/
 
 /* define some commands */
-typedef enum {
-    PMIX_REQ_CMD,
-    PMIX_ABORT_CMD,
-    PMIX_COMMIT_CMD,
-    PMIX_FENCENB_CMD,
-    PMIX_GETNB_CMD,
-    PMIX_FINALIZE_CMD,
-    PMIX_PUBLISHNB_CMD,
-    PMIX_LOOKUPNB_CMD,
-    PMIX_UNPUBLISHNB_CMD,
-    PMIX_SPAWNNB_CMD,
-    PMIX_CONNECTNB_CMD,
-    PMIX_DISCONNECTNB_CMD,
-    PMIX_NOTIFY_CMD,
-    PMIX_REGEVENTS_CMD,
-    PMIX_DEREGEVENTS_CMD,
-    PMIX_QUERY_CMD,
-    PMIX_LOG_CMD,
-    PMIX_ALLOC_CMD,
-    PMIX_JOB_CONTROL_CMD,
-    PMIX_MONITOR_CMD
-} pmix_cmd_t;
+typedef uint8_t pmix_cmd_t;
+#define PMIX_REQ_CMD             0
+#define PMIX_ABORT_CMD           1
+#define PMIX_COMMIT_CMD          2
+#define PMIX_FENCENB_CMD         3
+#define PMIX_GETNB_CMD           4
+#define PMIX_FINALIZE_CMD        5
+#define PMIX_PUBLISHNB_CMD       6
+#define PMIX_LOOKUPNB_CMD        7
+#define PMIX_UNPUBLISHNB_CMD     8
+#define PMIX_SPAWNNB_CMD         9
+#define PMIX_CONNECTNB_CMD      10
+#define PMIX_DISCONNECTNB_CMD   11
+#define PMIX_NOTIFY_CMD         12
+#define PMIX_REGEVENTS_CMD      13
+#define PMIX_DEREGEVENTS_CMD    14
+#define PMIX_QUERY_CMD          15
+#define PMIX_LOG_CMD            16
+#define PMIX_ALLOC_CMD          17
+#define PMIX_JOB_CONTROL_CMD    18
+#define PMIX_MONITOR_CMD        19
 
 /* provide a "pretty-print" function for cmds */
 const char* pmix_command_string(pmix_cmd_t cmd);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -50,9 +50,6 @@ BEGIN_C_DECLS
 
 
 /****   ENUM DEFINITIONS    ****/
-/* define a command type for communicating to the
- * pmix server */
-#define PMIX_CMD PMIX_UINT32
 
 /* define some commands */
 typedef enum {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2310,7 +2310,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
 
     /* retrieve the cmd */
     cnt = 1;
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         return rc;
     }

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -101,7 +101,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
     chain->final_cbdata = chain;
 
     cnt=1;
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.unpack(buf, &cmd, &cnt, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
@@ -549,7 +549,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
      * server that we are normally terminating */
     msg = PMIX_NEW(pmix_buffer_t);
     /* pack the cmd */
-    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_CMD))) {
+    if (PMIX_SUCCESS != (rc = pmix_bfrop.pack(msg, &cmd, 1, PMIX_COMMAND))) {
         PMIX_ERROR_LOG(rc);
         PMIX_RELEASE(msg);
         return rc;


### PR DESCRIPTION
…to support backward compatibility

Signed-off-by: Ralph Castain <rhc@open-mpi.org>