### PR TITLE
Support v2.0 clients

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -1042,7 +1042,6 @@ pmix_status_t pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t
      if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, sizeof(tmp)))) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
-
     tmp = pmix_htons(type);
     memcpy(dst, &tmp, sizeof(tmp));
     buffer->pack_ptr += sizeof(tmp);

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -70,7 +70,8 @@ pmix_status_t pmix_bfrops_base_pack_buffer(pmix_pointer_array_t *regtypes,
     pmix_status_t rc;
     pmix_bfrop_type_info_t *info;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_buffer( %p, %p, %lu, %d )\n",
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_buffer( %p, %p, %lu, %d )\n",
                         (void*)buffer, src, (long unsigned int)num_vals, (int)type);
 
     /* Pack the declared data type */
@@ -130,7 +131,8 @@ static pmix_status_t pack_gentype(pmix_buffer_t *buffer, const void *src,
     int32_t i;
     bool *s = (bool*)src;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_bool * %d\n", num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_bool * %d\n", num_vals);
 
     /* check to see if buffer needs extending */
     if (NULL == (dst = (uint8_t*)pmix_bfrop_buffer_extend(buffer, num_vals))) {
@@ -215,7 +217,8 @@ pmix_status_t pmix_bfrops_base_pack_byte(pmix_buffer_t *buffer, const void *src,
 {
     char *dst;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_byte * %d\n", num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_byte * %d\n", num_vals);
 
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals))) {
@@ -242,7 +245,8 @@ pmix_status_t pmix_bfrops_base_pack_int16(pmix_buffer_t *buffer, const void *src
     uint16_t tmp, *srctmp = (uint16_t*) src;
     char *dst;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_int16 * %d\n", num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int16 * %d\n", num_vals);
 
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals*sizeof(tmp)))) {
@@ -270,7 +274,8 @@ pmix_status_t pmix_bfrops_base_pack_int32(pmix_buffer_t *buffer, const void *src
     uint32_t tmp, *srctmp = (uint32_t*) src;
     char *dst;
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_int32 * %d\n", num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int32 * %d\n", num_vals);
 
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals*sizeof(tmp)))) {
@@ -298,7 +303,8 @@ pmix_status_t pmix_bfrops_base_pack_int64(pmix_buffer_t *buffer, const void *src
     char *dst;
     size_t bytes_packed = num_vals * sizeof(tmp);
 
-    pmix_output_verbose(20, pmix_globals.debug_output, "pmix_bfrops_base_pack_int64 * %d\n", num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix_bfrops_base_pack_int64 * %d\n", num_vals);
 
     /* check to see if buffer needs extending */
     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -400,7 +400,7 @@ static const char* data_type_string(pmix_data_type_t type)
 
 int pmix12_v2_to_v1_datatype(pmix_data_type_t v2type)
 {
-    int v1type;
+    int v1type = PMIX_UNDEF;
 
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
         /* if I am a server, then I'm passing the data type to

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -162,29 +162,29 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
                    (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
 
+    /* some v1 types are simply declared differently */
+    switch (type) {
+        case PMIX_COMMAND:
+            v1type = PMIX_UINT32;
+            break;
+        case PMIX_SCOPE:
+        case PMIX_DATA_RANGE:
+            v1type = PMIX_UINT;
+            break;
+        case PMIX_PROC_RANK:
+        case PMIX_PERSIST:
+            v1type = PMIX_INT;
+            break;
+        default:
+            v1type = type;
+    }
+
     /** Unpack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
         if (PMIX_SUCCESS != (rc = pmix12_bfrop_get_data_type(buffer, &local_type))) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
-        /* some v1 types are simply declared differently */
-        switch (type) {
-            case PMIX_COMMAND:
-                v1type = PMIX_UINT32;
-                break;
-            case PMIX_SCOPE:
-            case PMIX_DATA_RANGE:
-                v1type = PMIX_UINT;
-                break;
-            case PMIX_PROC_RANK:
-            case PMIX_PERSIST:
-                v1type = PMIX_INT;
-                break;
-            default:
-                v1type = type;
-        }
-
         /* if the data types don't match, then return an error */
         if (v1type != local_type) {
             pmix_output(0, "PMIX bfrop:unpack: got type %d when expecting type %d", local_type, v1type);

--- a/src/mca/bfrops/v20/Makefile.am
+++ b/src/mca/bfrops/v20/Makefile.am
@@ -19,10 +19,17 @@
 # $HEADER$
 #
 
-headers = bfrop_pmix20.h
+headers = \
+		bfrop_pmix20.h \
+		internal.h
+
 sources = \
         bfrop_pmix20_component.c \
-        bfrop_pmix20.c
+        bfrop_pmix20.c \
+        copy.c \
+        pack.c \
+        print.c \
+        unpack.c
 
 # Make the output library in this directory, and name it either
 # mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -24,20 +24,13 @@
 
 #include <src/include/pmix_config.h>
 
+#include "src/util/error.h"
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_pmix20.h"
+#include "internal.h"
 
 static pmix_status_t init(void);
 static void finalize(void);
-static pmix_status_t pmix20_pack(pmix_buffer_t *buffer,
-                                const void *src, int num_vals,
-                                pmix_data_type_t type);
-static pmix_status_t pmix20_unpack(pmix_buffer_t *buffer, void *dest,
-                                  int32_t *num_vals, pmix_data_type_t type);
-static pmix_status_t pmix20_copy(void **dest, void *src,
-                                pmix_data_type_t type);
-static pmix_status_t pmix20_print(char **output, char *prefix,
-                                 void *src, pmix_data_type_t type);
 static pmix_status_t register_type(const char *name,
                                    pmix_data_type_t type,
                                    pmix_bfrop_pack_fn_t pack,
@@ -50,15 +43,15 @@ pmix_bfrops_module_t pmix_bfrops_pmix20_module = {
     .version = "v20",
     .init = init,
     .finalize = finalize,
-    .pack = pmix20_pack,
-    .unpack = pmix20_unpack,
-    .copy = pmix20_copy,
-    .print = pmix20_print,
-    .copy_payload = pmix_bfrops_base_copy_payload,
-    .value_xfer = pmix_bfrops_base_value_xfer,
-    .value_load = pmix_bfrops_base_value_load,
-    .value_unload = pmix_bfrops_base_value_unload,
-    .value_cmp = pmix_bfrops_base_value_cmp,
+    .pack = pmix20_bfrop_pack,
+    .unpack = pmix20_bfrop_unpack,
+    .copy = pmix20_bfrop_copy,
+    .print = pmix20_bfrop_print,
+    .copy_payload = pmix20_bfrop_copy_payload,
+    .value_xfer = pmix20_bfrop_value_xfer,
+    .value_load = pmix20_bfrop_value_load,
+    .value_unload = pmix20_bfrop_value_unload,
+    .value_cmp = pmix20_bfrop_value_cmp,
     .register_type = register_type,
     .data_type_string = data_type_string
 };
@@ -67,317 +60,317 @@ static pmix_status_t init(void)
 {
     /* some standard types don't require anything special */
     PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL,
-                       pmix_bfrops_base_pack_bool,
-                       pmix_bfrops_base_unpack_bool,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_bool,
+                       pmix20_bfrop_pack_bool,
+                       pmix20_bfrop_unpack_bool,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_bool,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE,
-                       pmix_bfrops_base_pack_byte,
-                       pmix_bfrops_base_unpack_byte,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_byte,
+                       pmix20_bfrop_pack_byte,
+                       pmix20_bfrop_unpack_byte,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_byte,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING,
-                       pmix_bfrops_base_pack_string,
-                       pmix_bfrops_base_unpack_string,
-                       pmix_bfrops_base_copy_string,
-                       pmix_bfrops_base_print_string,
+                       pmix20_bfrop_pack_string,
+                       pmix20_bfrop_unpack_string,
+                       pmix20_bfrop_copy_string,
+                       pmix20_bfrop_print_string,
                        &mca_bfrops_v20_component.types);
 
     /* Register the rest of the standard generic types to point to internal functions */
     PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE,
-                       pmix_bfrops_base_pack_sizet,
-                       pmix_bfrops_base_unpack_sizet,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_size,
+                       pmix20_bfrop_pack_sizet,
+                       pmix20_bfrop_unpack_sizet,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_size,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID,
-                       pmix_bfrops_base_pack_pid,
-                       pmix_bfrops_base_unpack_pid,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pid,
+                       pmix20_bfrop_pack_pid,
+                       pmix20_bfrop_unpack_pid,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_pid,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT,
-                       pmix_bfrops_base_pack_int,
-                       pmix_bfrops_base_unpack_int,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int,
+                       pmix20_bfrop_pack_int,
+                       pmix20_bfrop_unpack_int,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_int,
                        &mca_bfrops_v20_component.types);
 
     /* Register all the standard fixed types to point to base functions */
     PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8,
-                       pmix_bfrops_base_pack_byte,
-                       pmix_bfrops_base_unpack_byte,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int8,
+                       pmix20_bfrop_pack_byte,
+                       pmix20_bfrop_unpack_byte,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_int8,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16,
-                       pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int16,
+                       pmix20_bfrop_pack_int16,
+                       pmix20_bfrop_unpack_int16,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_int16,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32,
-                       pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int32,
+                       pmix20_bfrop_pack_int32,
+                       pmix20_bfrop_unpack_int32,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_int32,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64,
-                       pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_int64,
+                       pmix20_bfrop_pack_int64,
+                       pmix20_bfrop_unpack_int64,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_int64,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT,
-                       pmix_bfrops_base_pack_int,
-                       pmix_bfrops_base_unpack_int,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint,
+                       pmix20_bfrop_pack_int,
+                       pmix20_bfrop_unpack_int,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_uint,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8,
-                       pmix_bfrops_base_pack_byte,
-                       pmix_bfrops_base_unpack_byte,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint8,
+                       pmix20_bfrop_pack_byte,
+                       pmix20_bfrop_unpack_byte,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_uint8,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16,
-                       pmix_bfrops_base_pack_int16,
-                       pmix_bfrops_base_unpack_int16,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint16,
+                       pmix20_bfrop_pack_int16,
+                       pmix20_bfrop_unpack_int16,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_uint16,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32,
-                       pmix_bfrops_base_pack_int32,
-                       pmix_bfrops_base_unpack_int32,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint32,
+                       pmix20_bfrop_pack_int32,
+                       pmix20_bfrop_unpack_int32,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_uint32,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64,
-                       pmix_bfrops_base_pack_int64,
-                       pmix_bfrops_base_unpack_int64,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_uint64,
+                       pmix20_bfrop_pack_int64,
+                       pmix20_bfrop_unpack_int64,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_uint64,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT,
-                       pmix_bfrops_base_pack_float,
-                       pmix_bfrops_base_unpack_float,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_float,
+                       pmix20_bfrop_pack_float,
+                       pmix20_bfrop_unpack_float,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_float,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE,
-                       pmix_bfrops_base_pack_double,
-                       pmix_bfrops_base_unpack_double,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_double,
+                       pmix20_bfrop_pack_double,
+                       pmix20_bfrop_unpack_double,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_double,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL,
-                       pmix_bfrops_base_pack_timeval,
-                       pmix_bfrops_base_unpack_timeval,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_timeval,
+                       pmix20_bfrop_pack_timeval,
+                       pmix20_bfrop_unpack_timeval,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_timeval,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME,
-                       pmix_bfrops_base_pack_time,
-                       pmix_bfrops_base_unpack_time,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_time,
+                       pmix20_bfrop_pack_time,
+                       pmix20_bfrop_unpack_time,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_time,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS,
-                       pmix_bfrops_base_pack_status,
-                       pmix_bfrops_base_unpack_status,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_status,
+                       pmix20_bfrop_pack_status,
+                       pmix20_bfrop_unpack_status,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_status,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE,
-                       pmix_bfrops_base_pack_value,
-                       pmix_bfrops_base_unpack_value,
-                       pmix_bfrops_base_copy_value,
-                       pmix_bfrops_base_print_value,
+                       pmix20_bfrop_pack_value,
+                       pmix20_bfrop_unpack_value,
+                       pmix20_bfrop_copy_value,
+                       pmix20_bfrop_print_value,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC,
-                       pmix_bfrops_base_pack_proc,
-                       pmix_bfrops_base_unpack_proc,
-                       pmix_bfrops_base_copy_proc,
-                       pmix_bfrops_base_print_proc,
+                       pmix20_bfrop_pack_proc,
+                       pmix20_bfrop_unpack_proc,
+                       pmix20_bfrop_copy_proc,
+                       pmix20_bfrop_print_proc,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP,
-                       pmix_bfrops_base_pack_app,
-                       pmix_bfrops_base_unpack_app,
-                       pmix_bfrops_base_copy_app,
-                       pmix_bfrops_base_print_app,
+                       pmix20_bfrop_pack_app,
+                       pmix20_bfrop_unpack_app,
+                       pmix20_bfrop_copy_app,
+                       pmix20_bfrop_print_app,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO,
-                       pmix_bfrops_base_pack_info,
-                       pmix_bfrops_base_unpack_info,
-                       pmix_bfrops_base_copy_info,
-                       pmix_bfrops_base_print_info,
+                       pmix20_bfrop_pack_info,
+                       pmix20_bfrop_unpack_info,
+                       pmix20_bfrop_copy_info,
+                       pmix20_bfrop_print_info,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA,
-                       pmix_bfrops_base_pack_pdata,
-                       pmix_bfrops_base_unpack_pdata,
-                       pmix_bfrops_base_copy_pdata,
-                       pmix_bfrops_base_print_pdata,
+                       pmix20_bfrop_pack_pdata,
+                       pmix20_bfrop_unpack_pdata,
+                       pmix20_bfrop_copy_pdata,
+                       pmix20_bfrop_print_pdata,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER,
-                       pmix_bfrops_base_pack_buf,
-                       pmix_bfrops_base_unpack_buf,
-                       pmix_bfrops_base_copy_buf,
-                       pmix_bfrops_base_print_buf,
+                       pmix20_bfrop_pack_buf,
+                       pmix20_bfrop_unpack_buf,
+                       pmix20_bfrop_copy_buf,
+                       pmix20_bfrop_print_buf,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT,
-                       pmix_bfrops_base_pack_bo,
-                       pmix_bfrops_base_unpack_bo,
-                       pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo,
+                       pmix20_bfrop_pack_bo,
+                       pmix20_bfrop_unpack_bo,
+                       pmix20_bfrop_copy_bo,
+                       pmix20_bfrop_print_bo,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL,
-                       pmix_bfrops_base_pack_kval,
-                       pmix_bfrops_base_unpack_kval,
-                       pmix_bfrops_base_copy_kval,
-                       pmix_bfrops_base_print_kval,
+                       pmix20_bfrop_pack_kval,
+                       pmix20_bfrop_unpack_kval,
+                       pmix20_bfrop_copy_kval,
+                       pmix20_bfrop_print_kval,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX,
-                       pmix_bfrops_base_pack_modex,
-                       pmix_bfrops_base_unpack_modex,
-                       pmix_bfrops_base_copy_modex,
-                       pmix_bfrops_base_print_modex,
+                       pmix20_bfrop_pack_modex,
+                       pmix20_bfrop_unpack_modex,
+                       pmix20_bfrop_copy_modex,
+                       pmix20_bfrop_print_modex,
                        &mca_bfrops_v20_component.types);
 
     /* these are fixed-sized values and can be done by base */
     PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST,
-                       pmix_bfrops_base_pack_persist,
-                       pmix_bfrops_base_unpack_persist,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_persist,
+                       pmix20_bfrop_pack_persist,
+                       pmix20_bfrop_unpack_persist,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_persist,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER,
-                       pmix_bfrops_base_pack_ptr,
-                       pmix_bfrops_base_unpack_ptr,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr,
+                       pmix20_bfrop_pack_ptr,
+                       pmix20_bfrop_unpack_ptr,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_ptr,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE,
-                       pmix_bfrops_base_pack_scope,
-                       pmix_bfrops_base_unpack_scope,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_std_copy,
+                       pmix20_bfrop_pack_scope,
+                       pmix20_bfrop_unpack_scope,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_std_copy,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE,
-                       pmix_bfrops_base_pack_range,
-                       pmix_bfrops_base_unpack_range,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_ptr,
+                       pmix20_bfrop_pack_range,
+                       pmix20_bfrop_unpack_range,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_ptr,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND,
-                       pmix_bfrops_base_pack_cmd,
-                       pmix_bfrops_base_unpack_cmd,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_cmd,
+                       pmix20_bfrop_pack_cmd,
+                       pmix20_bfrop_unpack_cmd,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_cmd,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
-                       pmix_bfrops_base_pack_info_directives,
-                       pmix_bfrops_base_unpack_info_directives,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_info_directives,
+                       pmix20_bfrop_pack_infodirs,
+                       pmix20_bfrop_unpack_infodirs,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_infodirs,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE,
-                       pmix_bfrops_base_pack_datatype,
-                       pmix_bfrops_base_unpack_datatype,
-                       pmix_bfrops_base_std_copy,
+                       pmix20_bfrop_pack_datatype,
+                       pmix20_bfrop_unpack_datatype,
+                       pmix20_bfrop_std_copy,
                        pmix_bfrops_base_print_datatype,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE,
-                       pmix_bfrops_base_pack_pstate,
-                       pmix_bfrops_base_unpack_pstate,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_pstate,
+                       pmix20_bfrop_pack_pstate,
+                       pmix20_bfrop_unpack_pstate,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_pstate,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO,
-                       pmix_bfrops_base_pack_pinfo,
-                       pmix_bfrops_base_unpack_pinfo,
-                       pmix_bfrops_base_copy_pinfo,
-                       pmix_bfrops_base_print_pinfo,
+                       pmix20_bfrop_pack_pinfo,
+                       pmix20_bfrop_unpack_pinfo,
+                       pmix20_bfrop_copy_pinfo,
+                       pmix20_bfrop_print_pinfo,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY,
-                       pmix_bfrops_base_pack_darray,
-                       pmix_bfrops_base_unpack_darray,
-                       pmix_bfrops_base_copy_darray,
-                       pmix_bfrops_base_print_darray,
+                       pmix20_bfrop_pack_darray,
+                       pmix20_bfrop_unpack_darray,
+                       pmix20_bfrop_copy_darray,
+                       pmix20_bfrop_print_darray,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK,
-                       pmix_bfrops_base_pack_rank,
-                       pmix_bfrops_base_unpack_rank,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_rank,
+                       pmix20_bfrop_pack_rank,
+                       pmix20_bfrop_unpack_rank,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_rank,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY,
-                       pmix_bfrops_base_pack_query,
-                       pmix_bfrops_base_unpack_query,
-                       pmix_bfrops_base_copy_query,
-                       pmix_bfrops_base_print_query,
+                       pmix20_bfrop_pack_query,
+                       pmix20_bfrop_unpack_query,
+                       pmix20_bfrop_copy_query,
+                       pmix20_bfrop_print_query,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING",
                        PMIX_COMPRESSED_STRING,
-                       pmix_bfrops_base_pack_bo,
-                       pmix_bfrops_base_unpack_bo,
-                       pmix_bfrops_base_copy_bo,
-                       pmix_bfrops_base_print_bo,
+                       pmix20_bfrop_pack_bo,
+                       pmix20_bfrop_unpack_bo,
+                       pmix20_bfrop_copy_bo,
+                       pmix20_bfrop_print_bo,
                        &mca_bfrops_v20_component.types);
 
     PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE",
                        PMIX_ALLOC_DIRECTIVE,
-                       pmix_bfrops_base_pack_alloc_directive,
-                       pmix_bfrops_base_unpack_alloc_directive,
-                       pmix_bfrops_base_std_copy,
-                       pmix_bfrops_base_print_alloc_directive,
+                       pmix20_bfrop_pack_alloc_directive,
+                       pmix20_bfrop_unpack_alloc_directive,
+                       pmix20_bfrop_std_copy,
+                       pmix20_bfrop_print_alloc_directive,
                        &mca_bfrops_v20_component.types);
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY,
-                       pmix_bfrops_base_pack_array,
-                       pmix_bfrops_base_unpack_array,
-                       pmix_bfrops_base_copy_array,
-                       pmix_bfrops_base_print_array,
+                       pmix20_bfrop_pack_array,
+                       pmix20_bfrop_unpack_array,
+                       pmix20_bfrop_copy_array,
+                       pmix20_bfrop_print_array,
                        &mca_bfrops_v20_component.types);
     /********************/
 
@@ -398,37 +391,6 @@ static void finalize(void)
     }
 }
 
