### PR TITLE
Take another step forward - deal with the difference in credential or…

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_frame.c
+++ b/src/mca/bfrops/base/bfrop_base_frame.c
@@ -48,6 +48,7 @@
 
 /* Instantiate the global vars */
 pmix_bfrops_globals_t pmix_bfrops_globals = {{{0}}};
+int pmix_bfrops_base_output = 0;
 
 static int pmix_bfrop_register(pmix_mca_base_register_flag_t flags)
 {
@@ -96,12 +97,16 @@ static pmix_status_t pmix_bfrop_close(void)
 
 static pmix_status_t pmix_bfrop_open(pmix_mca_base_open_flag_t flags)
 {
+    pmix_status_t rc;
+
     /* initialize globals */
     pmix_bfrops_globals.initialized = true;
     PMIX_CONSTRUCT(&pmix_bfrops_globals.actives, pmix_list_t);
 
     /* Open up all available components */
-    return pmix_mca_base_framework_components_open(&pmix_bfrops_base_framework, flags);
+    rc = pmix_mca_base_framework_components_open(&pmix_bfrops_base_framework, flags);
+    pmix_bfrops_base_output = pmix_bfrops_base_framework.framework_output;
+    return rc;
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, bfrops, "PMIx Buffer Operations",

--- a/src/mca/bfrops/bfrops.h
+++ b/src/mca/bfrops/bfrops.h
@@ -393,29 +393,40 @@ PMIX_EXPORT char* pmix_bfrops_base_get_available_modules(void);
 /* Select a bfrops module for a given version */
 PMIX_EXPORT pmix_bfrops_module_t* pmix_bfrops_base_assign_module(const char *version);
 
+/* provide a backdoor to access the framework debug output */
+PMIX_EXPORT extern int pmix_bfrops_base_output;
+
 /* MACROS FOR EXECUTING BFROPS FUNCTIONS */
 #define PMIX_BFROPS_ASSIGN_TYPE(p, b)               \
     (b)->type = (p)->nptr->compat.type
 
-#define PMIX_BFROPS_PACK(r, p, b, s, n, t)                                          \
-    do {                                                                            \
-        if (PMIX_BFROP_BUFFER_UNDEF == (b)->type) {                                 \
-            (b)->type = (p)->nptr->compat.type;                                     \
-            (r) = (p)->nptr->compat.bfrops->pack(b, s, n, t);                       \
-        } else if ((b)->type == (p)->nptr->compat.type) {                           \
-            (r) = (p)->nptr->compat.bfrops->pack(b, s, n, t);                       \
-        } else {                                                                    \
-            (r) = PMIX_ERR_PACK_MISMATCH;                                           \
-        }                                                                           \
+#define PMIX_BFROPS_PACK(r, p, b, s, n, t)                          \
+    do {                                                            \
+        pmix_output_verbose(2, pmix_bfrops_base_output,             \
+                            "[%s:%d] PACK version %s",              \
+                            __FILE__, __LINE__,                     \
+                            (p)->nptr->compat.bfrops->version);     \
+        if (PMIX_BFROP_BUFFER_UNDEF == (b)->type) {                 \
+            (b)->type = (p)->nptr->compat.type;                     \
+            (r) = (p)->nptr->compat.bfrops->pack(b, s, n, t);       \
+        } else if ((b)->type == (p)->nptr->compat.type) {           \
+            (r) = (p)->nptr->compat.bfrops->pack(b, s, n, t);       \
+        } else {                                                    \
+            (r) = PMIX_ERR_PACK_MISMATCH;                           \
+        }                                                           \
     } while(0)
 
-#define PMIX_BFROPS_UNPACK(r, p, b, d, m, t)                                        \
-    do {                                                                            \
-        if ((b)->type == (p)->nptr->compat.type) {                                  \
-            (r) = (p)->nptr->compat.bfrops->unpack(b, d, m, t);                     \
-        } else {                                                                    \
-            (r) = PMIX_ERR_UNPACK_FAILURE;                                          \
-        }                                                                           \
+#define PMIX_BFROPS_UNPACK(r, p, b, d, m, t)                        \
+    do {                                                            \
+        pmix_output_verbose(2, pmix_bfrops_base_output,             \
+                            "[%s:%d] UNPACK version %s",            \
+                            __FILE__, __LINE__,                     \
+                            (p)->nptr->compat.bfrops->version);     \
+        if ((b)->type == (p)->nptr->compat.type) {                  \
+            (r) = (p)->nptr->compat.bfrops->unpack(b, d, m, t);     \
+        } else {                                                    \
+            (r) = PMIX_ERR_UNPACK_FAILURE;                          \
+        }                                                           \
     } while(0)
 
 #define PMIX_BFROPS_COPY(r, p, d, s, t)             \

--- a/src/mca/bfrops/pmix1/unpack.c
+++ b/src/mca/bfrops/pmix1/unpack.c
@@ -886,6 +886,13 @@ pmix_status_t pmix1_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         if (PMIX_SUCCESS != (ret = pmix1_bfrop_unpack_int(buffer, &ptr[i].rank, &m, PMIX_INT))) {
             return ret;
         }
+        /* we have to do some conversion here as the definition of rank
+         * changed from INT32 to UINT32 */
+        if (INT32_MAX == ptr[i].rank) {
+            ptr[i].rank = PMIX_RANK_UNDEF;
+        } else if (INT32_MAX-1 == ptr[i].rank) {
+            ptr[i].rank = PMIX_RANK_WILDCARD;
+        }
     }
     return PMIX_SUCCESS;
 }

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -660,18 +660,6 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, sec, strlen(sec));
     csize += strlen(sec)+1;
 
-    /* provide our active bfrops module */
-    memcpy(msg+csize, bfrops, strlen(bfrops));
-    csize += strlen(bfrops)+1;
-
-    /* provide the bfrops type */
-    memcpy(msg+csize, &bftype, sizeof(bftype));
-    csize += sizeof(bftype);
-
-    /* provide the gds module */
-    memcpy(msg+csize, gds, strlen(gds));
-    csize += strlen(gds)+1;
-
     /* load the length of the credential - we put this in uint32_t
      * format as that is a fixed size, and convert to network
      * byte order for heterogeneity */
@@ -713,6 +701,18 @@ static pmix_status_t send_connect_ack(int sd)
     /* provide our version */
     memcpy(msg+csize, PMIX_VERSION, strlen(PMIX_VERSION));
     csize += strlen(PMIX_VERSION)+1;
+
+    /* provide our active bfrops module */
+    memcpy(msg+csize, bfrops, strlen(bfrops));
+    csize += strlen(bfrops)+1;
+
+    /* provide the bfrops type */
+    memcpy(msg+csize, &bftype, sizeof(bftype));
+    csize += sizeof(bftype);
+
+    /* provide the gds module */
+    memcpy(msg+csize, gds, strlen(gds));
+    csize += strlen(gds)+1;
 
     /* send the entire message across */
     if (PMIX_SUCCESS != pmix_ptl_base_send_blocking(sd, msg, sdsize)) {

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -513,6 +513,9 @@ static void connection_handler(int sd, short args, void *cbdata)
         rc = PMIX_ERR_NOMEM;
         goto error;
     }
+    /* mark it as being a v1 type */
+    psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V1;
+    /* add the nspace tracker */
     PMIX_RETAIN(nptr);
     psave->nptr = nptr;
     PMIX_RETAIN(info);

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -174,7 +174,8 @@ int pmix_rte_init(pmix_proc_type_t type,
         ret = PMIX_ERR_NOMEM;
         goto return_error;
     }
-    pmix_globals.mypeer->proc_type = type;
+    /* whatever our declared proc type, we are definitely v2 */
+    pmix_globals.mypeer->proc_type = type | PMIX_PROC_V2;
     /* create an nspace object for ourselves - we will
      * fill in the nspace name later */
     pmix_globals.mypeer->nptr = PMIX_NEW(pmix_nspace_t);


### PR DESCRIPTION
…dering between v2.0 and v2.1 when connecting. Don't respond to PMIx_Commit from v1 clients as they are not expecting a response. Check and deal with the change in rank type from INT to UINT32.

Now working except for PMIx_Get of modex data from other procs

Signed-off-by: Ralph Castain <rhc@open-mpi.org>