### PR TITLE
There are times when the host RM may choose not to provide job-level …

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -234,6 +234,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_HWLOC_SHMEM_ADDR               "pmix.hwlocaddr"        // (size_t) address of HWLOC shared memory segment
 #define PMIX_HWLOC_SHMEM_SIZE               "pmix.hwlocsize"        // (size_t) size of HWLOC shared memory segment
 #define PMIX_HWLOC_SHMEM_FILE               "pmix.hwlocfile"        // (char*) path to HWLOC shared memory file
+#define PMIX_HWLOC_XML_V1                   "pmix.hwlocxml1"        // (char*) XML representation of local topology using HWLOC v1.x format
+#define PMIX_HWLOC_XML_V2                   "pmix.hwlocxml2"        // (char*) XML representation of local topology using HWLOC v2.x format
 
 /* request-related info */
 #define PMIX_COLLECT_DATA                   "pmix.collect"          // (bool) collect data and return it at the end of the operation

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -568,7 +568,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* lood for a debugger attach key */
     (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
-    PMIX_INFO_LOAD(&ginfo, PMIX_IMMEDIATE, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&ginfo, PMIX_OPTIONAL, NULL, PMIX_BOOL);
     if (PMIX_SUCCESS == PMIx_Get(&wildcard, PMIX_DEBUG_STOP_IN_INIT, &ginfo, 1, &val)) {
         PMIX_VALUE_FREE(val, 1); // cleanup memory
         /* if the value was found, then we need to wait for debugger attach here */

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -398,6 +398,45 @@ static pmix_status_t process_values(pmix_value_t **v, pmix_cb_t *cb)
     return PMIX_SUCCESS;
 }
 
+static void infocb(pmix_status_t status,
+                   pmix_info_t *info, size_t ninfo,
+                   void *cbdata,
+                   pmix_release_cbfunc_t release_fn,
+                   void *release_cbdata)
+{
+    pmix_query_caddy_t *cd = (pmix_query_caddy_t*)cbdata;
+    pmix_value_t *kv = NULL;
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS == status) {
+        if (NULL != info) {
+            /* there should be only one returned value */
+            if (1 != ninfo) {
+                rc = PMIX_ERR_INVALID_VAL;
+            } else {
+                PMIX_VALUE_CREATE(kv, 1);
+                if (NULL == kv) {
+                    rc = PMIX_ERR_NOMEM;
+                } else {
+                    rc = pmix_value_xfer(kv, &info[0].value);
+                }
+            }
+        } else {
+            rc = PMIX_ERR_NOT_FOUND;
+        }
+    } else {
+        rc = status;
+    }
+    if (NULL != cd->valcbfunc) {
+        cd->valcbfunc(rc, kv, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+    PMIX_VALUE_FREE(kv, 1);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+}
+
 static void _getnbfn(int fd, short flags, void *cbdata)
 {
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
@@ -409,7 +448,9 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     char *tmp;
     pmix_proc_t proc;
     bool optional = false;
+    bool immediate = false;
     struct timeval tv;
+    pmix_query_caddy_t *cd;
 
     /* cb was passed to us from another thread - acquire it */
     PMIX_ACQUIRE_OBJECT(cb);
@@ -430,6 +471,11 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                 if (PMIX_UNDEF == cb->info[n].value.type ||
                     cb->info[n].value.data.flag) {
                     optional = true;
+                }
+            } else if (0 == strncmp(cb->info[n].key, PMIX_IMMEDIATE, PMIX_MAX_KEYLEN)) {
+                if (PMIX_UNDEF == cb->info[n].value.type ||
+                    cb->info[n].value.data.flag) {
+                    immediate = true;
                 }
             } else if (0 == strncmp(cb->info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
                 /* set a timer to kick us out if we don't
@@ -473,6 +519,25 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                  */
                 goto request;
             } else {
+                /* if immediate was given, then we are being directed to
+                 * check with the server even though the caller is looking for
+                 * job-level info. In some cases, a server may elect not
+                 * to provide info at init to save memory */
+                if (immediate) {
+                    /* the direct modex request doesn't pass a key as it
+                     * was intended to support non-job-level information.
+                     * So instead, we will use the PMIx_Query function
+                     * to request the information */
+                    cd = PMIX_NEW(pmix_query_caddy_t);
+                    cd->cbdata = cb->cbdata;
+                    cd->valcbfunc = cb->cbfunc.valuefn;
+                    PMIX_QUERY_CREATE(cd->queries, 1);
+                    cd->nqueries = 1;
+                    pmix_argv_append_nosize(&cd->queries[0].keys, cb->key);
+                    PMIx_Query_info_nb(cd->queries, 1, infocb, cd);
+                    PMIX_RELEASE(cb);
+                    return;
+                }
                 /* we should have had this info, so respond with the error */
                 goto respond;
             }
@@ -494,25 +559,25 @@ static void _getnbfn(int fd, short flags, void *cbdata)
   respond:
     /* if a callback was provided, execute it */
     if (NULL != cb->cbfunc.valuefn) {
-      if (NULL != val)  {
-          /* if this is a compressed string, then uncompress it */
-          if (PMIX_COMPRESSED_STRING == val->type) {
-              pmix_util_uncompress_string(&tmp, (uint8_t*)val->data.bo.bytes, val->data.bo.size);
-              if (NULL == tmp) {
-                  PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-                  rc = PMIX_ERR_NOMEM;
-                  PMIX_VALUE_RELEASE(val);
-                  val = NULL;
-              } else {
-                  PMIX_VALUE_DESTRUCT(val);
-                  PMIX_VAL_ASSIGN(val, string, tmp);
-              }
-          }
-      }
-      cb->cbfunc.valuefn(rc, val, cb->cbdata);
+        if (NULL != val)  {
+            /* if this is a compressed string, then uncompress it */
+            if (PMIX_COMPRESSED_STRING == val->type) {
+                pmix_util_uncompress_string(&tmp, (uint8_t*)val->data.bo.bytes, val->data.bo.size);
+                if (NULL == tmp) {
+                    PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                    rc = PMIX_ERR_NOMEM;
+                    PMIX_VALUE_RELEASE(val);
+                    val = NULL;
+                } else {
+                    PMIX_VALUE_DESTRUCT(val);
+                    PMIX_VAL_ASSIGN(val, string, tmp);
+                }
+            }
+        }
+        cb->cbfunc.valuefn(rc, val, cb->cbdata);
     }
     if (NULL != val) {
-      PMIX_VALUE_RELEASE(val);
+        PMIX_VALUE_RELEASE(val);
     }
     PMIX_RELEASE(cb);
     return;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -245,6 +245,7 @@ static void qcon(pmix_query_caddy_t *p)
     p->info = NULL;
     p->ninfo = 0;
     p->cbfunc = NULL;
+    p->valcbfunc = NULL;
     p->cbdata = NULL;
     p->relcbfunc = NULL;
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -219,6 +219,7 @@ typedef struct {
     pmix_info_t *info;
     size_t ninfo;
     pmix_info_cbfunc_t cbfunc;
+    pmix_value_cbfunc_t valcbfunc;
     pmix_release_cbfunc_t relcbfunc;
     void *cbdata;
 } pmix_query_caddy_t;

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -863,6 +863,7 @@ static pmix_status_t query_fn(pmix_proc_t *proct,
     /* keep this simple */
     PMIX_INFO_CREATE(info, nqueries);
     for (n=0; n < nqueries; n++) {
+        pmix_output(0, "\tKey: %s", queries[n].keys[0]);
         (void)strncpy(info[n].key, queries[n].keys[0], PMIX_MAX_KEYLEN);
         info[n].value.type = PMIX_STRING;
         if (0 > asprintf(&info[n].value.data.string, "%d", (int)n)) {


### PR DESCRIPTION
…info at startup - e.g., to reduce memory footprint by using some other mechanism. An example is the shared memory used by HWLOC that resides outside of PMIx. However, if such a method isn't available or doesn't succeed, the client may still need the information. So provide a mechanism by which the client can, in certain circumstances, request a piece of job-level info from the server

Signed-off-by: Ralph Castain <rhc@open-mpi.org>