### PR TITLE
Do not lock v2.0 clients to the "hash" gds component. Add debug output

### DIFF
--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -482,6 +482,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     if (NULL != evar) {
         PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, evar, PMIX_STRING);
         pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
     } else {
         pmix_client_globals.myserver->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
     }
@@ -490,7 +491,6 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_INIT;
     }
-    PMIX_INFO_DESTRUCT(&ginfo);
     /* now select a GDS module for our own internal use - the user may
      * have passed down a directive for this purpose. If they did, then
      * use it. Otherwise, we want the "hash" module */

--- a/src/mca/gds/base/gds_base_frame.c
+++ b/src/mca/gds/base/gds_base_frame.c
@@ -47,6 +47,7 @@
 
 /* Instantiate the global vars */
 pmix_gds_globals_t pmix_gds_globals = {{{0}}};
+int pmix_gds_base_output = -1;
 
 static pmix_status_t pmix_gds_close(void)
 {
@@ -74,13 +75,17 @@ static pmix_status_t pmix_gds_close(void)
 
 static pmix_status_t pmix_gds_open(pmix_mca_base_open_flag_t flags)
 {
+    pmix_status_t rc;
+
     /* initialize globals */
     pmix_gds_globals.initialized = true;
     pmix_gds_globals.all_mods = NULL;
     PMIX_CONSTRUCT(&pmix_gds_globals.actives, pmix_list_t);
 
     /* Open up all available components */
-    return pmix_mca_base_framework_components_open(&pmix_gds_base_framework, flags);
+    rc = pmix_mca_base_framework_components_open(&pmix_gds_base_framework, flags);
+    pmix_gds_base_output = pmix_gds_base_framework.framework_output;
+    return rc;
 }
 
 PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, gds, "PMIx Generalized Data Store",

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -949,7 +949,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         proc_type = PMIX_PROC_V20;
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
-        gds = "hash";
+        gds = NULL;
     } else {
         proc_type = PMIX_PROC_V21;
         /* extract the name of the bfrops module they used */
@@ -1136,9 +1136,14 @@ static void connection_handler(int sd, short args, void *cbdata)
     peer->nptr->compat.type = bftype;
 
     /* set the gds module to match this peer */
-    PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, gds, PMIX_STRING);
+    if (NULL != gds) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, gds, PMIX_STRING);
+        peer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
+    } else {
+        peer->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
+    }
     free(msg);  // can now release the data buffer
-    peer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
     if (NULL == peer->nptr->compat.gds) {
         info->proc_cnt--;
         pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>