### PR TITLE
Addressed the dstore compatibility between v2.1 and v.2.0

### DIFF
--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -1641,7 +1641,7 @@ static int pmix_sm_store(ns_track_elem_t *ns_info, pmix_rank_t rank, pmix_kval_t
     datadesc = ns_info->data_seg;
     /* pack value to the buffer */
     PMIX_CONSTRUCT(&buffer, pmix_buffer_t);
-    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buffer, kval->value, 1, PMIX_VALUE);
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver, &buffer, kval->value, 1, PMIX_VALUE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto exit;
@@ -2513,12 +2513,12 @@ static pmix_status_t _dstore_fetch(const char *nspace, pmix_rank_t rank,
                 int cnt = 1;
                 /* unpack value for this key from the buffer. */
                 PMIX_VALUE_CONSTRUCT(&val);
-                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &buffer, &val, &cnt, PMIX_VALUE);
+                PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver, &buffer, &val, &cnt, PMIX_VALUE);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto done;
                 }
-                PMIX_BFROPS_COPY(rc, pmix_globals.mypeer, (void**)kvs, &val, PMIX_VALUE);
+                PMIX_BFROPS_COPY(rc, pmix_client_globals.myserver, (void**)kvs, &val, PMIX_VALUE);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     goto done;
@@ -3004,6 +3004,9 @@ static pmix_status_t dstore_register_job_info(struct pmix_peer_t *pr,
                         peer->info->pname.nspace, peer->info->pname.rank);
 
     if (0 == ns->ndelivered) { // don't store twice
+        pmix_client_globals.myserver->nptr->compat.type = peer->nptr->compat.type;
+        pmix_client_globals.myserver->nptr->compat.bfrops = peer->nptr->compat.bfrops;
+
         (void)strncpy(proc.nspace, ns->nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         rc = _store_job_info(&proc);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1916,13 +1916,23 @@ static void _cnct(int sd, short args, void *cbdata)
                     }
                 }
                 PMIX_DESTRUCT(&cb);
-                PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
-                PMIX_BFROPS_PACK(rc, cd->peer, reply, &bo, 1, PMIX_BYTE_OBJECT);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(reply);
-                    PMIX_DESTRUCT(&pbkt);
-                    goto cleanup;
+                if (PMIX_PROC_IS_V21(cd->peer)) {
+                    PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
+                    PMIX_BFROPS_PACK(rc, cd->peer, reply, &bo, 1, PMIX_BYTE_OBJECT);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(reply);
+                        PMIX_DESTRUCT(&pbkt);
+                        goto cleanup;
+                    }
+                } else {
+                    PMIX_BFROPS_PACK(rc, cd->peer, reply, &pbkt, 1, PMIX_BUFFER);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(reply);
+                        PMIX_DESTRUCT(&pbkt);
+                        goto cleanup;
+                    }
                 }
                 PMIX_DESTRUCT(&pbkt);
             }

--- a/test/pmix_client.c
+++ b/test/pmix_client.c
@@ -93,11 +93,6 @@ int main(int argc, char **argv)
         info[0].value.type = PMIX_STRING;
         info[0].value.data.string = strdup(params.gds_mode);
         ninfo = 1;
-        {
-            int delay = 0;
-            while(delay)
-                sleep(1);
-        }
     }
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, info, ninfo))) {
         TEST_ERROR(("Client ns %s rank %d: PMIx_Init failed: %d", params.nspace, params.rank, rc));


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>

Closes #498 

PR is in progress. Don't merge. 

There are results of testing for v2.1 server with v2.0 clients:
```
/pmix/v2.1/test $ ./check.sh
OK ./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:0-2;1:3]" -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --ns-dist 3:1 --fence "[db | 0:;1:]" -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --ns-dist 3:1 --fence "[0:]" -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --ns-dist 3:1 --fence "[b | 0:]" -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --ns-dist 3:1 --fence "[d | 0:]" --noise [0:0,1] -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --job-fence -c -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 4 --job-fence -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 2 --test-publish -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 2 --test-spawn -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 2 --test-connect -e /home/user/pmix/v2.0/test/.libs/pmix_client
FAIL ./pmix_test -n 5 --test-resolve-peers --ns-dist "1:2:2" -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 5 --test-replace 100:0,1,10,50,99 -e /home/user/pmix/v2.0/test/.libs/pmix_client
OK ./pmix_test -n 5 --test-internal 10 -e /home/user/pmix/v2.0/test/.libs/pmix_client
```