-static pmix_status_t pmix20_pack(pmix_buffer_t *buffer,
-                                const void *src, int num_vals,
-                                pmix_data_type_t type)
-{
-    /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_pack(&mca_bfrops_v20_component.types,
-                                 buffer, src, num_vals, type);
-}
-
-static pmix_status_t pmix20_unpack(pmix_buffer_t *buffer, void *dest,
-                                  int32_t *num_vals, pmix_data_type_t type)
-{
-     /* kick the process off by passing this in to the base */
-    return pmix_bfrops_base_unpack(&mca_bfrops_v20_component.types,
-                                   buffer, dest, num_vals, type);
-}
-
-static pmix_status_t pmix20_copy(void **dest, void *src,
-                                pmix_data_type_t type)
-{
-    return pmix_bfrops_base_copy(&mca_bfrops_v20_component.types,
-                                 dest, src, type);
-}
-
-static pmix_status_t pmix20_print(char **output, char *prefix,
-                                 void *src, pmix_data_type_t type)
-{
-    return pmix_bfrops_base_print(&mca_bfrops_v20_component.types,
-                                  output, prefix, src, type);
-}
-
 static pmix_status_t register_type(const char *name, pmix_data_type_t type,
                                    pmix_bfrop_pack_fn_t pack,
                                    pmix_bfrop_unpack_fn_t unpack,
@@ -444,5 +406,338 @@ static pmix_status_t register_type(const char *name, pmix_data_type_t type,
 
 static const char* data_type_string(pmix_data_type_t type)
 {
-    return pmix_bfrops_base_data_type_string(&mca_bfrops_v20_component.types, type);
+    pmix_bfrop_type_info_t *info;
+
+    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+        return NULL;
+    }
+    return info->odti_name;
+}
+
+pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type)
+{
+    pmix_data_type_t v20type = PMIX_UNDEF;
+
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        /* if I am a server, then I'm passing the data type to
+         * a PMIx v1 compatible client. The data type was redefined
+         * in v2, and so we have to do some conversions here */
+        switch(v21type) {
+            case PMIX_COMMAND:
+                /* the client unfortunately didn't separate these out,
+                 * but instead set them to PMIX_UINT32 */
+                v20type = PMIX_UINT32;
+                break;
+
+            default:
+                v20type = v21type;
+        }
+    }
+    return v20type;
+}
+
+pmix_status_t pmix20_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
+{
+    pmix_data_type_t v20type;
+
+    v20type = pmix20_v21_to_v20_datatype(type);
+
+    return pmix20_bfrop_pack_datatype(buffer, &v20type, 1, PMIX_DATA_TYPE);
+}
+
+pmix_status_t pmix20_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
+{
+    int32_t n=1;
+    pmix_status_t rc;
+
+    rc = pmix20_bfrop_unpack_datatype(buffer, type, &n, PMIX_DATA_TYPE);
+
+    return rc;
+}
+
+void pmix20_bfrop_value_load(pmix_value_t *v,
+                             const void *data,
+                             pmix_data_type_t type)
+{
+    pmix_byte_object_t *bo;
+    pmix_proc_info_t *pi;
+
+    v->type = type;
+    if (NULL == data) {
+        /* just set the fields to zero */
+        memset(&v->data, 0, sizeof(v->data));
+        if (PMIX_BOOL == type) {
+          v->data.flag = true; // existence of the attribute indicates true unless specified different
+        }
+    } else {
+        switch(type) {
+        case PMIX_UNDEF:
+            break;
+        case PMIX_BOOL:
+            memcpy(&(v->data.flag), data, 1);
+            break;
+        case PMIX_BYTE:
+            memcpy(&(v->data.byte), data, 1);
+            break;
+        case PMIX_STRING:
+            v->data.string = strdup(data);
+            break;
+        case PMIX_SIZE:
+            memcpy(&(v->data.size), data, sizeof(size_t));
+            break;
+        case PMIX_PID:
+            memcpy(&(v->data.pid), data, sizeof(pid_t));
+            break;
+        case PMIX_INT:
+            memcpy(&(v->data.integer), data, sizeof(int));
+            break;
+        case PMIX_INT8:
+            memcpy(&(v->data.int8), data, 1);
+            break;
+        case PMIX_INT16:
+            memcpy(&(v->data.int16), data, 2);
+            break;
+        case PMIX_INT32:
+            memcpy(&(v->data.int32), data, 4);
+            break;
+        case PMIX_INT64:
+            memcpy(&(v->data.int64), data, 8);
+            break;
+        case PMIX_UINT:
+            memcpy(&(v->data.uint), data, sizeof(int));
+            break;
+        case PMIX_UINT8:
+            memcpy(&(v->data.uint8), data, 1);
+            break;
+        case PMIX_UINT16:
+            memcpy(&(v->data.uint16), data, 2);
+            break;
+        case PMIX_UINT32:
+            memcpy(&(v->data.uint32), data, 4);
+            break;
+        case PMIX_UINT64:
+            memcpy(&(v->data.uint64), data, 8);
+            break;
+        case PMIX_FLOAT:
+            memcpy(&(v->data.fval), data, sizeof(float));
+            break;
+        case PMIX_DOUBLE:
+            memcpy(&(v->data.dval), data, sizeof(double));
+            break;
+        case PMIX_TIMEVAL:
+            memcpy(&(v->data.tv), data, sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            memcpy(&(v->data.time), data, sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            memcpy(&(v->data.status), data, sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC_RANK:
+            memcpy(&(v->data.rank), data, sizeof(pmix_rank_t));
+            break;
+        case PMIX_PROC:
+            PMIX_PROC_CREATE(v->data.proc, 1);
+            if (NULL == v->data.proc) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                return;
+            }
+            memcpy(v->data.proc, data, sizeof(pmix_proc_t));
+            break;
+        case PMIX_BYTE_OBJECT:
+            bo = (pmix_byte_object_t*)data;
+            v->data.bo.bytes = bo->bytes;
+            memcpy(&(v->data.bo.size), &bo->size, sizeof(size_t));
+            break;
+        case PMIX_PERSIST:
+            memcpy(&(v->data.persist), data, sizeof(pmix_persistence_t));
+            break;
+        case PMIX_SCOPE:
+            memcpy(&(v->data.scope), data, sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            memcpy(&(v->data.range), data, sizeof(pmix_data_range_t));
+            break;
+        case PMIX_PROC_STATE:
+            memcpy(&(v->data.state), data, sizeof(pmix_proc_state_t));
+            break;
+        case PMIX_PROC_INFO:
+            PMIX_PROC_INFO_CREATE(v->data.pinfo, 1);
+            if (NULL == v->data.pinfo) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                return;
+            }
+            pi = (pmix_proc_info_t*)data;
+            memcpy(&(v->data.pinfo->proc), &pi->proc, sizeof(pmix_proc_t));
+            if (NULL != pi->hostname) {
+                v->data.pinfo->hostname = strdup(pi->hostname);
+            }
+            if (NULL != pi->executable_name) {
+                v->data.pinfo->executable_name = strdup(pi->executable_name);
+            }
+            memcpy(&(v->data.pinfo->pid), &pi->pid, sizeof(pid_t));
+            memcpy(&(v->data.pinfo->exit_code), &pi->exit_code, sizeof(int));
+            break;
+        case PMIX_POINTER:
+            memcpy(&(v->data.ptr), data, sizeof(void*));
+            break;
+        default:
+            /* silence warnings */
+            PMIX_ERROR_LOG(PMIX_ERR_UNKNOWN_DATA_TYPE);
+            break;
+        }
+    }
+}
+
+pmix_status_t pmix20_bfrop_value_unload(pmix_value_t *kv,
+                                        void **data,
+                                        size_t *sz)
+{
+    pmix_status_t rc;
+    pmix_proc_t *pc;
+
+    rc = PMIX_SUCCESS;
+    if (NULL == data ||
+        (NULL == *data &&
+         PMIX_STRING != kv->type &&
+         PMIX_BYTE_OBJECT != kv->type)) {
+        rc = PMIX_ERR_BAD_PARAM;
+    } else {
+        switch(kv->type) {
+        case PMIX_UNDEF:
+            rc = PMIX_ERR_UNKNOWN_DATA_TYPE;
+            break;
+        case PMIX_BOOL:
+            memcpy(*data, &(kv->data.flag), 1);
+            *sz = 1;
+            break;
+        case PMIX_BYTE:
+            memcpy(*data, &(kv->data.byte), 1);
+            *sz = 1;
+            break;
+        case PMIX_STRING:
+            if (NULL != kv->data.string) {
+                *data = strdup(kv->data.string);
+                *sz = strlen(kv->data.string);
+            }
+            break;
+        case PMIX_SIZE:
+            memcpy(*data, &(kv->data.size), sizeof(size_t));
+            *sz = sizeof(size_t);
+            break;
+        case PMIX_PID:
+            memcpy(*data, &(kv->data.pid), sizeof(pid_t));
+            *sz = sizeof(pid_t);
+            break;
+        case PMIX_INT:
+            memcpy(*data, &(kv->data.integer), sizeof(int));
+            *sz = sizeof(int);
+            break;
+        case PMIX_INT8:
+            memcpy(*data, &(kv->data.int8), 1);
+            *sz = 1;
+            break;
+        case PMIX_INT16:
+            memcpy(*data, &(kv->data.int16), 2);
+            *sz = 2;
+            break;
+        case PMIX_INT32:
+            memcpy(*data, &(kv->data.int32), 4);
+            *sz = 4;
+            break;
+        case PMIX_INT64:
+            memcpy(*data, &(kv->data.int64), 8);
+            *sz = 8;
+            break;
+        case PMIX_UINT:
+            memcpy(*data, &(kv->data.uint), sizeof(int));
+            *sz = sizeof(int);
+            break;
+        case PMIX_UINT8:
+            memcpy(*data, &(kv->data.uint8), 1);
+            *sz = 1;
+            break;
+        case PMIX_UINT16:
+            memcpy(*data, &(kv->data.uint16), 2);
+            *sz = 2;
+            break;
+        case PMIX_UINT32:
+            memcpy(*data, &(kv->data.uint32), 4);
+            *sz = 4;
+            break;
+        case PMIX_UINT64:
+            memcpy(*data, &(kv->data.uint64), 8);
+            *sz = 8;
+            break;
+        case PMIX_FLOAT:
+            memcpy(*data, &(kv->data.fval), sizeof(float));
+            *sz = sizeof(float);
+            break;
+        case PMIX_DOUBLE:
+            memcpy(*data, &(kv->data.dval), sizeof(double));
+            *sz = sizeof(double);
+            break;
+        case PMIX_TIMEVAL:
+            memcpy(*data, &(kv->data.tv), sizeof(struct timeval));
+            *sz = sizeof(struct timeval);
+            break;
+        case PMIX_TIME:
+            memcpy(*data, &(kv->data.time), sizeof(time_t));
+            *sz = sizeof(time_t);
+            break;
+        case PMIX_STATUS:
+            memcpy(*data, &(kv->data.status), sizeof(pmix_status_t));
+            *sz = sizeof(pmix_status_t);
+            break;
+        case PMIX_PROC_RANK:
+            memcpy(*data, &(kv->data.rank), sizeof(pmix_rank_t));
+            *sz = sizeof(pmix_rank_t);
+            break;
+        case PMIX_PROC:
+            PMIX_PROC_CREATE(pc, 1);
+            if (NULL == pc) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                rc = PMIX_ERR_NOMEM;
+                break;
+            }
+            memcpy(pc, kv->data.proc, sizeof(pmix_proc_t));
+            *sz = sizeof(pmix_proc_t);
+            *data = pc;
+            break;
+        case PMIX_BYTE_OBJECT:
+            if (NULL != kv->data.bo.bytes && 0 < kv->data.bo.size) {
+                *data = kv->data.bo.bytes;
+                *sz = kv->data.bo.size;
+            } else {
+                *data = NULL;
+                *sz = 0;
+            }
+            break;
+        case PMIX_PERSIST:
+            memcpy(*data, &(kv->data.persist), sizeof(pmix_persistence_t));
+            *sz = sizeof(pmix_persistence_t);
+            break;
+        case PMIX_SCOPE:
+            memcpy(*data, &(kv->data.scope), sizeof(pmix_scope_t));
+            *sz = sizeof(pmix_scope_t);
+            break;
+        case PMIX_DATA_RANGE:
+            memcpy(*data, &(kv->data.range), sizeof(pmix_data_range_t));
+            *sz = sizeof(pmix_data_range_t);
+            break;
+        case PMIX_PROC_STATE:
+            memcpy(*data, &(kv->data.state), sizeof(pmix_proc_state_t));
+            *sz = sizeof(pmix_proc_state_t);
+            break;
+        case PMIX_POINTER:
+            memcpy(*data, &(kv->data.ptr), sizeof(void*));
+            *sz = sizeof(void*);
+            break;
+        default:
+            /* silence warnings */
+            rc = PMIX_ERROR;
+            break;
+        }
+    }
+    return rc;
 }

--- a/src/mca/bfrops/v20/bfrop_pmix20.h
+++ b/src/mca/bfrops/v20/bfrop_pmix20.h
@@ -17,8 +17,8 @@
  * $HEADER$
  */
 
-#ifndef PMIX_BFROPS_PMIX2_H
-#define PMIX_BFROPS_PMIX2_H
+#ifndef PMIX20_BFROPS_H
+#define PMIX20_BFROPS_H
 
 #include "src/mca/bfrops/bfrops.h"
 
@@ -31,4 +31,4 @@ extern pmix_bfrops_module_t pmix_bfrops_pmix20_module;
 
 END_C_DECLS
 
-#endif /* PMIX_BFROPS_PMIX2_H */
+#endif /* PMIX20_BFROPS_H */

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -1,0 +1,1522 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix20.h"
+#include "internal.h"
+
+ pmix_status_t pmix20_bfrop_copy(void **dest, void *src, pmix_data_type_t type)
+{
+    pmix_bfrop_type_info_t *info;
+
+    /* check for error */
+    if (NULL == dest) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL == src) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+   /* Lookup the copy function for this type and call it */
+
+    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+        PMIX_ERROR_LOG(PMIX_ERR_UNKNOWN_DATA_TYPE);
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+
+    return info->odti_copy_fn(dest, src, type);
+}
+
+pmix_status_t pmix20_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src)
+{
+    size_t to_copy = 0;
+    char *ptr;
+    /* deal with buffer type */
+    if( NULL == dest->base_ptr ){
+        /* destination buffer is empty - derive src buffer type */
+        dest->type = src->type;
+    } else if( dest->type != src->type ){
+        /* buffer types mismatch */
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    to_copy = src->pack_ptr - src->unpack_ptr;
+    if( NULL == (ptr = pmix_bfrop_buffer_extend(dest, to_copy)) ){
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    memcpy(ptr,src->unpack_ptr, to_copy);
+    dest->bytes_used += to_copy;
+    dest->pack_ptr += to_copy;
+    return PMIX_SUCCESS;
+}
+
+
+/*
+ * STANDARD COPY FUNCTION - WORKS FOR EVERYTHING NON-STRUCTURED
+ */
+ pmix_status_t pmix20_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type)
+{
+    size_t datasize;
+    uint8_t *val = NULL;
+
+    switch(type) {
+    case PMIX_BOOL:
+        datasize = sizeof(bool);
+        break;
+
+    case PMIX_INT:
+    case PMIX_UINT:
+        datasize = sizeof(int);
+        break;
+
+    case PMIX_SIZE:
+        datasize = sizeof(size_t);
+        break;
+
+    case PMIX_PID:
+        datasize = sizeof(pid_t);
+        break;
+
+    case PMIX_BYTE:
+    case PMIX_INT8:
+    case PMIX_UINT8:
+        datasize = 1;
+        break;
+
+    case PMIX_INT16:
+    case PMIX_UINT16:
+        datasize = 2;
+        break;
+
+    case PMIX_INT32:
+    case PMIX_UINT32:
+        datasize = 4;
+        break;
+
+    case PMIX_INT64:
+    case PMIX_UINT64:
+        datasize = 8;
+        break;
+
+    case PMIX_FLOAT:
+        datasize = sizeof(float);
+        break;
+
+    case PMIX_TIMEVAL:
+        datasize = sizeof(struct timeval);
+        break;
+
+    case PMIX_TIME:
+        datasize = sizeof(time_t);
+        break;
+
+    case PMIX_STATUS:
+        datasize = sizeof(pmix_status_t);
+        break;
+
+    case PMIX_PROC_RANK:
+        datasize = sizeof(pmix_rank_t);
+        break;
+
+    case PMIX_PERSIST:
+        datasize = sizeof(pmix_persistence_t);
+        break;
+
+    case PMIX_POINTER:
+        datasize = sizeof(char*);
+        break;
+
+    case PMIX_SCOPE:
+        datasize = sizeof(pmix_scope_t);
+        break;
+
+    case PMIX_DATA_RANGE:
+        datasize = sizeof(pmix_data_range_t);
+        break;
+
+    case PMIX_COMMAND:
+        datasize = sizeof(pmix_cmd_t);
+        break;
+
+    case PMIX_INFO_DIRECTIVES:
+        datasize = sizeof(pmix_info_directives_t);
+        break;
+
+    case PMIX_PROC_STATE:
+        datasize = sizeof(pmix_proc_state_t);
+        break;
+
+    case PMIX_ALLOC_DIRECTIVE:
+        datasize = sizeof(pmix_alloc_directive_t);
+        break;
+
+    default:
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+
+    val = (uint8_t*)malloc(datasize);
+    if (NULL == val) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    memcpy(val, src, datasize);
+    *dest = val;
+
+    return PMIX_SUCCESS;
+}
+
+/* compare function for pmix_value_t*/
+pmix_value_cmp_t pmix20_bfrop_value_cmp(pmix_value_t *p, pmix_value_t *p1)
+{
+    bool rc = false;
+    switch (p->type) {
+        case PMIX_BOOL:
+            rc = (p->data.flag == p1->data.flag);
+            break;
+        case PMIX_BYTE:
+            rc = (p->data.byte == p1->data.byte);
+            break;
+        case PMIX_SIZE:
+            rc = (p->data.size == p1->data.size);
+            break;
+        case PMIX_INT:
+            rc = (p->data.integer == p1->data.integer);
+            break;
+        case PMIX_INT8:
+            rc = (p->data.int8 == p1->data.int8);
+            break;
+        case PMIX_INT16:
+            rc = (p->data.int16 == p1->data.int16);
+            break;
+        case PMIX_INT32:
+            rc = (p->data.int32 == p1->data.int32);
+            break;
+        case PMIX_INT64:
+            rc = (p->data.int64 == p1->data.int64);
+            break;
+        case PMIX_UINT:
+            rc = (p->data.uint == p1->data.uint);
+            break;
+        case PMIX_UINT8:
+            rc = (p->data.uint8 == p1->data.int8);
+            break;
+        case PMIX_UINT16:
+            rc = (p->data.uint16 == p1->data.uint16);
+            break;
+        case PMIX_UINT32:
+            rc = (p->data.uint32 == p1->data.uint32);
+            break;
+        case PMIX_UINT64:
+            rc = (p->data.uint64 == p1->data.uint64);
+            break;
+        case PMIX_STRING:
+            rc = strcmp(p->data.string, p1->data.string);
+            break;
+        default:
+            pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
+    }
+    if (rc) {
+        return PMIX_EQUAL;
+    }
+    return PMIX_VALUE1_GREATER;
+}
+
+/* COPY FUNCTIONS FOR NON-STANDARD SYSTEM TYPES */
+
+/*
+ * STRING
+ */
+ pmix_status_t pmix20_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type)
+{
+    if (NULL == src) {  /* got zero-length string/NULL pointer - store NULL */
+        *dest = NULL;
+    } else {
+        *dest = strdup(src);
+    }
+
+    return PMIX_SUCCESS;
+}
+/* compare function for pmix_value_t */
+bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
+{
+    bool rc = false;
+
+    if (p->type != p1->type) {
+        return rc;
+    }
+
+    switch (p->type) {
+        case PMIX_UNDEF:
+            rc = true;
+            break;
+        case PMIX_BOOL:
+            rc = (p->data.flag == p1->data.flag);
+            break;
+        case PMIX_BYTE:
+            rc = (p->data.byte == p1->data.byte);
+            break;
+        case PMIX_SIZE:
+            rc = (p->data.size == p1->data.size);
+            break;
+        case PMIX_INT:
+            rc = (p->data.integer == p1->data.integer);
+            break;
+        case PMIX_INT8:
+            rc = (p->data.int8 == p1->data.int8);
+            break;
+        case PMIX_INT16:
+            rc = (p->data.int16 == p1->data.int16);
+            break;
+        case PMIX_INT32:
+            rc = (p->data.int32 == p1->data.int32);
+            break;
+        case PMIX_INT64:
+            rc = (p->data.int64 == p1->data.int64);
+            break;
+        case PMIX_UINT:
+            rc = (p->data.uint == p1->data.uint);
+            break;
+        case PMIX_UINT8:
+            rc = (p->data.uint8 == p1->data.int8);
+            break;
+        case PMIX_UINT16:
+            rc = (p->data.uint16 == p1->data.uint16);
+            break;
+        case PMIX_UINT32:
+            rc = (p->data.uint32 == p1->data.uint32);
+            break;
+        case PMIX_UINT64:
+            rc = (p->data.uint64 == p1->data.uint64);
+            break;
+        case PMIX_STRING:
+            rc = strcmp(p->data.string, p1->data.string);
+            break;
+        case PMIX_COMPRESSED_STRING:
+            if (p->data.bo.size != p1->data.bo.size) {
+                return false;
+            } else {
+                return true;
+            }
+        case PMIX_STATUS:
+            rc = (p->data.status == p1->data.status);
+            break;
+        default:
+            pmix_output(0, "COMPARE-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
+    }
+    return rc;
+}
+/* COPY FUNCTIONS FOR GENERIC PMIX TYPES - we
+ * are not allocating memory and so we cannot
+ * use the regular copy functions */
+pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
+{
+    size_t n, m;
+    pmix_status_t rc;
+    char **prarray, **strarray;
+    pmix_value_t *pv, *sv;
+    pmix_info_t *p1, *s1;
+    pmix_app_t *pa, *sa;
+    pmix_pdata_t *pd, *sd;
+    pmix_buffer_t *pb, *sb;
+    pmix_byte_object_t *pbo, *sbo;
+    pmix_kval_t *pk, *sk;
+    pmix_modex_data_t *pm, *sm;
+    pmix_proc_info_t *pi, *si;
+    pmix_query_t *pq, *sq;
+
+    /* copy the right field */
+    p->type = src->type;
+    switch (src->type) {
+    case PMIX_UNDEF:
+    break;
+    case PMIX_BOOL:
+        p->data.flag = src->data.flag;
+        break;
+    case PMIX_BYTE:
+        p->data.byte = src->data.byte;
+        break;
+    case PMIX_STRING:
+        if (NULL != src->data.string) {
+            p->data.string = strdup(src->data.string);
+        } else {
+            p->data.string = NULL;
+        }
+        break;
+    case PMIX_SIZE:
+        p->data.size = src->data.size;
+        break;
+    case PMIX_PID:
+        p->data.pid = src->data.pid;
+        break;
+    case PMIX_INT:
+        /* to avoid alignment issues */
+        memcpy(&p->data.integer, &src->data.integer, sizeof(int));
+        break;
+    case PMIX_INT8:
+        p->data.int8 = src->data.int8;
+        break;
+    case PMIX_INT16:
+        /* to avoid alignment issues */
+        memcpy(&p->data.int16, &src->data.int16, 2);
+        break;
+    case PMIX_INT32:
+        /* to avoid alignment issues */
+        memcpy(&p->data.int32, &src->data.int32, 4);
+        break;
+    case PMIX_INT64:
+        /* to avoid alignment issues */
+        memcpy(&p->data.int64, &src->data.int64, 8);
+        break;
+    case PMIX_UINT:
+        /* to avoid alignment issues */
+        memcpy(&p->data.uint, &src->data.uint, sizeof(unsigned int));
+        break;
+    case PMIX_UINT8:
+        p->data.uint8 = src->data.uint8;
+        break;
+    case PMIX_UINT16:
+        /* to avoid alignment issues */
+        memcpy(&p->data.uint16, &src->data.uint16, 2);
+        break;
+    case PMIX_UINT32:
+        /* to avoid alignment issues */
+        memcpy(&p->data.uint32, &src->data.uint32, 4);
+        break;
+    case PMIX_UINT64:
+        /* to avoid alignment issues */
+        memcpy(&p->data.uint64, &src->data.uint64, 8);
+        break;
+    case PMIX_FLOAT:
+        p->data.fval = src->data.fval;
+        break;
+    case PMIX_DOUBLE:
+        p->data.dval = src->data.dval;
+        break;
+    case PMIX_TIMEVAL:
+        memcpy(&p->data.tv, &src->data.tv, sizeof(struct timeval));
+        break;
+    case PMIX_TIME:
+        memcpy(&p->data.time, &src->data.time, sizeof(time_t));
+        break;
+    case PMIX_STATUS:
+        memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
+        break;
+    case PMIX_PROC:
+        memcpy(&p->data.proc, &src->data.proc, sizeof(pmix_proc_t));
+        break;
+    case PMIX_PROC_RANK:
+        memcpy(&p->data.proc, &src->data.rank, sizeof(pmix_rank_t));
+        break;
+    case PMIX_BYTE_OBJECT:
+    case PMIX_COMPRESSED_STRING:
+        memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
+        if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
+            p->data.bo.bytes = malloc(src->data.bo.size);
+            memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
+            p->data.bo.size = src->data.bo.size;
+        } else {
+            p->data.bo.bytes = NULL;
+            p->data.bo.size = 0;
+        }
+        break;
+    case PMIX_PERSIST:
+        memcpy(&p->data.persist, &src->data.persist, sizeof(pmix_persistence_t));
+        break;
+    case PMIX_SCOPE:
+        memcpy(&p->data.scope, &src->data.scope, sizeof(pmix_scope_t));
+        break;
+    case PMIX_DATA_RANGE:
+        memcpy(&p->data.range, &src->data.range, sizeof(pmix_data_range_t));
+        break;
+    case PMIX_PROC_STATE:
+        memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
+        break;
+    case PMIX_PROC_INFO:
+        PMIX_PROC_INFO_CREATE(p->data.pinfo, 1);
+        if (NULL != src->data.pinfo->hostname) {
+            p->data.pinfo->hostname = strdup(src->data.pinfo->hostname);
+        }
+        if (NULL != src->data.pinfo->executable_name) {
+            p->data.pinfo->executable_name = strdup(src->data.pinfo->executable_name);
+        }
+        memcpy(&p->data.pinfo->pid, &src->data.pinfo->pid, sizeof(pid_t));
+        memcpy(&p->data.pinfo->exit_code, &src->data.pinfo->exit_code, sizeof(int));
+        memcpy(&p->data.pinfo->state, &src->data.pinfo->state, sizeof(pmix_proc_state_t));
+        break;
+    case PMIX_DATA_ARRAY:
+        p->data.darray = (pmix_data_array_t*)calloc(1, sizeof(pmix_data_array_t));
+        p->data.darray->type = src->data.darray->type;
+        p->data.darray->size = src->data.darray->size;
+        if (0 == p->data.darray->size || NULL == src->data.darray->array) {
+            p->data.darray->array = NULL;
+            p->data.darray->size = 0;
+            break;
+        }
+        /* allocate space and do the copy */
+        switch (src->data.darray->type) {
+            case PMIX_UINT8:
+            case PMIX_INT8:
+            case PMIX_BYTE:
+                p->data.darray->array = (char*)malloc(src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size);
+                break;
+            case PMIX_UINT16:
+            case PMIX_INT16:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint16_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint16_t));
+                break;
+            case PMIX_UINT32:
+            case PMIX_INT32:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint32_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint32_t));
+                break;
+            case PMIX_UINT64:
+            case PMIX_INT64:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint64_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint64_t));
+                break;
+            case PMIX_BOOL:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(bool));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(bool));
+                break;
+            case PMIX_SIZE:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(size_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(size_t));
+                break;
+            case PMIX_PID:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(pid_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pid_t));
+                break;
+            case PMIX_STRING:
+                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                prarray = (char**)p->data.darray->array;
+                strarray = (char**)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (NULL != strarray[n]) {
+                        prarray[n] = strdup(strarray[n]);
+                    }
+                }
+                break;
+            case PMIX_INT:
+            case PMIX_UINT:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(int));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(int));
+                break;
+            case PMIX_FLOAT:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(float));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(float));
+                break;
+            case PMIX_DOUBLE:
+                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(double));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(double));
+                break;
+            case PMIX_TIMEVAL:
+                p->data.darray->array = (struct timeval*)malloc(src->data.darray->size * sizeof(struct timeval));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(struct timeval));
+                break;
+            case PMIX_TIME:
+                p->data.darray->array = (time_t*)malloc(src->data.darray->size * sizeof(time_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(time_t));
+                break;
+            case PMIX_STATUS:
+                p->data.darray->array = (pmix_status_t*)malloc(src->data.darray->size * sizeof(pmix_status_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_status_t));
+                break;
+            case PMIX_VALUE:
+                PMIX_VALUE_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pv = (pmix_value_t*)p->data.darray->array;
+                sv = (pmix_value_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(&pv[n], &sv[n]))) {
+                        PMIX_VALUE_FREE(pv, src->data.darray->size);
+                        return rc;
+                    }
+                }
+                break;
+            case PMIX_PROC:
+                PMIX_PROC_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_proc_t));
+                break;
+            case PMIX_APP:
+                PMIX_APP_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pa = (pmix_app_t*)p->data.darray->array;
+                sa = (pmix_app_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (NULL != sa[n].cmd) {
+                        pa[n].cmd = strdup(sa[n].cmd);
+                    }
+                    if (NULL != sa[n].argv) {
+                        pa[n].argv = pmix_argv_copy(sa[n].argv);
+                    }
+                    if (NULL != sa[n].env) {
+                        pa[n].env = pmix_argv_copy(sa[n].env);
+                    }
+                    if (NULL != sa[n].cwd) {
+                        pa[n].cwd = strdup(sa[n].cwd);
+                    }
+                    pa[n].maxprocs = sa[n].maxprocs;
+                    if (0 < sa[n].ninfo && NULL != sa[n].info) {
+                        PMIX_INFO_CREATE(pa[n].info, sa[n].ninfo);
+                        if (NULL == pa[n].info) {
+                            PMIX_APP_FREE(pa, src->data.darray->size);
+                            return PMIX_ERR_NOMEM;
+                        }
+                        pa[n].ninfo = sa[n].ninfo;
+                        for (m=0; m < pa[n].ninfo; m++) {
+                            PMIX_INFO_XFER(&pa[n].info[m], &sa[n].info[m]);
+                        }
+                    }
+                }
+                break;
+            case PMIX_INFO:
+                PMIX_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                p1 = (pmix_info_t*)p->data.darray->array;
+                s1 = (pmix_info_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
+                }
+                break;
+            case PMIX_PDATA:
+                PMIX_PDATA_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pd = (pmix_pdata_t*)p->data.darray->array;
+                sd = (pmix_pdata_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data.flag, sd[n].value.type);
+                }
+                break;
+            case PMIX_BUFFER:
+                p->data.darray->array = (pmix_buffer_t*)malloc(src->data.darray->size * sizeof(pmix_buffer_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pb = (pmix_buffer_t*)p->data.darray->array;
+                sb = (pmix_buffer_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    PMIX_CONSTRUCT(&pb[n], pmix_buffer_t);
+                    pmix20_bfrop_copy_payload(&pb[n], &sb[n]);
+                }
+                break;
+            case PMIX_BYTE_OBJECT:
+            case PMIX_COMPRESSED_STRING:
+                p->data.darray->array = (pmix_byte_object_t*)malloc(src->data.darray->size * sizeof(pmix_byte_object_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pbo = (pmix_byte_object_t*)p->data.darray->array;
+                sbo = (pmix_byte_object_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
+                        pbo[n].size = sbo[n].size;
+                        pbo[n].bytes = (char*)malloc(pbo[n].size);
+                        memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
+                    } else {
+                        pbo[n].bytes = NULL;
+                        pbo[n].size = 0;
+                    }
+                }
+                break;
+            case PMIX_KVAL:
+                p->data.darray->array = (pmix_kval_t*)calloc(src->data.darray->size , sizeof(pmix_kval_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pk = (pmix_kval_t*)p->data.darray->array;
+                sk = (pmix_kval_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (NULL != sk[n].key) {
+                        pk[n].key = strdup(sk[n].key);
+                    }
+                    if (NULL != sk[n].value) {
+                        PMIX_VALUE_CREATE(pk[n].value, 1);
+                        if (NULL == pk[n].value) {
+                            free(p->data.darray->array);
+                            return PMIX_ERR_NOMEM;
+                        }
+                        if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(pk[n].value, sk[n].value))) {
+                            return rc;
+                        }
+                    }
+                }
+                break;
+            case PMIX_MODEX:
+                PMIX_MODEX_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pm = (pmix_modex_data_t*)p->data.darray->array;
+                sm = (pmix_modex_data_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    memcpy(&pm[n], &sm[n], sizeof(pmix_modex_data_t));
+                    if (NULL != sm[n].blob && 0 < sm[n].size) {
+                        pm[n].blob = (uint8_t*)malloc(sm[n].size);
+                        if (NULL == pm[n].blob) {
+                            return PMIX_ERR_NOMEM;
+                        }
+                        memcpy(pm[n].blob, sm[n].blob, sm[n].size);
+                        pm[n].size = sm[n].size;
+                    } else {
+                        pm[n].blob = NULL;
+                        pm[n].size = 0;
+                    }
+                }
+                break;
+            case PMIX_PERSIST:
+                p->data.darray->array = (pmix_persistence_t*)malloc(src->data.darray->size * sizeof(pmix_persistence_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_persistence_t));
+                break;
+            case PMIX_POINTER:
+                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                prarray = (char**)p->data.darray->array;
+                strarray = (char**)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    prarray[n] = strarray[n];
+                }
+                break;
+            case PMIX_SCOPE:
+                p->data.darray->array = (pmix_scope_t*)malloc(src->data.darray->size * sizeof(pmix_scope_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_scope_t));
+                break;
+            case PMIX_DATA_RANGE:
+                p->data.darray->array = (pmix_data_range_t*)malloc(src->data.darray->size * sizeof(pmix_data_range_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_data_range_t));
+                break;
+            case PMIX_COMMAND:
+                p->data.darray->array = (pmix_cmd_t*)malloc(src->data.darray->size * sizeof(pmix_cmd_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_cmd_t));
+                break;
+            case PMIX_INFO_DIRECTIVES:
+                p->data.darray->array = (pmix_info_directives_t*)malloc(src->data.darray->size * sizeof(pmix_info_directives_t));
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_info_directives_t));
+                break;
+            case PMIX_PROC_INFO:
+                PMIX_PROC_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pi = (pmix_proc_info_t*)p->data.darray->array;
+                si = (pmix_proc_info_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    memcpy(&pi[n].proc, &si[n].proc, sizeof(pmix_proc_t));
+                    if (NULL != si[n].hostname) {
+                        pi[n].hostname = strdup(si[n].hostname);
+                    } else {
+                        pi[n].hostname = NULL;
+                    }
+                    if (NULL != si[n].executable_name) {
+                        pi[n].executable_name = strdup(si[n].executable_name);
+                    } else {
+                        pi[n].executable_name = NULL;
+                    }
+                    pi[n].pid = si[n].pid;
+                    pi[n].exit_code = si[n].exit_code;
+                    pi[n].state = si[n].state;
+                }
+                break;
+            case PMIX_DATA_ARRAY:
+                return PMIX_ERR_NOT_SUPPORTED;  // don't support iterative arrays
+            case PMIX_QUERY:
+                PMIX_QUERY_CREATE(p->data.darray->array, src->data.darray->size);
+                if (NULL == p->data.darray->array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                pq = (pmix_query_t*)p->data.darray->array;
+                sq = (pmix_query_t*)src->data.darray->array;
+                for (n=0; n < src->data.darray->size; n++) {
+                    if (NULL != sq[n].keys) {
+                        pq[n].keys = pmix_argv_copy(sq[n].keys);
+                    }
+                    if (NULL != sq[n].qualifiers && 0 < sq[n].nqual) {
+                        PMIX_INFO_CREATE(pq[n].qualifiers, sq[n].nqual);
+                        if (NULL == pq[n].qualifiers) {
+                            PMIX_QUERY_FREE(pq, src->data.darray->size);
+                            return PMIX_ERR_NOMEM;
+                        }
+                        for (m=0; m < sq[n].nqual; m++) {
+                            PMIX_INFO_XFER(&pq[n].qualifiers[m], &sq[n].qualifiers[m]);
+                        }
+                        pq[n].nqual = sq[n].nqual;
+                    } else {
+                        pq[n].qualifiers = NULL;
+                        pq[n].nqual = 0;
+                    }
+                }
+                break;
+            default:
+                return PMIX_ERR_UNKNOWN_DATA_TYPE;
+        }
+        break;
+    case PMIX_POINTER:
+        memcpy(&p->data.ptr, &src->data.ptr, sizeof(void*));
+        break;
+    /**** DEPRECATED ****/
+    case PMIX_INFO_ARRAY:
+        p->data.array->size = src->data.array->size;
+        if (0 < src->data.array->size) {
+            p->data.array->array = (pmix_info_t*)malloc(src->data.array->size * sizeof(pmix_info_t));
+            if (NULL == p->data.array->array) {
+                return PMIX_ERR_NOMEM;
+            }
+            p1 = (pmix_info_t*)p->data.array->array;
+            s1 = (pmix_info_t*)src->data.array->array;
+            for (n=0; n < src->data.darray->size; n++) {
+                PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
+            }
+        }
+        break;
+    /********************/
+    default:
+        pmix_output(0, "COPY-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)src->type);
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+/* PMIX_VALUE */
+pmix_status_t pmix20_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
+                                    pmix_data_type_t type)
+{
+    pmix_value_t *p;
+
+    /* create the new object */
+    *dest = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    p = *dest;
+
+    /* copy the type */
+    p->type = src->type;
+    /* copy the data */
+    return pmix20_bfrop_value_xfer(p, src);
+}
+
+pmix_status_t pmix20_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
+                                   pmix_data_type_t type)
+{
+    *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
+    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    (*dest)->flags = src->flags;
+    return pmix20_bfrop_value_xfer(&(*dest)->value, &src->value);
+}
+
+pmix_status_t pmix20_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
+                                  pmix_data_type_t type)
+{
+    *dest = PMIX_NEW(pmix_buffer_t);
+    pmix20_bfrop_copy_payload(*dest, src);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
+                                  pmix_data_type_t type)
+{
+    size_t j;
+
+    *dest = (pmix_app_t*)malloc(sizeof(pmix_app_t));
+    (*dest)->cmd = strdup(src->cmd);
+    (*dest)->argv = pmix_argv_copy(src->argv);
+    (*dest)->env = pmix_argv_copy(src->env);
+    if (NULL != src->cwd) {
+        (*dest)->cwd = strdup(src->cwd);
+    }
+    (*dest)->maxprocs = src->maxprocs;
+    (*dest)->ninfo = src->ninfo;
+    (*dest)->info = (pmix_info_t*)malloc(src->ninfo * sizeof(pmix_info_t));
+    for (j=0; j < src->ninfo; j++) {
+        (void)strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
+        pmix20_bfrop_value_xfer(&(*dest)->info[j].value, &src->info[j].value);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
+                                   pmix_data_type_t type)
+{
+    pmix_kval_t *p;
+
+    /* create the new object */
+    *dest = PMIX_NEW(pmix_kval_t);
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    p = *dest;
+
+    /* copy the type */
+    p->value->type = src->value->type;
+    /* copy the data */
+    return pmix20_bfrop_value_xfer(p->value, src->value);
+}
+
+pmix_status_t pmix20_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
+                                   pmix_data_type_t type)
+{
+    *dest = (pmix_proc_t*)malloc(sizeof(pmix_proc_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    (void)strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
+    (*dest)->rank = src->rank;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
+                                    pmix_data_type_t type)
+{
+    *dest = (pmix_modex_data_t*)malloc(sizeof(pmix_modex_data_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    (*dest)->blob = NULL;
+    (*dest)->size = 0;
+    if (NULL != src->blob) {
+        (*dest)->blob = (uint8_t*)malloc(src->size * sizeof(uint8_t));
+        if (NULL == (*dest)->blob) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        memcpy((*dest)->blob, src->blob, src->size * sizeof(uint8_t));
+        (*dest)->size = src->size;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
+                                      pmix_data_type_t type)
+{
+    *dest = (pmix_persistence_t*)malloc(sizeof(pmix_persistence_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    memcpy(*dest, src, sizeof(pmix_persistence_t));
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
+                                 pmix_data_type_t type)
+{
+    *dest = (pmix_byte_object_t*)malloc(sizeof(pmix_byte_object_t));
+    if (NULL == *dest) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    (*dest)->bytes = (char*)malloc(src->size);
+    memcpy((*dest)->bytes, src->bytes, src->size);
+    (*dest)->size = src->size;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
+                                    pmix_data_type_t type)
+{
+    *dest = (pmix_pdata_t*)malloc(sizeof(pmix_pdata_t));
+    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    (*dest)->proc.rank = src->proc.rank;
+    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    return pmix20_bfrop_value_xfer(&(*dest)->value, &src->value);
+}
+
+pmix_status_t pmix20_bfrop_copy_pinfo(pmix_proc_info_t **dest, pmix_proc_info_t *src,
+                                    pmix_data_type_t type)
+{
+    *dest = (pmix_proc_info_t*)malloc(sizeof(pmix_proc_info_t));
+    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    (*dest)->proc.rank = src->proc.rank;
+    if (NULL != src->hostname) {
+        (*dest)->hostname = strdup(src->hostname);
+    }
+    if (NULL != src->executable_name) {
+        (*dest)->executable_name = strdup(src->executable_name);
+    }
+    (*dest)->pid = src->pid;
+    (*dest)->exit_code = src->exit_code;
+    (*dest)->state = src->state;
+    return PMIX_SUCCESS;
+}
+
+/* the pmix_data_array_t is a little different in that it
+ * is an array of values, and so we cannot just copy one
+ * value at a time. So handle all value types here */
+pmix_status_t pmix20_bfrop_copy_darray(pmix_data_array_t **dest,
+                                     pmix_data_array_t *src,
+                                     pmix_data_type_t type)
+{
+    pmix_data_array_t *p;
+    size_t n, m;
+    pmix_status_t rc;
+    char **prarray, **strarray;
+    pmix_value_t *pv, *sv;
+    pmix_app_t *pa, *sa;
+    pmix_info_t *p1, *s1;
+    pmix_pdata_t *pd, *sd;
+    pmix_buffer_t *pb, *sb;
+    pmix_byte_object_t *pbo, *sbo;
+    pmix_kval_t *pk, *sk;
+    pmix_modex_data_t *pm, *sm;
+    pmix_proc_info_t *pi, *si;
+    pmix_query_t *pq, *sq;
+
+    p = (pmix_data_array_t*)calloc(1, sizeof(pmix_data_array_t));
+    if (NULL == p) {
+        return PMIX_ERR_NOMEM;
+    }
+    p->type = src->type;
+    p->size = src->size;
+    /* process based on type of array element */
+    switch (src->type) {
+        p->type = src->type;
+        p->size = src->size;
+        if (0 == p->size || NULL == src->array) {
+            p->array = NULL;
+            p->size = 0;
+            break;
+        }
+        case PMIX_UINT8:
+        case PMIX_INT8:
+        case PMIX_BYTE:
+            p->array = (char*)malloc(src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size);
+            break;
+        case PMIX_UINT16:
+        case PMIX_INT16:
+            p->array = (char*)malloc(src->size * sizeof(uint16_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint16_t));
+            break;
+        case PMIX_UINT32:
+        case PMIX_INT32:
+            p->array = (char*)malloc(src->size * sizeof(uint32_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint32_t));
+            break;
+        case PMIX_UINT64:
+        case PMIX_INT64:
+            p->array = (char*)malloc(src->size * sizeof(uint64_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(uint64_t));
+            break;
+        case PMIX_BOOL:
+            p->array = (char*)malloc(src->size * sizeof(bool));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(bool));
+            break;
+        case PMIX_SIZE:
+            p->array = (char*)malloc(src->size * sizeof(size_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(size_t));
+            break;
+        case PMIX_PID:
+            p->array = (char*)malloc(src->size * sizeof(pid_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pid_t));
+            break;
+        case PMIX_STRING:
+            p->array = (char**)malloc(src->size * sizeof(char*));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            prarray = (char**)p->array;
+            strarray = (char**)src->array;
+            for (n=0; n < src->size; n++) {
+                if (NULL != strarray[n]) {
+                    prarray[n] = strdup(strarray[n]);
+                }
+            }
+            break;
+        case PMIX_INT:
+        case PMIX_UINT:
+            p->array = (char*)malloc(src->size * sizeof(int));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(int));
+            break;
+        case PMIX_FLOAT:
+            p->array = (char*)malloc(src->size * sizeof(float));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(float));
+            break;
+        case PMIX_DOUBLE:
+            p->array = (char*)malloc(src->size * sizeof(double));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(double));
+            break;
+        case PMIX_TIMEVAL:
+            p->array = (struct timeval*)malloc(src->size * sizeof(struct timeval));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            p->array = (time_t*)malloc(src->size * sizeof(time_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            p->array = (pmix_status_t*)malloc(src->size * sizeof(pmix_status_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_status_t));
+            break;
+        case PMIX_VALUE:
+            PMIX_VALUE_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pv = (pmix_value_t*)p->array;
+            sv = (pmix_value_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(&pv[n], &sv[n]))) {
+                    PMIX_VALUE_FREE(pv, src->size);
+                    free(p);
+                    return rc;
+                }
+            }
+            break;
+        case PMIX_PROC:
+            PMIX_PROC_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_proc_t));
+            break;
+        case PMIX_PROC_RANK:
+            p->array = (char*)malloc(src->size * sizeof(pmix_rank_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_proc_t));
+            break;
+        case PMIX_APP:
+            PMIX_APP_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pa = (pmix_app_t*)p->array;
+            sa = (pmix_app_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                if (NULL != sa[n].cmd) {
+                    pa[n].cmd = strdup(sa[n].cmd);
+                }
+                if (NULL != sa[n].argv) {
+                    pa[n].argv = pmix_argv_copy(sa[n].argv);
+                }
+                if (NULL != sa[n].env) {
+                    pa[n].env = pmix_argv_copy(sa[n].env);
+                }
+                if (NULL != sa[n].cwd) {
+                    pa[n].cwd = strdup(sa[n].cwd);
+                }
+                pa[n].maxprocs = sa[n].maxprocs;
+                if (0 < sa[n].ninfo && NULL != sa[n].info) {
+                    PMIX_INFO_CREATE(pa[n].info, sa[n].ninfo);
+                    if (NULL == pa[n].info) {
+                        PMIX_APP_FREE(pa, p->size);
+                        free(p);
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pa[n].ninfo = sa[n].ninfo;
+                    for (m=0; m < pa[n].ninfo; m++) {
+                        PMIX_INFO_XFER(&pa[n].info[m], &sa[n].info[m]);
+                    }
+                }
+            }
+            break;
+        case PMIX_INFO:
+            PMIX_INFO_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            p1 = (pmix_info_t*)p->array;
+            s1 = (pmix_info_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
+            }
+            break;
+        case PMIX_PDATA:
+            PMIX_PDATA_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pd = (pmix_pdata_t*)p->array;
+            sd = (pmix_pdata_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data, sd[n].value.type);
+            }
+            break;
+        case PMIX_BUFFER:
+            p->array = (pmix_buffer_t*)malloc(src->size * sizeof(pmix_buffer_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pb = (pmix_buffer_t*)p->array;
+            sb = (pmix_buffer_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                PMIX_CONSTRUCT(&pb[n], pmix_buffer_t);
+                pmix20_bfrop_copy_payload(&pb[n], &sb[n]);
+            }
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+            p->array = (pmix_byte_object_t*)malloc(src->size * sizeof(pmix_byte_object_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pbo = (pmix_byte_object_t*)p->array;
+            sbo = (pmix_byte_object_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
+                    pbo[n].size = sbo[n].size;
+                    pbo[n].bytes = (char*)malloc(pbo[n].size);
+                    memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
+                } else {
+                    pbo[n].bytes = NULL;
+                    pbo[n].size = 0;
+                }
+            }
+            break;
+        case PMIX_KVAL:
+            p->array = (pmix_kval_t*)calloc(src->size , sizeof(pmix_kval_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pk = (pmix_kval_t*)p->array;
+            sk = (pmix_kval_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                if (NULL != sk[n].key) {
+                    pk[n].key = strdup(sk[n].key);
+                }
+                if (NULL != sk[n].value) {
+                    PMIX_VALUE_CREATE(pk[n].value, 1);
+                    if (NULL == pk[n].value) {
+                        PMIX_VALUE_FREE(pk[n].value, 1);
+                        free(p);
+                        return PMIX_ERR_NOMEM;
+                    }
+                    if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(pk[n].value, sk[n].value))) {
+                        PMIX_VALUE_FREE(pk[n].value, 1);
+                        free(p);
+                        return rc;
+                    }
+                }
+            }
+            break;
+        case PMIX_MODEX:
+            PMIX_MODEX_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pm = (pmix_modex_data_t*)p->array;
+            sm = (pmix_modex_data_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                memcpy(&pm[n], &sm[n], sizeof(pmix_modex_data_t));
+                if (NULL != sm[n].blob && 0 < sm[n].size) {
+                    pm[n].blob = (uint8_t*)malloc(sm[n].size);
+                    if (NULL == pm[n].blob) {
+                        PMIX_MODEX_FREE(pm, src->size);
+                        free(p);
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(pm[n].blob, sm[n].blob, sm[n].size);
+                    pm[n].size = sm[n].size;
+                } else {
+                    pm[n].blob = NULL;
+                    pm[n].size = 0;
+                }
+            }
+            break;
+        case PMIX_PERSIST:
+            p->array = (pmix_persistence_t*)malloc(src->size * sizeof(pmix_persistence_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_persistence_t));
+            break;
+        case PMIX_POINTER:
+            p->array = (char**)malloc(src->size * sizeof(char*));
+            prarray = (char**)p->array;
+            strarray = (char**)src->array;
+            for (n=0; n < src->size; n++) {
+                prarray[n] = strarray[n];
+            }
+            break;
+        case PMIX_SCOPE:
+            p->array = (pmix_scope_t*)malloc(src->size * sizeof(pmix_scope_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            p->array = (pmix_data_range_t*)malloc(src->size * sizeof(pmix_data_range_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_data_range_t));
+            break;
+        case PMIX_COMMAND:
+            p->array = (pmix_cmd_t*)malloc(src->size * sizeof(pmix_cmd_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_cmd_t));
+            break;
+        case PMIX_INFO_DIRECTIVES:
+            p->array = (pmix_info_directives_t*)malloc(src->size * sizeof(pmix_info_directives_t));
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            memcpy(p->array, src->array, src->size * sizeof(pmix_info_directives_t));
+            break;
+        case PMIX_PROC_INFO:
+            PMIX_PROC_INFO_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pi = (pmix_proc_info_t*)p->array;
+            si = (pmix_proc_info_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                memcpy(&pi[n].proc, &si[n].proc, sizeof(pmix_proc_t));
+                if (NULL != si[n].hostname) {
+                    pi[n].hostname = strdup(si[n].hostname);
+                } else {
+                    pi[n].hostname = NULL;
+                }
+                if (NULL != si[n].executable_name) {
+                    pi[n].executable_name = strdup(si[n].executable_name);
+                } else {
+                    pi[n].executable_name = NULL;
+                }
+                pi[n].pid = si[n].pid;
+                pi[n].exit_code = si[n].exit_code;
+                pi[n].state = si[n].state;
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            free(p);
+            return PMIX_ERR_NOT_SUPPORTED;  // don't support iterative arrays
+        case PMIX_QUERY:
+            PMIX_QUERY_CREATE(p->array, src->size);
+            if (NULL == p->array) {
+                free(p);
+                return PMIX_ERR_NOMEM;
+            }
+            pq = (pmix_query_t*)p->array;
+            sq = (pmix_query_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                if (NULL != sq[n].keys) {
+                    pq[n].keys = pmix_argv_copy(sq[n].keys);
+                }
+                if (NULL != sq[n].qualifiers && 0 < sq[n].nqual) {
+                    PMIX_INFO_CREATE(pq[n].qualifiers, sq[n].nqual);
+                    if (NULL == pq[n].qualifiers) {
+                        PMIX_INFO_FREE(pq[n].qualifiers, sq[n].nqual);
+                        free(p);
+                        return PMIX_ERR_NOMEM;
+                    }
+                    for (m=0; m < sq[n].nqual; m++) {
+                        PMIX_INFO_XFER(&pq[n].qualifiers[m], &sq[n].qualifiers[m]);
+                    }
+                    pq[n].nqual = sq[n].nqual;
+                } else {
+                    pq[n].qualifiers = NULL;
+                    pq[n].nqual = 0;
+                }
+            }
+            break;
+        default:
+            free(p);
+            return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+
+    (*dest) = p;
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_copy_query(pmix_query_t **dest,
+                                    pmix_query_t *src,
+                                    pmix_data_type_t type)
+{
+    pmix_status_t rc;
+
+    *dest = (pmix_query_t*)malloc(sizeof(pmix_query_t));
+    if (NULL != src->keys) {
+        (*dest)->keys = pmix_argv_copy(src->keys);
+    }
+    (*dest)->nqual = src->nqual;
+    if (NULL != src->qualifiers) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_copy_info(&((*dest)->qualifiers), src->qualifiers, PMIX_INFO))) {
+            free(*dest);
+            return rc;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_copy_array(pmix_info_array_t **dest,
+                                    pmix_info_array_t *src,
+                                    pmix_data_type_t type)
+{
+    pmix_info_t *d1, *s1;
+
+    *dest = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
+    (*dest)->size = src->size;
+    (*dest)->array = (pmix_info_t*)malloc(src->size * sizeof(pmix_info_t));
+    d1 = (pmix_info_t*)(*dest)->array;
+    s1 = (pmix_info_t*)src->array;
+    memcpy(d1, s1, src->size * sizeof(pmix_info_t));
+    return PMIX_SUCCESS;
+}
+/*******************/

--- a/src/mca/bfrops/v20/internal.h
+++ b/src/mca/bfrops/v20/internal.h
@@ -1,0 +1,376 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+#ifndef PMIX20_BFROP_INTERNAL_H_
+#define PMIX20_BFROP_INTERNAL_H_
+
+#include <src/include/pmix_config.h>
+
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h> /* for struct timeval */
+#endif
+
+#include "src/class/pmix_pointer_array.h"
+
+#include "src/mca/bfrops/base/base.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+ BEGIN_C_DECLS
+
+/*
+ * Implementations of API functions
+ */
+
+pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer, const void *src,
+                                int32_t num_vals,
+                                pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer, void *dest,
+                                  int32_t *max_num_vals,
+                                  pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_copy(void **dest, void *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
+
+pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src);
+
+void pmix20_bfrop_value_load(pmix_value_t *v, const void *data,
+                            pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_value_unload(pmix_value_t *kv,
+                                       void **data,
+                                       size_t *sz);
+
+pmix_value_cmp_t pmix20_bfrop_value_cmp(pmix_value_t *p,
+                                       pmix_value_t *p1);
+
+/*
+ * Specialized functions
+ */
+pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
+                                         int32_t *num_vals, pmix_data_type_t type);
+
+/*
+ * Internal pack functions
+ */
+
+pmix_status_t pmix20_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_infodirs(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
+                                 int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_pstate(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_pinfo(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
+                                              int32_t num_vals, pmix_data_type_t type);
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+/********************/
+
+/*
+ * Internal unpack functions
+ */
+ pmix_status_t pmix20_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+
+ pmix_status_t pmix20_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+
+ pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
+                                    int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_pstate(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
+                                                int32_t *num_vals, pmix_data_type_t type);
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+/********************/
+
+/*
+ * Internal copy functions
+ */
+
+pmix_status_t pmix20_bfrop_std_copy(void **dest, void *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_string(char **dest, char *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_value(pmix_value_t **dest, pmix_value_t *src,
+                                    pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
+                                   pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
+                                  pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
+                                   pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_buf(pmix_buffer_t **dest, pmix_buffer_t *src,
+                                  pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_kval(pmix_kval_t **dest, pmix_kval_t *src,
+                                   pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_modex(pmix_modex_data_t **dest, pmix_modex_data_t *src,
+                                    pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_persist(pmix_persistence_t **dest, pmix_persistence_t *src,
+                                      pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_bo(pmix_byte_object_t **dest, pmix_byte_object_t *src,
+                                 pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
+                                    pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_pinfo(pmix_proc_info_t **dest, pmix_proc_info_t *src,
+                                    pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_darray(pmix_data_array_t **dest, pmix_data_array_t *src,
+                                     pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_copy_query(pmix_query_t **dest, pmix_query_t *src,
+                                    pmix_data_type_t type);
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_copy_array(pmix_info_array_t **dest,
+                                    pmix_info_array_t *src,
+                                    pmix_data_type_t type);
+
+/********************/
+
+/*
+ * Internal print functions
+ */
+pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix, int8_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix, int16_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix, int64_t *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix, uint32_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix, uint64_t *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix, float *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix, double *src, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix, struct timeval *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix, time_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix, pmix_status_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix, pmix_value_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix,
+                                    pmix_proc_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_app(char **output, char *prefix,
+                                   pmix_app_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_info(char **output, char *prefix,
+                                    pmix_info_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_buf(char **output, char *prefix,
+                                   pmix_buffer_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_kval(char **output, char *prefix,
+                                    pmix_kval_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_modex(char **output, char *prefix,
+                                     pmix_modex_data_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix,
+                                       pmix_persistence_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_scope(char **output, char *prefix,
+                                     pmix_scope_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_range(char **output, char *prefix,
+                                     pmix_data_range_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix,
+                                   pmix_cmd_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix,
+                                        pmix_info_directives_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix,
+                                  pmix_byte_object_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_pdata(char **output, char *prefix,
+                                     pmix_pdata_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_ptr(char **output, char *prefix,
+                                   void *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_pstate(char **output, char *prefix,
+                                      pmix_proc_state_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_pinfo(char **output, char *prefix,
+                                     pmix_proc_info_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_darray(char **output, char *prefix,
+                                      pmix_data_array_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix,
+                                     pmix_query_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_rank(char **output, char *prefix,
+                                    pmix_rank_t *src, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_print_alloc_directive(char **output, char *prefix,
+                                               pmix_alloc_directive_t *src,
+                                               pmix_data_type_t type);
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix,
+                                     pmix_info_array_t *src,
+                                     pmix_data_type_t type);
+/********************/
+
+/*
+ * Internal helper functions
+ */
+
+pmix_status_t pmix20_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
+
+pmix_status_t pmix20_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type);
+
+pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type);
+
+END_C_DECLS
+
+#endif

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -1,0 +1,1054 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2007 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <src/include/types.h>
+
+#ifdef HAVE_ARPA_INET_H
+#include <arpa/inet.h>
+#endif
+
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix20.h"
+#include "internal.h"
+
+pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer,
+                              const void *src, int32_t num_vals,
+                              pmix_data_type_t type)
+ {
+    pmix_status_t rc;
+
+    /* check for error */
+    if (NULL == buffer) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Pack the number of values */
+    if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(buffer, PMIX_INT32))) {
+            return rc;
+        }
+    }
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_pack_int32(buffer, &num_vals, 1, PMIX_INT32))) {
+        return rc;
+    }
+
+    /* Pack the value(s) */
+    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, type);
+}
+
+pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer,
+                                     const void *src, int32_t num_vals,
+                                     pmix_data_type_t type)
+{
+    pmix_status_t rc;
+    pmix_bfrop_type_info_t *info;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_buffer( %p, %p, %lu, %d )\n",
+                        (void*)buffer, src, (long unsigned int)num_vals, (int)type);
+
+    /* Pack the declared data type */
+    if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(buffer, type))) {
+            return rc;
+        }
+    }
+
+    /* Lookup the pack function for this type and call it */
+
+    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+        return PMIX_ERR_PACK_FAILURE;
+    }
+
+    return info->odti_pack_fn(buffer, src, num_vals, type);
+}
+
+
+/* PACK FUNCTIONS FOR GENERIC SYSTEM TYPES */
+
+/*
+ * BOOL
+ */
+pmix_status_t pmix20_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+ {
+    uint8_t *dst;
+    int32_t i;
+    bool *s = (bool*)src;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_bool * %d\n", num_vals);
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = (uint8_t*)pmix_bfrop_buffer_extend(buffer, num_vals))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* store the data */
+    for (i=0; i < num_vals; i++) {
+        if (s[i]) {
+            dst[i] = 1;
+        } else {
+            dst[i] = 0;
+        }
+    }
+
+    /* update buffer pointers */
+    buffer->pack_ptr += num_vals;
+    buffer->bytes_used += num_vals;
+
+    return PMIX_SUCCESS;
+}
+
+/*
+ * INT
+ */
+pmix_status_t pmix20_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+
+    /* System types need to always be described so we can properly
+       unpack them */
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_INT))) {
+        return ret;
+    }
+
+    /* Turn around and pack the real type */
+    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_INT);
+}
+
+/*
+ * SIZE_T
+ */
+pmix_status_t pmix20_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+
+    /* System types need to always be described so we can properly
+       unpack them. */
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_SIZE_T))) {
+        return ret;
+    }
+
+    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_SIZE_T);
+}
+
+/*
+ * PID_T
+ */
+pmix_status_t pmix20_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+
+    /* System types need to always be described so we can properly
+       unpack them. */
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_PID_T))) {
+        return ret;
+    }
+
+    /* Turn around and pack the real type */
+    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_PID_T);
+}
+
+
+/* PACK FUNCTIONS FOR NON-GENERIC SYSTEM TYPES */
+
+/*
+ * BYTE, CHAR, INT8
+ */
+pmix_status_t pmix20_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+ {
+    char *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_byte * %d\n", num_vals);
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    /* store the data */
+    memcpy(dst, src, num_vals);
+
+    /* update buffer pointers */
+    buffer->pack_ptr += num_vals;
+    buffer->bytes_used += num_vals;
+
+    return PMIX_SUCCESS;
+}
+
+/*
+ * INT16
+ */
+pmix_status_t pmix20_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+ {
+    int32_t i;
+    uint16_t tmp, *srctmp = (uint16_t*) src;
+    char *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_int16 * %d\n", num_vals);
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals*sizeof(tmp)))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0; i < num_vals; ++i) {
+        tmp = pmix_htons(srctmp[i]);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += num_vals * sizeof(tmp);
+    buffer->bytes_used += num_vals * sizeof(tmp);
+
+    return PMIX_SUCCESS;
+}
+
+/*
+ * INT32
+ */
+pmix_status_t pmix20_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+ {
+    int32_t i;
+    uint32_t tmp, *srctmp = (uint32_t*) src;
+    char *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_int32 * %d\n", num_vals);
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, num_vals*sizeof(tmp)))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0; i < num_vals; ++i) {
+        tmp = htonl(srctmp[i]);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += num_vals * sizeof(tmp);
+    buffer->bytes_used += num_vals * sizeof(tmp);
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_int16(buffer, src, num_vals, type);
+}
+
+/*
+ * INT64
+ */
+pmix_status_t pmix20_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+ {
+    int32_t i;
+    uint64_t tmp, tmp2;
+    char *dst;
+    size_t bytes_packed = num_vals * sizeof(tmp);
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_pack_int64 * %d\n", num_vals);
+    /* check to see if buffer needs extending */
+    if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, bytes_packed))) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    for (i = 0; i < num_vals; ++i) {
+        memcpy(&tmp2, (char *)src+i*sizeof(uint64_t), sizeof(uint64_t));
+        tmp = pmix_hton64(tmp2);
+        memcpy(dst, &tmp, sizeof(tmp));
+        dst += sizeof(tmp);
+    }
+    buffer->pack_ptr += bytes_packed;
+    buffer->bytes_used += bytes_packed;
+
+    return PMIX_SUCCESS;
+}
+
+/*
+ * STRING
+ */
+pmix_status_t pmix20_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i, len;
+    char **ssrc = (char**) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        if (NULL == ssrc[i]) {  /* got zero-length string/NULL pointer - store NULL */
+        len = 0;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            return ret;
+        }
+    } else {
+        len = (int32_t)strlen(ssrc[i]) + 1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            return ret;
+        }
+        if (PMIX_SUCCESS != (ret =
+            pmix20_bfrop_pack_byte(buffer, ssrc[i], len, PMIX_BYTE))) {
+            return ret;
+    }
+}
+}
+
+return PMIX_SUCCESS;
+}
+
+/* FLOAT */
+pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i;
+    float *ssrc = (float*)src;
+    char *convert;
+
+    for (i = 0; i < num_vals; ++i) {
+        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+            free(convert);
+            return ret;
+        }
+        free(convert);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* DOUBLE */
+pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i;
+    double *ssrc = (double*)src;
+    char *convert;
+
+    for (i = 0; i < num_vals; ++i) {
+        if (0 > asprintf(&convert, "%f", ssrc[i])) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+            free(convert);
+            return ret;
+        }
+        free(convert);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* TIMEVAL */
+pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
+{
+    int64_t tmp[2];
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i;
+    struct timeval *ssrc = (struct timeval *)src;
+
+    for (i = 0; i < num_vals; ++i) {
+        tmp[0] = (int64_t)ssrc[i].tv_sec;
+        tmp[1] = (int64_t)ssrc[i].tv_usec;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(buffer, tmp, 2, PMIX_INT64))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* TIME */
+pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i;
+    time_t *ssrc = (time_t *)src;
+    uint64_t ui64;
+
+    /* time_t is a system-dependent size, so cast it
+     * to uint64_t as a generic safe size
+     */
+     for (i = 0; i < num_vals; ++i) {
+        ui64 = (uint64_t)ssrc[i];
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(buffer, &ui64, 1, PMIX_UINT64))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* STATUS */
+pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret = PMIX_SUCCESS;
+    int32_t i;
+    pmix_status_t *ssrc = (pmix_status_t *)src;
+    int32_t status;
+
+    for (i = 0; i < num_vals; ++i) {
+        status = (int32_t)ssrc[i];
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &status, 1, PMIX_INT32))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+/* PACK FUNCTIONS FOR GENERIC PMIX TYPES */
+static pmix_status_t pack_val(pmix_buffer_t *buffer,
+                              pmix_value_t *p)
+{
+    pmix_status_t ret;
+
+    switch (p->type) {
+        case PMIX_UNDEF:
+            break;
+        case PMIX_BOOL:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.flag, 1, PMIX_BOOL))) {
+                return ret;
+            }
+            break;
+        case PMIX_BYTE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.byte, 1, PMIX_BYTE))) {
+                return ret;
+            }
+            break;
+        case PMIX_STRING:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.string, 1, PMIX_STRING))) {
+                return ret;
+            }
+            break;
+        case PMIX_SIZE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.size, 1, PMIX_SIZE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PID:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.pid, 1, PMIX_PID))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.integer, 1, PMIX_INT))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT8:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int8, 1, PMIX_INT8))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT16:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int16, 1, PMIX_INT16))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT32:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int32, 1, PMIX_INT32))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT64:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int64, 1, PMIX_INT64))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint, 1, PMIX_UINT))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT8:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint8, 1, PMIX_UINT8))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT16:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint16, 1, PMIX_UINT16))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT32:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint32, 1, PMIX_UINT32))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT64:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint64, 1, PMIX_UINT64))) {
+                return ret;
+            }
+            break;
+        case PMIX_FLOAT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.fval, 1, PMIX_FLOAT))) {
+                return ret;
+            }
+            break;
+        case PMIX_DOUBLE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
+                return ret;
+            }
+            break;
+        case PMIX_TIMEVAL:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
+                return ret;
+            }
+            break;
+        case PMIX_TIME:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.time, 1, PMIX_TIME))) {
+                return ret;
+            }
+            break;
+        case PMIX_STATUS:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.status, 1, PMIX_STATUS))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.proc, 1, PMIX_PROC))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_RANK:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.rank, 1, PMIX_PROC_RANK))) {
+                return ret;
+            }
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
+                return ret;
+            }
+            break;
+        case PMIX_PERSIST:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.persist, 1, PMIX_PERSIST))) {
+                return ret;
+            }
+            break;
+        case PMIX_POINTER:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.ptr, 1, PMIX_POINTER))) {
+                return ret;
+            }
+            break;
+        case PMIX_SCOPE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.scope, 1, PMIX_SCOPE))) {
+                return ret;
+            }
+            break;
+        case PMIX_DATA_RANGE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.range, 1, PMIX_DATA_RANGE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_STATE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.state, 1, PMIX_PROC_STATE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_INFO:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.pinfo, 1, PMIX_PROC_INFO))) {
+                return ret;
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_DATA_ARRAY))) {
+                return ret;
+            }
+            break;
+        case PMIX_QUERY:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_QUERY))) {
+                return ret;
+            }
+            break;
+        /**** DEPRECATED ****/
+        case PMIX_INFO_ARRAY:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.array, 1, PMIX_INFO_ARRAY))) {
+                return ret;
+            }
+            break;
+        /********************/
+        default:
+        pmix_output(0, "PACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
+        return PMIX_ERROR;
+    }
+    return PMIX_SUCCESS;
+}
+
+/*
+ * PMIX_VALUE
+ */
+ pmix_status_t pmix20_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_value_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_value_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, ptr[i].type))) {
+            return ret;
+        }
+        /* now pack the right field */
+        if (PMIX_SUCCESS != (ret = pack_val(buffer, &ptr[i]))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t pmix20_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_info_t *info;
+    int32_t i;
+    pmix_status_t ret;
+    char *foo;
+
+    info = (pmix_info_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack key */
+        foo = info[i].key;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack info directives flag */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_infodirs(buffer, &info[i].flags, 1, PMIX_INFO_DIRECTIVES))) {
+            return ret;
+        }
+        /* pack the type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &info[i].value.type, 1, PMIX_INT))) {
+            return ret;
+        }
+        /* pack value */
+        if (PMIX_SUCCESS != (ret = pack_val(buffer, &info[i].value))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_pdata_t *pdata;
+    int32_t i;
+    pmix_status_t ret;
+    char *foo;
+
+    pdata = (pmix_pdata_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the proc */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(buffer, &pdata[i].proc, 1, PMIX_PROC))) {
+            return ret;
+        }
+        /* pack key */
+        foo = pdata[i].key;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack the type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &pdata[i].value.type, 1, PMIX_INT))) {
+            return ret;
+        }
+        /* pack value */
+        if (PMIX_SUCCESS != (ret = pack_val(buffer, &pdata[i].value))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_buffer_t **ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_buffer_t **) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the number of bytes */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i]->bytes_used, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        /* pack the bytes */
+        if (0 < ptr[i]->bytes_used) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, ptr[i]->base_ptr, ptr[i]->bytes_used, PMIX_BYTE))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_proc_t *proc;
+    int32_t i;
+    pmix_status_t ret;
+
+    proc = (pmix_proc_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        char *ptr = proc[i].nspace;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &ptr, 1, PMIX_STRING))) {
+            return ret;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_rank(buffer, &proc[i].rank, 1, PMIX_PROC_RANK))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_app_t *app;
+    int32_t i, j, nvals;
+    pmix_status_t ret;
+
+    app = (pmix_app_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].cmd, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* argv */
+        nvals = pmix_argv_count(app[i].argv);
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &nvals, 1, PMIX_INT32))) {
+            return ret;
+        }
+        for (j=0; j < nvals; j++) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].argv[j], 1, PMIX_STRING))) {
+                return ret;
+            }
+        }
+        /* env */
+        nvals = pmix_argv_count(app[i].env);
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &nvals, 1, PMIX_INT32))) {
+            return ret;
+        }
+        for (j=0; j < nvals; j++) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].env[j], 1, PMIX_STRING))) {
+                return ret;
+            }
+        }
+        /* cwd */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].cwd, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* maxprocs */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &app[i].maxprocs, 1, PMIX_INT))) {
+            return ret;
+        }
+        /* info array */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < app[i].ninfo) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_kval_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+    char *st;
+
+    ptr = (pmix_kval_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the key */
+        st = ptr[i].key;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &st, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack the value */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_value(buffer, ptr[i].value, 1, PMIX_VALUE))) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_modex_data_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_modex_data_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if( 0 < ptr[i].size){
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
+                                  int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_infodirs(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_int32(buffer, src, num_vals, PMIX_UINT32);
+}
+
+pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
+                                 int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+    int i;
+    pmix_byte_object_t *bo;
+
+    bo = (pmix_byte_object_t*)src;
+    for (i=0; i < num_vals; i++) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &bo[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < bo[i].size) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
+                        int32_t num_vals, pmix_data_type_t type)
+{
+    uint8_t foo=1;
+    /* it obviously makes no sense to pack a pointer and
+     * send it somewhere else, so we just pack a sentinel */
+    return pmix20_bfrop_pack_byte(buffer, &foo, 1, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_pstate(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_pinfo(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_proc_info_t *pinfo = (pmix_proc_info_t*)src;
+    pmix_status_t ret;
+    int32_t i;
+
+    for (i=0; i < num_vals; i++) {
+        /* pack the proc identifier */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(buffer, &pinfo[i].proc, 1, PMIX_PROC))) {
+            return ret;
+        }
+        /* pack the hostname and exec */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &pinfo[i].hostname, 1, PMIX_STRING))) {
+            return ret;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &pinfo[i].executable_name, 1, PMIX_STRING))) {
+            return ret;
+        }
+        /* pack the pid and state */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pid(buffer, &pinfo[i].pid, 1, PMIX_PID))) {
+            return ret;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pstate(buffer, &pinfo[i].state, 1, PMIX_PROC_STATE))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_data_array_t *p = (pmix_data_array_t*)src;
+    pmix_status_t ret;
+    int32_t i;
+
+    for (i=0; i < num_vals; i++) {
+        /* pack the actual type in the array */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_datatype(buffer, &p[i].type, 1, PMIX_DATA_TYPE))) {
+            return ret;
+        }
+        /* pack the number of array elements */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &p[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 == p[i].size || PMIX_UNDEF == p[i].type) {
+            /* nothing left to do */
+            continue;
+        }
+        /* pack the actual elements */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p[i].array, p[i].size, p[i].type))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_int32(buffer, src, num_vals, PMIX_UINT32);
+}
+
+pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_query_t *pq = (pmix_query_t*)src;
+    pmix_status_t ret;
+    int32_t i;
+    int32_t nkeys;
+
+    for (i=0; i < num_vals; i++) {
+        /* pack the number of keys */
+        nkeys = pmix_argv_count(pq[i].keys);
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &nkeys, 1, PMIX_INT32))) {
+            return ret;
+        }
+        if (0 < nkeys) {
+            /* pack the keys */
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, pq[i].keys, nkeys, PMIX_STRING))) {
+                return ret;
+            }
+        }
+        /* pack the number of qualifiers */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &pq[i].nqual, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < pq[i].nqual) {
+            /* pack any provided qualifiers */
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, pq[i].qualifiers, pq[i].nqual, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
+                                              int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+}
+
+
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                          int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_info_array_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the size */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            /* pack the values */
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+/********************/

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -1,0 +1,1495 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <src/include/pmix_stdint.h>
+
+#include <stdio.h>
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
+
+#include "src/util/error.h"
+#include "src/include/pmix_globals.h"
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix20.h"
+#include "internal.h"
+
+ pmix_status_t pmix20_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type)
+ {
+    pmix_bfrop_type_info_t *info;
+
+    /* check for error */
+    if (NULL == output) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Lookup the print function for this type and call it */
+
+    if(NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, type))) {
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+
+    return info->odti_print_fn(output, prefix, src, type);
+}
+
+/*
+ * STANDARD PRINT FUNCTIONS FOR SYSTEM TYPES
+ */
+ pmix_status_t pmix20_bfrop_print_bool(char **output, char *prefix, bool *src, pmix_data_type_t type)
+ {
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    }
+    else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_BOOL\tValue: %s", prefix,
+                     (*src) ? "TRUE" : "FALSE")) {
+        return PMIX_ERR_NOMEM;
+}
+if (prefx != prefix) {
+    free(prefx);
+}
+
+return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_byte(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_BYTE\tValue: %x", prefix, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_string(char **output, char *prefix, char *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_STRING\tValue: %s", prefx, src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_size(char **output, char *prefix, size_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_SIZE\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_pid(char **output, char *prefix, pid_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_PID\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_int(char **output, char *prefix, int *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INT\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_uint(char **output, char *prefix, uint *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_UINT\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_uint8(char **output, char *prefix, uint8_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_UINT8\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_uint16(char **output, char *prefix, uint16_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_UINT16\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_uint32(char **output, char *prefix,
+                                      uint32_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_UINT32\tValue: %u", prefx, (unsigned int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_int8(char **output, char *prefix,
+                                    int8_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INT8\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_int16(char **output, char *prefix,
+                                     int16_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INT16\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_int32(char **output, char *prefix, int32_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INT32\tValue: %d", prefx, (int) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+pmix_status_t pmix20_bfrop_print_uint64(char **output, char *prefix,
+                                      uint64_t *src,
+                                      pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_UINT64\tValue: %lu", prefx, (unsigned long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_int64(char **output, char *prefix,
+                                     int64_t *src,
+                                     pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INT64\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_float(char **output, char *prefix,
+                                     float *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_FLOAT\tValue: %f", prefx, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_double(char **output, char *prefix,
+                                      double *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_DOUBLE\tValue: %f", prefx, *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_time(char **output, char *prefix,
+                                    time_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+    char *t;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    t = ctime(src);
+    t[strlen(t)-1] = '\0';  // remove trailing newline
+
+    if (0 > asprintf(output, "%sData type: PMIX_TIME\tValue: %s", prefx, t)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_timeval(char **output, char *prefix,
+                                       struct timeval *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+                     (long)src->tv_sec, (long)src->tv_usec)) {
+        return PMIX_ERR_NOMEM;
+}
+if (prefx != prefix) {
+    free(prefx);
+}
+
+return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix,
+                                      pmix_status_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_STATUS\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_STATUS\tValue: %s", prefx, PMIx_Error_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+/* PRINT FUNCTIONS FOR GENERIC PMIX TYPES */
+
+/*
+ * PMIX_VALUE
+ */
+ pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix,
+                                      pmix_value_t *src, pmix_data_type_t type)
+ {
+    char *prefx;
+    int rc;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_VALUE\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    switch (src->type) {
+        case PMIX_UNDEF:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UNDEF", prefx);
+        break;
+        case PMIX_BYTE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_BYTE\tValue: %x",
+                      prefx, src->data.byte);
+        break;
+        case PMIX_STRING:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STRING\tValue: %s",
+                      prefx, src->data.string);
+        break;
+        case PMIX_SIZE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SIZE\tValue: %lu",
+                      prefx, (unsigned long)src->data.size);
+        break;
+        case PMIX_PID:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PID\tValue: %lu",
+                      prefx, (unsigned long)src->data.pid);
+        break;
+        case PMIX_INT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT\tValue: %d",
+                      prefx, src->data.integer);
+        break;
+        case PMIX_INT8:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT8\tValue: %d",
+                      prefx, (int)src->data.int8);
+        break;
+        case PMIX_INT16:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT16\tValue: %d",
+                      prefx, (int)src->data.int16);
+        break;
+        case PMIX_INT32:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT32\tValue: %d",
+                      prefx, src->data.int32);
+        break;
+        case PMIX_INT64:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_INT64\tValue: %ld",
+                      prefx, (long)src->data.int64);
+        break;
+        case PMIX_UINT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT\tValue: %u",
+                      prefx, src->data.uint);
+        break;
+        case PMIX_UINT8:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT8\tValue: %u",
+                      prefx, (unsigned int)src->data.uint8);
+        break;
+        case PMIX_UINT16:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT16\tValue: %u",
+                      prefx, (unsigned int)src->data.uint16);
+        break;
+        case PMIX_UINT32:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT32\tValue: %u",
+                      prefx, src->data.uint32);
+        break;
+        case PMIX_UINT64:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_UINT64\tValue: %lu",
+                      prefx, (unsigned long)src->data.uint64);
+        break;
+        case PMIX_FLOAT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_FLOAT\tValue: %f",
+                      prefx, src->data.fval);
+        break;
+        case PMIX_DOUBLE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DOUBLE\tValue: %f",
+                      prefx, src->data.dval);
+        break;
+        case PMIX_TIMEVAL:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIMEVAL\tValue: %ld.%06ld", prefx,
+                      (long)src->data.tv.tv_sec, (long)src->data.tv.tv_usec);
+        break;
+        case PMIX_TIME:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_TIME\tValue: %s", prefx,
+                      ctime(&src->data.time));
+        break;
+        case PMIX_STATUS:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATUS\tValue: %s", prefx,
+                      PMIx_Error_string(src->data.status));
+        break;
+        case PMIX_PROC:
+        if (NULL == src->data.proc) {
+            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\tNULL", prefx);
+        } else {
+            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC\t%s:%lu",
+                          prefx, src->data.proc->nspace, (unsigned long)src->data.proc->rank);
+        }
+        break;
+        case PMIX_BYTE_OBJECT:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: BYTE_OBJECT\tSIZE: %ld",
+                      prefx, (long)src->data.bo.size);
+        break;
+        case PMIX_PERSIST:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PERSIST\tValue: %s",
+                      prefx, PMIx_Persistence_string(src->data.persist));
+        break;
+        case PMIX_SCOPE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_SCOPE\tValue: %s",
+                      prefx, PMIx_Scope_string(src->data.scope));
+        break;
+        case PMIX_DATA_RANGE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_DATA_RANGE\tValue: %s",
+                      prefx, PMIx_Data_range_string(src->data.range));
+        break;
+        case PMIX_PROC_STATE:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_STATE\tValue: %s",
+                      prefx, PMIx_Proc_state_string(src->data.state));
+        break;
+        case PMIX_PROC_INFO:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_PROC_INFO\tProc: %s:%lu\n%s\tHost: %s\tExecutable: %s\tPid: %lu",
+                      prefx, src->data.pinfo->proc.nspace, (unsigned long)src->data.pinfo->proc.rank,
+                      prefx, src->data.pinfo->hostname, src->data.pinfo->executable_name,
+                      (unsigned long)src->data.pinfo->pid);
+        break;
+        case PMIX_DATA_ARRAY:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: DATA_ARRAY\tARRAY SIZE: %ld",
+                      prefx, (long)src->data.darray->size);
+        break;
+        /**** DEPRECATED ****/
+        case PMIX_INFO_ARRAY:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: INFO_ARRAY\tARRAY SIZE: %ld",
+                      prefx, (long)src->data.array->size);
+        break;
+        /********************/
+        default:
+        rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
+        break;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_info(char **output, char *prefix,
+                                    pmix_info_t *src, pmix_data_type_t type)
+{
+    char *tmp;
+    int rc;
+
+    pmix20_bfrop_print_value(&tmp, NULL, &src->value, PMIX_VALUE);
+    rc = asprintf(output, "%sKEY: %s DIRECTIVES: %0x %s", prefix, src->key,
+                  src->flags, (NULL == tmp) ? "PMIX_VALUE: NULL" : tmp);
+    if (NULL != tmp) {
+        free(tmp);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_pdata(char **output, char *prefix,
+                                     pmix_pdata_t *src, pmix_data_type_t type)
+{
+    char *tmp1, *tmp2;
+    int rc;
+
+    pmix20_bfrop_print_proc(&tmp1, NULL, &src->proc, PMIX_PROC);
+    pmix20_bfrop_print_value(&tmp2, NULL, &src->value, PMIX_VALUE);
+    rc = asprintf(output, "%s  %s  KEY: %s %s", prefix, tmp1, src->key,
+                  (NULL == tmp2) ? "NULL" : tmp2);
+    if (NULL != tmp1) {
+        free(tmp1);
+    }
+    if (NULL != tmp2) {
+        free(tmp2);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_buf(char **output, char *prefix,
+                                   pmix_buffer_t *src, pmix_data_type_t type)
+{
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_app(char **output, char *prefix,
+                                   pmix_app_t *src, pmix_data_type_t type)
+{
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_proc(char **output, char *prefix,
+                                    pmix_proc_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+    int rc;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    switch(src->rank) {
+        case PMIX_RANK_UNDEF:
+            rc = asprintf(output,
+                          "%sPROC: %s:PMIX_RANK_UNDEF", prefx, src->nspace);
+            break;
+        case PMIX_RANK_WILDCARD:
+            rc = asprintf(output,
+                          "%sPROC: %s:PMIX_RANK_WILDCARD", prefx, src->nspace);
+            break;
+        case PMIX_RANK_LOCAL_NODE:
+            rc = asprintf(output,
+                          "%sPROC: %s:PMIX_RANK_LOCAL_NODE", prefx, src->nspace);
+            break;
+        default:
+            rc = asprintf(output,
+                          "%sPROC: %s:%lu", prefx, src->nspace,
+                          (unsigned long)(src->rank));
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_kval(char **output, char *prefix,
+                                    pmix_kval_t *src, pmix_data_type_t type)
+{
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_modex(char **output, char *prefix,
+                                     pmix_modex_data_t *src, pmix_data_type_t type)
+{
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_persist(char **output, char *prefix, pmix_persistence_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_PERSIST\tValue: %ld", prefx, (long) *src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_scope(char **output, char *prefix,
+                                     pmix_scope_t *src,
+                                     pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_SCOPE\tValue: %s",
+                     prefx, PMIx_Scope_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_range(char **output, char *prefix,
+                                     pmix_data_range_t *src,
+                                     pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_DATA_RANGE\tValue: %s",
+                     prefx, PMIx_Data_range_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_cmd(char **output, char *prefix,
+                                   pmix_cmd_t *src,
+                                   pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_CMD\tValue: %s",
+                     prefx, pmix_command_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_infodirs(char **output, char *prefix,
+                                        pmix_info_directives_t *src,
+                                        pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_INFO_DIRECTIVES\tValue: %s",
+                     prefx, PMIx_Info_directives_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_bo(char **output, char *prefix,
+                                  pmix_byte_object_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    /* if src is NULL, just print data type and return */
+    if (NULL == src) {
+        if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tValue: NULL pointer", prefx)) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (prefx != prefix) {
+            free(prefx);
+        }
+        return PMIX_SUCCESS;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_BYTE_OBJECT\tSize: %ld", prefx, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_ptr(char **output, char *prefix,
+                                   void *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_POINTER\tAddress: %p", prefx, src)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_pstate(char **output, char *prefix,
+                                      pmix_proc_state_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_PROC_STATE\tValue: %s",
+                     prefx, PMIx_Proc_state_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_pinfo(char **output, char *prefix,
+                                     pmix_proc_info_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+    pmix_status_t rc = PMIX_SUCCESS;
+    char *p2, *tmp;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(&p2, "%s\t", prefx)) {
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_print_proc(&tmp, p2, &src->proc, PMIX_PROC))) {
+        free(p2);
+        goto done;
+    }
+
+    if (0 > asprintf(output,
+                     "%sData type: PMIX_PROC_INFO\tValue:\n%s\n%sHostname: %s\tExecutable: %s\n%sPid: %lu\tExit code: %d\tState: %s",
+                     prefx, tmp, p2, src->hostname, src->executable_name,
+                     p2, (unsigned long)src->pid, src->exit_code, PMIx_Proc_state_string(src->state))) {
+        free(p2);
+        rc = PMIX_ERR_NOMEM;
+    }
+
+  done:
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return rc;
+}
+
+pmix_status_t pmix20_bfrop_print_darray(char **output, char *prefix,
+                                      pmix_data_array_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_DATA_ARRAY\tSize: %lu",
+                     prefx, (unsigned long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_query(char **output, char *prefix,
+                                     pmix_query_t *src, pmix_data_type_t type)
+{
+    char *prefx, *p2;
+    pmix_status_t rc = PMIX_SUCCESS;
+    char *tmp, *t2, *t3;
+    size_t n;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(&p2, "%s\t", prefx)) {
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+
+    if (0 > asprintf(&tmp,
+                   "%sData type: PMIX_QUERY\tValue:", prefx)) {
+        free(p2);
+        rc = PMIX_ERR_NOMEM;
+        goto done;
+    }
+
+    /* print out the keys */
+    if (NULL != src->keys) {
+        for (n=0; NULL != src->keys[n]; n++) {
+            if (0 > asprintf(&t2, "%s\n%sKey: %s", tmp, p2, src->keys[n])) {
+                free(p2);
+                free(tmp);
+                rc = PMIX_ERR_NOMEM;
+                goto done;
+            }
+            free(tmp);
+            tmp = t2;
+        }
+    }
+
+    /* now print the qualifiers */
+    if (0 < src->nqual) {
+        for (n=0; n < src->nqual; n++) {
+            if (PMIX_SUCCESS != (rc = pmix20_bfrop_print_info(&t2, p2, &src->qualifiers[n], PMIX_PROC))) {
+                free(p2);
+                goto done;
+            }
+            if (0 > asprintf(&t3, "%s\n%s", tmp, t2)) {
+                free(p2);
+                free(tmp);
+                free(t2);
+                rc = PMIX_ERR_NOMEM;
+                goto done;
+            }
+            free(tmp);
+            free(t2);
+            tmp = t3;
+        }
+    }
+    *output = tmp;
+
+  done:
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return rc;
+}
+
+pmix_status_t pmix20_bfrop_print_rank(char **output, char *prefix,
+                                    pmix_rank_t *src, pmix_data_type_t type)
+{
+    char *prefx;
+    int rc;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    switch(*src) {
+        case PMIX_RANK_UNDEF:
+            rc = asprintf(output,
+                          "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_UNDEF",
+                          prefx);
+            break;
+        case PMIX_RANK_WILDCARD:
+            rc = asprintf(output,
+                          "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_WILDCARD",
+                          prefx);
+            break;
+        case PMIX_RANK_LOCAL_NODE:
+            rc = asprintf(output,
+                          "%sData type: PMIX_PROC_RANK\tValue: PMIX_RANK_LOCAL_NODE",
+                          prefx);
+            break;
+        default:
+            rc = asprintf(output, "%sData type: PMIX_PROC_RANK\tValue: %lu",
+                          prefx, (unsigned long)(*src));
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+    if (0 > rc) {
+        return PMIX_ERR_NOMEM;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_print_alloc_directive(char **output, char *prefix,
+                                               pmix_alloc_directive_t *src,
+                                               pmix_data_type_t type)
+{
+    char *prefx;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    if (0 > asprintf(output, "%sData type: PMIX_ALLOC_DIRECTIVE\tValue: %s",
+                     prefx, PMIx_Alloc_directive_string(*src))) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix,
+                                     pmix_info_array_t *src, pmix_data_type_t type)
+{
+    size_t j;
+    char *tmp, *tmp2, *tmp3, *pfx;
+    pmix_info_t *s1;
+
+    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (0 > asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix)) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
+    s1 = (pmix_info_t*)src->array;
+
+    for (j=0; j < src->size; j++) {
+        pmix20_bfrop_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
+        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+            free(tmp);
+            free(tmp2);
+            return PMIX_ERR_NOMEM;
+        }
+        free(tmp);
+        free(tmp2);
+        tmp = tmp3;
+    }
+    *output = tmp;
+    return PMIX_SUCCESS;
+}
+/********************/

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -1,0 +1,1463 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <src/include/types.h>
+
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix20.h"
+#include "internal.h"
+
+static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
+                                    int32_t *num_vals, pmix_data_type_t type)
+{
+    switch(type) {
+        case PMIX_INT8:
+        case PMIX_UINT8:
+        return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, type);
+        break;
+
+        case PMIX_INT16:
+        case PMIX_UINT16:
+        return pmix20_bfrop_unpack_int16(buffer, dest, num_vals, type);
+        break;
+
+        case PMIX_INT32:
+        case PMIX_UINT32:
+        return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, type);
+        break;
+
+        case PMIX_INT64:
+        case PMIX_UINT64:
+        return pmix20_bfrop_unpack_int64(buffer, dest, num_vals, type);
+        break;
+
+        default:
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
+}
+
+pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
+                                void *dst, int32_t *num_vals,
+                                pmix_data_type_t type)
+ {
+    pmix_status_t rc, ret;
+    int32_t local_num, n=1;
+    pmix_data_type_t local_type;
+
+    /* check for error */
+    if (NULL == buffer || NULL == dst || NULL == num_vals) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* if user provides a zero for num_vals, then there is no storage allocated
+     * so return an appropriate error
+     */
+     if (0 == *num_vals) {
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: inadequate space ( %p, %p, %lu, %d )\n",
+                            (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
+        return PMIX_ERR_UNPACK_INADEQUATE_SPACE;
+    }
+
+    /** Unpack the declared number of values
+     * REMINDER: it is possible that the buffer is corrupted and that
+     * the BFROP will *think* there is a proper int32_t variable at the
+     * beginning of the unpack region - but that the value is bogus (e.g., just
+     * a byte field in a string array that so happens to have a value that
+     * matches the int32_t data type flag). Therefore, this error check is
+     * NOT completely safe. This is true for ALL unpack functions, not just
+     * int32_t as used here.
+     */
+     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(buffer, &local_type))) {
+            *num_vals = 0;
+            /* don't error log here as the user may be unpacking past
+             * the end of the buffer, which isn't necessarily an error */
+            return rc;
+        }
+        if (PMIX_INT32 != local_type) { /* if the length wasn't first, then error */
+            *num_vals = 0;
+            return PMIX_ERR_UNPACK_FAILURE;
+        }
+    }
+
+    n=1;
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_unpack_int32(buffer, &local_num, &n, PMIX_INT32))) {
+        *num_vals = 0;
+            /* don't error log here as the user may be unpacking past
+             * the end of the buffer, which isn't necessarily an error */
+        return rc;
+    }
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: found %d values for %d provided storage",
+                        local_num, *num_vals);
+
+    /** if the storage provided is inadequate, set things up
+     * to unpack as much as we can and to return an error code
+     * indicating that everything was not unpacked - the buffer
+     * is left in a state where it can not be further unpacked.
+     */
+     if (local_num > *num_vals) {
+        local_num = *num_vals;
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: inadequate space ( %p, %p, %lu, %d )\n",
+                            (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
+        ret = PMIX_ERR_UNPACK_INADEQUATE_SPACE;
+    } else {  /** enough or more than enough storage */
+        *num_vals = local_num;  /** let the user know how many we actually unpacked */
+        ret = PMIX_SUCCESS;
+    }
+
+    /** Unpack the value(s) */
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_unpack_buffer(buffer, dst, &local_num, type))) {
+        *num_vals = 0;
+        ret = rc;
+    }
+
+    return ret;
+}
+
+pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
+                                       pmix_data_type_t type)
+{
+    pmix_status_t rc;
+    pmix_data_type_t local_type, v20type;
+    pmix_bfrop_type_info_t *info;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
+                        (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
+
+    /* some v20 types are simply declared differently */
+    switch (type) {
+        case PMIX_COMMAND:
+            v20type = PMIX_UINT32;
+            break;
+        default:
+            v20type = type;
+    }
+
+    /** Unpack the declared data type */
+    if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(buffer, &local_type))) {
+            return rc;
+        }
+        /* if the data types don't match, then return an error */
+        if (v20type != local_type) {
+            pmix_output(0, "PMIX bfrop:unpack: got type %d when expecting type %d", local_type, v20type);
+            return PMIX_ERR_PACK_MISMATCH;
+        }
+    }
+
+    /* Lookup the unpack function for this type and call it */
+
+    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, v20type))) {
+        return PMIX_ERR_UNPACK_FAILURE;
+    }
+
+    return info->odti_unpack_fn(buffer, dst, num_vals, v20type);
+}
+
+
+/* UNPACK GENERIC SYSTEM TYPES */
+
+/*
+ * BOOL
+ */
+pmix_status_t pmix20_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
+ {
+    int32_t i;
+    uint8_t *src;
+    bool *dst;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_bool * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, *num_vals)) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    src = (uint8_t*)buffer->unpack_ptr;
+    dst = (bool*)dest;
+
+    for (i=0; i < *num_vals; i++) {
+        if (src[i]) {
+            dst[i] = true;
+        } else {
+            dst[i] = false;
+        }
+    }
+
+    /* update buffer pointer */
+    buffer->unpack_ptr += *num_vals;
+
+    return PMIX_SUCCESS;
+}
+
+/*
+ * INT
+ */
+pmix_status_t pmix20_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
+                                    int32_t *num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+    pmix_data_type_t remote_type;
+
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+        return ret;
+    }
+
+    if (remote_type == BFROP_TYPE_INT) {
+        /* fast path it if the sizes are the same */
+        /* Turn around and unpack the real type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_INT))) {
+        }
+    } else {
+        /* slow path - types are different sizes */
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(int, remote_type, ret);
+    }
+
+    return ret;
+}
+
+/*
+ * SIZE_T
+ */
+pmix_status_t pmix20_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+    pmix_data_type_t remote_type;
+
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+        return ret;
+    }
+
+    if (remote_type == BFROP_TYPE_SIZE_T) {
+        /* fast path it if the sizes are the same */
+        /* Turn around and unpack the real type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
+        }
+    } else {
+        /* slow path - types are different sizes */
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(size_t, remote_type, ret);
+    }
+
+    return ret;
+}
+
+/*
+ * PID_T
+ */
+pmix_status_t pmix20_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
+                                    int32_t *num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+    pmix_data_type_t remote_type;
+
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+        return ret;
+    }
+
+    if (remote_type == BFROP_TYPE_PID_T) {
+        /* fast path it if the sizes are the same */
+        /* Turn around and unpack the real type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
+        }
+    } else {
+        /* slow path - types are different sizes */
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(pid_t, remote_type, ret);
+    }
+
+    return ret;
+}
+
+
+/* UNPACK FUNCTIONS FOR NON-GENERIC SYSTEM TYPES */
+
+/*
+ * BYTE, CHAR, INT8
+ */
+pmix_status_t pmix20_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
+ {
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_byte * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, *num_vals)) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    memcpy(dest, buffer->unpack_ptr, *num_vals);
+
+    /* update buffer pointer */
+    buffer->unpack_ptr += *num_vals;
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint16_t tmp, *desttmp = (uint16_t*) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_int16 * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy( &(tmp), buffer->unpack_ptr, sizeof(tmp) );
+        tmp = pmix_ntohs(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint32_t tmp, *desttmp = (uint32_t*) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_int32 * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy( &(tmp), buffer->unpack_ptr, sizeof(tmp) );
+        tmp = ntohl(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_int16(buffer, dest, num_vals, type);
+}
+
+pmix_status_t pmix20_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i;
+    uint64_t tmp, *desttmp = (uint64_t*) dest;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_int64 * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(tmp))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        memcpy( &(tmp), buffer->unpack_ptr, sizeof(tmp) );
+        tmp = pmix_ntoh64(tmp);
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+        buffer->unpack_ptr += sizeof(tmp);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_status_t ret;
+    int32_t i, len, n=1;
+    char **sdest = (char**) dest;
+
+    for (i = 0; i < (*num_vals); ++i) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &len, &n, PMIX_INT32))) {
+            return ret;
+        }
+        if (0 ==  len) {   /* zero-length string - unpack the NULL */
+            sdest[i] = NULL;
+        } else {
+            sdest[i] = (char*)malloc(len);
+            if (NULL == sdest[i]) {
+                return PMIX_ERR_OUT_OF_RESOURCE;
+            }
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, sdest[i], &len, PMIX_BYTE))) {
+                return ret;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i, n;
+    float *desttmp = (float*) dest, tmp;
+    pmix_status_t ret;
+    char *convert;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_float * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(float))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        n=1;
+        convert = NULL;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+            return ret;
+        }
+        if (NULL != convert) {
+            tmp = strtof(convert, NULL);
+            memcpy(&desttmp[i], &tmp, sizeof(tmp));
+            free(convert);
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i, n;
+    double *desttmp = (double*) dest, tmp;
+    pmix_status_t ret;
+    char *convert;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_double * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(double))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        n=1;
+        convert = NULL;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+            return ret;
+        }
+        if (NULL != convert) {
+            tmp = strtod(convert, NULL);
+            memcpy(&desttmp[i], &tmp, sizeof(tmp));
+            free(convert);
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i, n;
+    int64_t tmp[2];
+    struct timeval *desttmp = (struct timeval *) dest, tt;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack_timeval * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(struct timeval))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        n=2;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int64(buffer, tmp, &n, PMIX_INT64))) {
+            return ret;
+        }
+        tt.tv_sec = tmp[0];
+        tt.tv_usec = tmp[1];
+        memcpy(&desttmp[i], &tt, sizeof(tt));
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
+{
+    int32_t i, n;
+    time_t *desttmp = (time_t *) dest, tmp;
+    pmix_status_t ret;
+    uint64_t ui64;
+
+    /* time_t is a system-dependent size, so cast it
+     * to uint64_t as a generic safe size
+     */
+
+     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                         "pmix20_bfrop_unpack_time * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+     if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(uint64_t)))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    for (i = 0; i < (*num_vals); ++i) {
+        n=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int64(buffer, &ui64, &n, PMIX_UINT64))) {
+            return ret;
+        }
+        tmp = (time_t)ui64;
+        memcpy(&desttmp[i], &tmp, sizeof(tmp));
+    }
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
+{
+     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                         "pmix20_bfrop_unpack_status * %d\n", (int)*num_vals);
+    /* check to see if there's enough data in buffer */
+    if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(pmix_status_t)))) {
+        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
+    }
+
+    /* unpack the data */
+    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_INT32);
+}
+
+
+/* UNPACK FUNCTIONS FOR GENERIC PMIX TYPES */
+
+/*
+ * PMIX_VALUE
+ */
+ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
+ {
+    int32_t m;
+    pmix_status_t ret;
+
+    m = 1;
+    switch (val->type) {
+        case PMIX_UNDEF:
+            break;
+        case PMIX_BOOL:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.flag, &m, PMIX_BOOL))) {
+                return ret;
+            }
+            break;
+        case PMIX_BYTE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.byte, &m, PMIX_BYTE))) {
+                return ret;
+            }
+            break;
+        case PMIX_STRING:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.string, &m, PMIX_STRING))) {
+                return ret;
+            }
+            break;
+        case PMIX_SIZE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.size, &m, PMIX_SIZE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PID:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.pid, &m, PMIX_PID))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.integer, &m, PMIX_INT))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT8:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int8, &m, PMIX_INT8))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT16:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int16, &m, PMIX_INT16))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT32:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int32, &m, PMIX_INT32))) {
+                return ret;
+            }
+            break;
+        case PMIX_INT64:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int64, &m, PMIX_INT64))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint, &m, PMIX_UINT))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT8:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint8, &m, PMIX_UINT8))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT16:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint16, &m, PMIX_UINT16))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT32:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint32, &m, PMIX_UINT32))) {
+                return ret;
+            }
+            break;
+        case PMIX_UINT64:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint64, &m, PMIX_UINT64))) {
+                return ret;
+            }
+            break;
+        case PMIX_FLOAT:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.fval, &m, PMIX_FLOAT))) {
+                return ret;
+            }
+            break;
+        case PMIX_DOUBLE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
+                return ret;
+            }
+            break;
+        case PMIX_TIMEVAL:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
+                return ret;
+            }
+            break;
+        case PMIX_TIME:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.time, &m, PMIX_TIME))) {
+                return ret;
+            }
+            break;
+        case PMIX_STATUS:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.status, &m, PMIX_STATUS))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC:
+            /* this field is now a pointer, so we must allocate storage for it */
+            PMIX_PROC_CREATE(val->data.proc, m);
+            if (NULL == val->data.proc) {
+                return PMIX_ERR_NOMEM;
+            }
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.proc, &m, PMIX_PROC))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_RANK:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.rank, &m, PMIX_PROC_RANK))) {
+                return ret;
+            }
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
+                return ret;
+            }
+            break;
+        case PMIX_PERSIST:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.proc, &m, PMIX_PROC))) {
+                return ret;
+            }
+            break;
+        case PMIX_POINTER:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.ptr, &m, PMIX_POINTER))) {
+                return ret;
+            }
+            break;
+        case PMIX_SCOPE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.scope, &m, PMIX_SCOPE))) {
+                return ret;
+            }
+            break;
+        case PMIX_DATA_RANGE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.range, &m, PMIX_DATA_RANGE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_STATE:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.state, &m, PMIX_PROC_STATE))) {
+                return ret;
+            }
+            break;
+        case PMIX_PROC_INFO:
+            /* this is now a pointer, so allocate storage for it */
+            PMIX_PROC_INFO_CREATE(val->data.pinfo, 1);
+            if (NULL == val->data.pinfo) {
+                return PMIX_ERR_NOMEM;
+            }
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.pinfo, &m, PMIX_PROC_INFO))) {
+                return ret;
+            }
+            break;
+        case PMIX_DATA_ARRAY:
+            /* this is now a pointer, so allocate storage for it */
+            val->data.darray = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
+            if (NULL == val->data.darray) {
+                return PMIX_ERR_NOMEM;
+            }
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_DATA_ARRAY))) {
+                return ret;
+            }
+            break;
+        case PMIX_QUERY:
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_QUERY))) {
+                return ret;
+            }
+            break;
+        /**** DEPRECATED ****/
+        case PMIX_INFO_ARRAY:
+            /* this field is now a pointer, so we must allocate storage for it */
+            val->data.array = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
+            if (NULL == val->data.array) {
+                return PMIX_ERR_NOMEM;
+            }
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.array, &m, PMIX_INFO_ARRAY))) {
+                return ret;
+            }
+            break;
+        /********************/
+        default:
+            pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
+            return PMIX_ERROR;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_value_t *ptr;
+    int32_t i, n;
+    pmix_status_t ret;
+
+    ptr = (pmix_value_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        /* unpack the type */
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &ptr[i].type))) {
+            return ret;
+        }
+        /* unpack value */
+        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i])) ) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
+                           int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_info_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    char *tmp;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d info", *num_vals);
+
+    ptr = (pmix_info_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        memset(ptr[i].key, 0, sizeof(ptr[i].key));
+        memset(&ptr[i].value, 0, sizeof(pmix_value_t));
+        /* unpack key */
+        m=1;
+        tmp = NULL;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        if (NULL == tmp) {
+            PMIX_ERROR_LOG(PMIX_ERROR);
+            return PMIX_ERROR;
+        }
+        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        free(tmp);
+        /* unpack the flags */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_infodirs(buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        /* unpack value - since the value structure is statically-defined
+         * instead of a pointer in this struct, we directly unpack it to
+         * avoid the malloc */
+         m=1;
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].value.type, &m, PMIX_INT))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: info type %d", ptr[i].value.type);
+        m=1;
+        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+                            int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_pdata_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    char *tmp;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d pdata", *num_vals);
+
+    ptr = (pmix_pdata_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_PDATA_CONSTRUCT(&ptr[i]);
+        /* unpack the proc */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+            return ret;
+        }
+        /* unpack key */
+        m=1;
+        tmp = NULL;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            return ret;
+        }
+        if (NULL == tmp) {
+            return PMIX_ERROR;
+        }
+        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        free(tmp);
+        /* unpack value - since the value structure is statically-defined
+         * instead of a pointer in this struct, we directly unpack it to
+         * avoid the malloc */
+         m=1;
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].value.type, &m, PMIX_INT))) {
+            return ret;
+        }
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: pdata type %d", ptr[i].value.type);
+        m=1;
+        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
+                          int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_buffer_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    size_t nbytes;
+
+    ptr = (pmix_buffer_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        /* unpack the number of bytes */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &nbytes, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        m = nbytes;
+        /* setup the buffer's data region */
+        if (0 < nbytes) {
+            ptr[i].base_ptr = (char*)malloc(nbytes);
+            /* unpack the bytes */
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
+                return ret;
+            }
+        }
+        ptr[i].pack_ptr = ptr[i].base_ptr + m;
+        ptr[i].unpack_ptr = ptr[i].base_ptr;
+        ptr[i].bytes_allocated = nbytes;
+        ptr[i].bytes_used = m;
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
+                           int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_proc_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    char *tmp;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d procs", *num_vals);
+
+    ptr = (pmix_proc_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: init proc[%d]", i);
+        memset(&ptr[i], 0, sizeof(pmix_proc_t));
+        /* unpack nspace */
+        m=1;
+        tmp = NULL;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            return ret;
+        }
+        if (NULL == tmp) {
+            return PMIX_ERROR;
+        }
+        (void)strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
+        free(tmp);
+        /* unpack the rank */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_rank(buffer, &ptr[i].rank, &m, PMIX_PROC_RANK))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
+                          int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_app_t *ptr;
+    int32_t i, k, n, m;
+    pmix_status_t ret;
+    int32_t nval;
+    char *tmp;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d apps", *num_vals);
+
+    ptr = (pmix_app_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        /* initialize the fields */
+        PMIX_APP_CONSTRUCT(&ptr[i]);
+        /* unpack cmd */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
+            return ret;
+        }
+        /* unpack argc */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &nval, &m, PMIX_INT32))) {
+            return ret;
+        }
+        /* unpack argv */
+        for (k=0; k < nval; k++) {
+            m=1;
+            tmp = NULL;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+                return ret;
+            }
+            if (NULL == tmp) {
+                return PMIX_ERROR;
+            }
+            pmix_argv_append_nosize(&ptr[i].argv, tmp);
+            free(tmp);
+        }
+        /* unpack env */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &nval, &m, PMIX_INT32))) {
+            return ret;
+        }
+        for (k=0; k < nval; k++) {
+            m=1;
+            tmp = NULL;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+                return ret;
+            }
+            if (NULL == tmp) {
+                return PMIX_ERROR;
+            }
+            pmix_argv_append_nosize(&ptr[i].env, tmp);
+            free(tmp);
+        }
+        /* unpack cwd */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].cwd, &m, PMIX_STRING))) {
+            return ret;
+        }
+        /* unpack maxprocs */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
+            return ret;
+        }
+        /* unpack info array */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].ninfo) {
+            PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
+            m = ptr[i].ninfo;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(buffer, ptr[i].info, &m, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
+                           int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_kval_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d kvals", *num_vals);
+
+    ptr = (pmix_kval_t*) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_CONSTRUCT(&ptr[i], pmix_kval_t);
+        /* unpack the key */
+        m = 1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].key, &m, PMIX_STRING))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+        /* allocate the space */
+        ptr[i].value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        /* unpack the value */
+        m = 1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(buffer, ptr[i].value, &m, PMIX_VALUE))) {
+            PMIX_ERROR_LOG(ret);
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
+                            int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_modex_data_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d modex", *num_vals);
+
+    ptr = (pmix_modex_data_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
+        /* unpack the number of bytes */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            ptr[i].blob = (uint8_t*)malloc(ptr[i].size * sizeof(uint8_t));
+            m=ptr[i].size;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].blob, &m, PMIX_UINT8))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
+                                    int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
+}
+
+pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
+                         int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_byte_object_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d byte_object", *num_vals);
+
+    ptr = (pmix_byte_object_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        memset(&ptr[i], 0, sizeof(pmix_byte_object_t));
+        /* unpack the number of bytes */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            ptr[i].bytes = (char*)malloc(ptr[i].size * sizeof(char));
+            m=ptr[i].size;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
+                          int32_t *num_vals, pmix_data_type_t type)
+{
+    uint8_t foo=1;
+    int32_t cnt=1;
+
+    /* it obviously makes no sense to pack a pointer and
+     * send it somewhere else, so we just unpack the sentinel */
+    return pmix20_bfrop_unpack_byte(buffer, &foo, &cnt, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_pstate(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+
+pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_proc_info_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d pinfo", *num_vals);
+
+    ptr = (pmix_proc_info_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_PROC_INFO_CONSTRUCT(&ptr[i]);
+        /* unpack the proc */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+            return ret;
+        }
+        /* unpack the hostname */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].hostname, &m, PMIX_STRING))) {
+            return ret;
+        }
+        /* unpack the executable */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].executable_name, &m, PMIX_STRING))) {
+            return ret;
+        }
+        /* unpack pid */
+         m=1;
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pid(buffer, &ptr[i].pid, &m, PMIX_PID))) {
+            return ret;
+        }
+        /* unpack state */
+         m=1;
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pstate(buffer, &ptr[i].state, &m, PMIX_PROC_STATE))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_data_array_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    size_t nbytes;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d data arrays", *num_vals);
+
+    ptr = (pmix_data_array_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        memset(&ptr[i], 0, sizeof(pmix_data_array_t));
+        /* unpack the type */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_datatype(buffer, &ptr[i].type, &m, PMIX_DATA_TYPE))) {
+            return ret;
+        }
+        /* unpack the number of array elements */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 == ptr[i].size || PMIX_UNDEF == ptr[i].type) {
+            /* nothing else to do */
+            continue;
+        }
+        /* allocate storage for the array and unpack the array elements */
+        m = ptr[i].size;
+        switch(ptr[i].type) {
+            case PMIX_BOOL:
+                nbytes = sizeof(bool);
+                break;
+            case PMIX_BYTE:
+            case PMIX_INT8:
+            case PMIX_UINT8:
+                nbytes = sizeof(int8_t);
+                break;
+            case PMIX_INT16:
+            case PMIX_UINT16:
+                nbytes = sizeof(int16_t);
+                break;
+            case PMIX_INT32:
+            case PMIX_UINT32:
+                nbytes = sizeof(int32_t);
+                break;
+            case PMIX_INT64:
+            case PMIX_UINT64:
+                nbytes = sizeof(int64_t);
+                break;
+            case PMIX_STRING:
+                nbytes = sizeof(char*);
+                break;
+            case PMIX_SIZE:
+                nbytes = sizeof(size_t);
+                break;
+            case PMIX_PID:
+                nbytes = sizeof(pid_t);
+                break;
+            case PMIX_INT:
+            case PMIX_UINT:
+                nbytes = sizeof(int);
+                break;
+            case PMIX_FLOAT:
+                nbytes = sizeof(float);
+                break;
+            case PMIX_DOUBLE:
+                nbytes = sizeof(double);
+                break;
+            case PMIX_TIMEVAL:
+                nbytes = sizeof(struct timeval);
+                break;
+            case PMIX_TIME:
+                nbytes = sizeof(time_t);
+                break;
+            case PMIX_STATUS:
+                nbytes = sizeof(pmix_status_t);
+                break;
+            case PMIX_INFO:
+                nbytes = sizeof(pmix_info_t);
+                break;
+            case PMIX_PROC:
+                nbytes = sizeof(pmix_proc_t);
+                break;
+            case PMIX_BYTE_OBJECT:
+            case PMIX_COMPRESSED_STRING:
+                nbytes = sizeof(pmix_byte_object_t);
+                break;
+            case PMIX_PERSIST:
+                nbytes = sizeof(pmix_persistence_t);
+                break;
+            case PMIX_SCOPE:
+                nbytes = sizeof(pmix_scope_t);
+                break;
+            case PMIX_DATA_RANGE:
+                nbytes = sizeof(pmix_data_range_t);
+                break;
+            case PMIX_PROC_STATE:
+                nbytes = sizeof(pmix_proc_state_t);
+                break;
+            case PMIX_PROC_INFO:
+                nbytes = sizeof(pmix_proc_info_t);
+                break;
+            case PMIX_QUERY:
+                nbytes = sizeof(pmix_query_t);
+            default:
+                return PMIX_ERR_NOT_SUPPORTED;
+        }
+        if (NULL == (ptr[i].array = malloc(m * nbytes))) {
+            return PMIX_ERR_NOMEM;
+        }
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, ptr[i].array, &m, ptr[i].type))) {
+            return ret;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
+}
+
+pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_query_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+    int32_t nkeys;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d queries", *num_vals);
+
+    ptr = (pmix_query_t *) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        PMIX_QUERY_CONSTRUCT(&ptr[i]);
+        /* unpack the number of keys */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &nkeys, &m, PMIX_INT32))) {
+            return ret;
+        }
+        if (0 < nkeys) {
+            /* unpack the keys */
+            if (NULL == (ptr[i].keys = (char**)calloc(nkeys+1, sizeof(char*)))) {
+                return PMIX_ERR_NOMEM;
+            }
+            /* unpack keys */
+            m=nkeys;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, ptr[i].keys, &m, PMIX_STRING))) {
+                return ret;
+            }
+        }
+        /* unpack the number of qualifiers */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].nqual, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].nqual) {
+            /* unpack the qualifiers */
+            PMIX_INFO_CREATE(ptr[i].qualifiers, ptr[i].nqual);
+            m =  ptr[i].nqual;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(buffer, ptr[i].qualifiers, &m, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
+                                                int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+}
+
+
+/**** DEPRECATED ****/
+pmix_status_t pmix20_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix20_bfrop_unpack: %d info arrays", *num_vals);
+
+    ptr = (pmix_info_array_t*) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix20_bfrop_unpack: init array[%d]", i);
+        memset(&ptr[i], 0, sizeof(pmix_info_array_t));
+        /* unpack the size of this array */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
+            m=ptr[i].size;
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+/********************/

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2408,7 +2408,8 @@ static pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank,
         if ((NULL == key) && (kval_cnt > 0)) {
             kval = (pmix_value_t*)malloc(sizeof(pmix_value_t));
             if (NULL == kval) {
-                return PMIX_ERR_NOMEM;
+                rc = PMIX_ERR_NOMEM;
+                goto done;
             }
             PMIX_VALUE_CONSTRUCT(kval);
 

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1027,9 +1027,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         pnd->proc_type = proc_type;
         /* pass along the bfrop, buffer_type, and sec fields so
          * we can assign them once we create a peer object */
-        if (NULL != sec) {
-            pnd->psec = strdup(sec);
-        }
+        pnd->psec = strdup(sec);
         if (NULL != bfrops) {
             pnd->bfrops = strdup(bfrops);
         }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -589,7 +589,7 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
                 PMIX_DESTRUCT(&cb);
                 return rc;
             }
-            if (PMIX_PROC_IS_V1(peer)) {
+            if (PMIX_PROC_IS_V1(cd->peer)) {
                 /* if the client is using v1, then it expects the
                  * data returned to it as the rank followed by abyte object containing
                  * a buffer - so we have to do a little gyration */


### PR DESCRIPTION
This completes the basic level of cross-version support where the server is newer than the client. Still need to investigate the reverse scenario, and test the heck out of this code.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>