### PR TITLE
Get the reverse mode to work for v20 - i.e., let a v2.1 client connect to a v2.0 server.

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -447,17 +447,17 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_globals.mypeer->info->pname.nspace = strdup(proc->nspace);
     pmix_globals.mypeer->info->pname.rank = proc->rank;
 
-    /* select our bfrops compat module - the selection will be based
+    /* select our psec compat module - the selection will be based
      * on the corresponding envars that should have been passed
      * to us at launch */
-    evar = getenv("PMIX_BFROPS_MODE");
-    pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(evar);
-    if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
+    evar = getenv("PMIX_SECURITY_MODE");
+    pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(evar);
+    if (NULL == pmix_globals.mypeer->nptr->compat.psec) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
     }
     /* the server will be using the same */
-    pmix_client_globals.myserver->nptr->compat.bfrops = pmix_globals.mypeer->nptr->compat.bfrops;
+    pmix_client_globals.myserver->nptr->compat.psec = pmix_globals.mypeer->nptr->compat.psec;
 
     /* set the buffer type - the selection will be based
      * on the corresponding envars that should have been passed
@@ -474,26 +474,17 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     /* the server will be using the same */
     pmix_client_globals.myserver->nptr->compat.type = pmix_globals.mypeer->nptr->compat.type;
 
-
-    /* select our psec compat module - the selection will be based
-     * on the corresponding envars that should have been passed
-     * to us at launch */
-    evar = getenv("PMIX_SECURITY_MODE");
-    pmix_globals.mypeer->nptr->compat.psec = pmix_psec_base_assign_module(evar);
-    if (NULL == pmix_globals.mypeer->nptr->compat.psec) {
-        PMIX_RELEASE_THREAD(&pmix_global_lock);
-        return PMIX_ERR_INIT;
-    }
-    /* the server will be using the same */
-    pmix_client_globals.myserver->nptr->compat.psec = pmix_globals.mypeer->nptr->compat.psec;
-
     /* select the gds compat module we will use to interact with
      * our server- the selection will be based
      * on the corresponding envars that should have been passed
      * to us at launch */
     evar = getenv("PMIX_GDS_MODULE");
-    PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, evar, PMIX_STRING);
-    pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+    if (NULL != evar) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, evar, PMIX_STRING);
+        pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+    } else {
+        pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
+    }
     if (NULL == pmix_client_globals.myserver->nptr->compat.gds) {
         PMIX_INFO_DESTRUCT(&ginfo);
         PMIX_RELEASE_THREAD(&pmix_global_lock);

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -400,44 +400,42 @@ static const char* data_type_string(pmix_data_type_t type)
 
 int pmix12_v2_to_v1_datatype(pmix_data_type_t v2type)
 {
-    int v1type = PMIX_UNDEF;
+    int v1type;
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
-        /* if I am a server, then I'm passing the data type to
-         * a PMIx v1 compatible client. The data type was redefined
-         * in v2, and so we have to do some conversions here */
-        switch(v2type) {
-            case 20:
-                /* the client thinks this is simply an int */
-                v1type = 6;
-                break;
+    /* I'm passing the data type to
+     * a PMIx v1 compatible peer. The data type was redefined
+     * in v2, and so we have to do some conversions here */
+    switch(v2type) {
+        case 20:
+            /* the client thinks this is simply an int */
+            v1type = 6;
+            break;
 
-            case 44:
-                /* the client thinks this is PMIX_INFO_ARRAY */
-                v1type = 22;
-                break;
+        case 44:
+            /* the client thinks this is PMIX_INFO_ARRAY */
+            v1type = 22;
+            break;
 
-            case 40:
-                /* proc rank is just an int in v1 */
-                v1type = 6;
-                break;
+        case 40:
+            /* proc rank is just an int in v1 */
+            v1type = 6;
+            break;
 
-            case 22:
-            case 23:
-            case 24:
-            case 25:
-            case 26:
-            case 27:
-            case 28:
-            case 29:
-            case 30:
-                /* shift up one */
-                v1type = v2type + 1;
-                break;
+        case 22:
+        case 23:
+        case 24:
+        case 25:
+        case 26:
+        case 27:
+        case 28:
+        case 29:
+        case 30:
+            /* shift up one */
+            v1type = v2type + 1;
+            break;
 
-            default:
-                v1type = v2type;
-        }
+        default:
+            v1type = v2type;
     }
     return v1type;
 }
@@ -453,40 +451,38 @@ pmix_status_t pmix12_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type
 
 pmix_data_type_t pmix12_v1_to_v2_datatype(int v1type)
 {
-    pmix_data_type_t v2type = PMIX_UNDEF;
+    pmix_data_type_t v2type;
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
-        /* if I am a server, then I'm getting the data type that was given to
-         * me by a PMIx v1 compatible client. The data type was redefined
-         * in v2, and so we have to do some conversions here */
+    /* I'm getting the data type that was given to
+     * me by a PMIx v1 compatible peer. The data type was redefined
+     * in v2, and so we have to do some conversions here */
 
-        switch(v1type) {
-            case 20:
-                /* the client thinks this is PMIX_HWLOC_TOPO, which we don't support */
-                v2type = PMIX_UNDEF;
-                break;
+    switch(v1type) {
+        case 20:
+            /* the peer thinks this is PMIX_HWLOC_TOPO, which we don't support */
+            v2type = PMIX_UNDEF;
+            break;
 
-            case 22:
-                /* the client thinks this is PMIX_INFO_ARRAY */
-                v2type = PMIX_INFO_ARRAY;
-                break;
+        case 22:
+            /* the peer thinks this is PMIX_INFO_ARRAY */
+            v2type = PMIX_INFO_ARRAY;
+            break;
 
-            case 23:
-            case 24:
-            case 25:
-            case 26:
-            case 27:
-            case 28:
-            case 29:
-            case 30:
-            case 31:
-                /* shift down one */
-                v2type = v1type - 1;
-                break;
+        case 23:
+        case 24:
+        case 25:
+        case 26:
+        case 27:
+        case 28:
+        case 29:
+        case 30:
+        case 31:
+            /* shift down one */
+            v2type = v1type - 1;
+            break;
 
-            default:
-                v2type = v1type;
-        }
+        default:
+            v2type = v1type;
     }
     return v2type;
 }

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -25,6 +25,8 @@
 #include <src/include/pmix_config.h>
 
 #include "src/util/error.h"
+#include "src/include/pmix_globals.h"
+#include "src/client/pmix_client_ops.h"
 #include "src/mca/bfrops/base/base.h"
 #include "bfrop_pmix20.h"
 #include "internal.h"
@@ -416,22 +418,20 @@ static const char* data_type_string(pmix_data_type_t type)
 
 pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type)
 {
-    pmix_data_type_t v20type = PMIX_UNDEF;
+    pmix_data_type_t v20type;
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
-        /* if I am a server, then I'm passing the data type to
-         * a PMIx v1 compatible client. The data type was redefined
-         * in v2, and so we have to do some conversions here */
-        switch(v21type) {
-            case PMIX_COMMAND:
-                /* the client unfortunately didn't separate these out,
-                 * but instead set them to PMIX_UINT32 */
-                v20type = PMIX_UINT32;
-                break;
+    /* iI'm passing the data type to
+     * a PMIx v20 compatible client. The data type was redefined
+     * in v21, and so we have to do some conversions here */
+    switch(v21type) {
+        case PMIX_COMMAND:
+            /* the peer unfortunately didn't separate these out,
+             * but instead set them to PMIX_UINT32 */
+            v20type = PMIX_UINT32;
+            break;
 
-            default:
-                v20type = v21type;
-        }
+        default:
+            v20type = v21type;
     }
     return v20type;
 }
