### PR TITLE
Allow tools to initialize without requiring they connect to a server.

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -124,12 +124,15 @@ typedef uint32_t pmix_rank_t;
                                                                     //        client rendezvous points and contact info
 #define PMIX_SYSTEM_TMPDIR                  "pmix.sys.tmpdir"       // (char*) temp directory for this system, where PMIx
                                                                     //        server will place tool rendezvous points and contact info
+#define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_SERVER_ENABLE_MONITORING       "pmix.srv.monitor"      // (bool) Enable PMIx internal monitoring by server
 #define PMIX_SERVER_NSPACE                  "pmix.srv.nspace"       // (char*) Name of the nspace to use for this server
 #define PMIX_SERVER_RANK                    "pmix.srv.rank"         // (pmix_rank_t) Rank of this server
 
 
 /* tool-related attributes */
+#define PMIX_TOOL_NSPACE                    "pmix.tool.nspace"      // (char*) Name of the nspace to use for this tool
+#define PMIX_TOOL_RANK                      "pmix.tool.rank"        // (uint32_t) Rank of this tool
 #define PMIX_SERVER_PIDINFO                 "pmix.srvr.pidinfo"     // (pid_t) pid of the target server for a tool
 #define PMIX_CONNECT_TO_SYSTEM              "pmix.cnct.sys"         // (bool) The requestor requires that a connection be made only to
                                                                     //        a local system-level PMIx server
@@ -138,7 +141,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SERVER_HOSTNAME                "pmix.srvr.host"        // (char*) node where target server is located
 #define PMIX_CONNECT_MAX_RETRIES            "pmix.tool.mretries"    // (uint32_t) maximum number of times to try to connect to server
 #define PMIX_CONNECT_RETRY_DELAY            "pmix.tool.retry"       // (uint32_t) time in seconds between connection attempts
-
+#define PMIX_TOOL_DO_NOT_CONNECT            "pmix.tool.nocon"       // (bool) the tool wants to use internal PMIx support, but does
+                                                                    //        not want to connect to a PMIx server
 
 /* identification attributes */
 #define PMIX_USERID                         "pmix.euid"             // (uint32_t) effective user id

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -298,7 +298,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
     /* if we are a client, and we haven't already registered a handler of this
      * type with our server, or if we have directives, then we need to notify
      * the server */
-    if (!PMIX_PROC_IS_SERVER &&
+    if (!PMIX_PROC_IS_SERVER && pmix_globals.connected &&
        (need_register || 0 < pmix_list_get_size(xfer))) {
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix: _add_hdlr sending to server");
@@ -821,9 +821,9 @@ static void dereg_event_hdlr(int sd, short args, void *cbdata)
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
 
-    /* if I am not the server, then I need to notify the server
-     * to remove my registration */
-    if (!PMIX_PROC_IS_SERVER) {
+    /* if I am not the server, and I am connected, then I need
+     * to notify the server to remove my registration */
+    if (!PMIX_PROC_IS_SERVER && pmix_globals.connected) {
         msg = PMIX_NEW(pmix_buffer_t);
         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
                          msg, &cmd, 1, PMIX_COMMAND);

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2071,9 +2071,7 @@ static pmix_status_t dstore_init(pmix_info_t info[], size_t ninfo)
     /* for clients */
     else {
         if (NULL == (dstor_tmpdir = getenv(PMIX_DSTORE_ESH_BASE_PATH))){
-            rc = PMIX_ERR_BAD_PARAM;
-            PMIX_ERROR_LOG(rc);
-            goto err_exit;
+            return PMIX_ERR_NOT_AVAILABLE; // simply disqualify ourselves
         }
         if (NULL == (_base_path = strdup(dstor_tmpdir))) {
             rc = PMIX_ERR_OUT_OF_RESOURCE;

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -188,10 +188,18 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strcmp(info[n].key, PMIX_CONNECT_TO_SYSTEM)) {
-                system_level_only = true;
+                if (PMIX_UNDEF == info[n].value.type) {
+                    system_level_only = true;
+                } else {
+                    system_level_only = info[n].value.data.flag;
+                }
             } else if (0 == strcmp(info[n].key, PMIX_CONNECT_SYSTEM_FIRST)) {
                 /* try the system-level */
-                system_level = true;
+                if (PMIX_UNDEF == info[n].value.type) {
+                    system_level = true;
+                } else {
+                    system_level = info[n].value.data.flag;
+                }
             } else if (0 == strcmp(info[n].key, PMIX_SERVER_PIDINFO)) {
                 mca_ptl_tcp_component.tool_pid = info[n].value.data.pid;
             } else if (0 == strcmp(info[n].key, PMIX_SERVER_URI)) {


### PR DESCRIPTION
This allows tools to use the internal PMIx storage for distributing data within themselves when they have alternative methods for connecting to a server, or simply want to operate in standalone mode.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>