@@ -441,7 +441,6 @@ pmix_status_t pmix20_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type
     pmix_data_type_t v20type;
 
     v20type = pmix20_v21_to_v20_datatype(type);
-
     return pmix20_bfrop_pack_datatype(buffer, &v20type, 1, PMIX_DATA_TYPE);
 }
 

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2792,7 +2792,7 @@ static pmix_status_t dstore_assign_module(pmix_info_t *info, size_t ninfo,
     size_t n, m;
     char **options;
 
-    *priority = -1;
+    *priority = 20;
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -166,7 +166,7 @@ static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo,
     size_t n, m;
     char **options;
 
-    *priority = -1;
+    *priority = 10;
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_GDS_MODULE, PMIX_MAX_KEYLEN)) {

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -482,7 +482,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     }
 
     lt = PMIX_NEW(pmix_listener_t);
-    lt->varname = strdup("PMIX_SERVER_URI2");
+    lt->varname = strdup("PMIX_SERVER_URI2:PMIX_SERVER_URI21");
     lt->protocol = PMIX_PROTOCOL_V2;
     lt->ptl = (struct pmix_ptl_module_t*)&pmix_ptl_tcp_module;
     lt->cbfunc = connection_handler;
@@ -587,7 +587,9 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         }
 
         /* output my nspace and rank plus the URI */
-        fprintf(fp, "%s.%d:%s\n", pmix_globals.myid.nspace, pmix_globals.myid.rank, lt->uri);
+        fprintf(fp, "%s\n", lt->uri);
+        /* add a flag that indicates we accept v2.1 protocols */
+        fprintf(fp, "%s\n", PMIX_VERSION);
         fclose(fp);
         /* set the file mode */
         if (0 != chmod(mca_ptl_tcp_component.system_filename, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH)) {
@@ -618,8 +620,10 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
             goto sockerror;
         }
 
-        /* output my nspace and rank plus the URI */
-        fprintf(fp, "%s.%d:%s\n", pmix_globals.myid.nspace, pmix_globals.myid.rank, lt->uri);
+        /* output my URI */
+        fprintf(fp, "%s\n", lt->uri);
+        /* add a flag that indicates we accept v2.1 protocols */
+        fprintf(fp, "%s\n", PMIX_VERSION);
         fclose(fp);
         /* set the file mode */
         if (0 != chmod(mca_ptl_tcp_component.session_filename, S_IRUSR | S_IWUSR | S_IRGRP)) {

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -52,6 +52,7 @@
 #include "src/client/pmix_client_ops.h"
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_socket_errno.h"
+#include "src/mca/bfrops/base/base.h"
 #include "src/mca/psec/base/base.h"
 
 #include "src/mca/ptl/base/base.h"
@@ -122,6 +123,15 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         PMIX_ERROR_LOG(PMIX_ERROR);
         return PMIX_ERROR;
     }
+    /* definitely a v1 server */
+    pmix_client_globals.myserver->proc_type = PMIX_PROC_SERVER | PMIX_PROC_V1;
+    /* must use the v12 bfrops module */
+    pmix_globals.mypeer->nptr->compat.bfrops = pmix_bfrops_base_assign_module("v12");
+    if (NULL == pmix_globals.mypeer->nptr->compat.bfrops) {
+        return PMIX_ERR_INIT;
+    }
+    /* the server will be using the same */
+    pmix_client_globals.myserver->nptr->compat.bfrops = pmix_globals.mypeer->nptr->compat.bfrops;
 
     /* set the server nspace */
     if (NULL == pmix_client_globals.myserver->info) {


### PR DESCRIPTION
Note that all work to-date is with dstore disabled on both sides.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>