### PR TITLE
Add attributes to fully support OMPI spawn options. Only retry connection if wait_to_connect param is non-zero

### DIFF
--- a/include/pmix_common.h
+++ b/include/pmix_common.h
@@ -344,6 +344,21 @@ typedef uint32_t pmix_rank_t;
                                                                     //        job - i.e., not part of the "comm_world" of the job
 #define PMIX_SET_SESSION_CWD                "pmix.ssncwd"           // (bool) set the application's current working directory to
                                                                     //        the session working directory assigned by the RM
+#define PMIX_TAG_OUTPUT                     "pmix.tagout"           // (bool) tag application output with the ID of the source
+#define PMIX_TIMESTAMP_OUTPUT               "pmix.tsout"            // (bool) timestamp output from applications
+#define PMIX_MERGE_STDERR_STDOUT            "pmix.mergeerrout"      // (bool) merge stdout and stderr streams from application procs
+#define PMIX_OUTPUT_TO_FILE                 "pmix.outfile"          // (char*) output application output to given file
+#define PMIX_INDEX_ARGV                     "pmix.indxargv"         // (bool) mark the argv with the rank of the proc
+#define PMIX_CPUS_PER_PROC                  "pmix.cpuperproc"       // (uint32_t) #cpus to assign to each rank
+#define PMIX_NO_PROCS_ON_HEAD               "pmix.nolocal"          // (bool) do not place procs on the head node
+#define PMIX_NO_OVERSUBSCRIBE               "pmix.noover"           // (bool) do not oversubscribe the cpus
+#define PMIX_REPORT_BINDINGS                "pmix.repbind"          // (bool) report bindings of the individual procs
+#define PMIX_CPU_LIST                       "pmix.cpulist"          // (char*) list of cpus to use for this job
+#define PMIX_JOB_RECOVERABLE                "pmix.recover"          // (bool) application supports recoverable operations
+#define PMIX_JOB_CONTINUOUS                 "pmix.continuous"       // (bool) application is continuous, all failed procs should
+                                                                        //        be immediately restarted
+#define PMIX_MAX_RESTARTS                   "pmix.maxrestarts"      // (uint32_t) max number of times to restart a job
+
 
 /* query attributes */
 #define PMIX_QUERY_NAMESPACES               "pmix.qry.ns"           // (char*) request a comma-delimited list of active nspaces

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -471,7 +471,7 @@ static pmix_status_t parse_uri_file(char *filename,
          * user isn't authorized to access it - or it may just
          * not exist yet! Check for existence */
         if (0 != access(filename, R_OK)) {
-            if (ENOENT == errno) {
+            if (ENOENT == errno && 0 < mca_ptl_tcp_component.wait_to_connect) {
                 /* the file does not exist, so give it
                  * a little time to see if the server
                  * is still starting up */
@@ -979,6 +979,7 @@ static pmix_status_t df_search(char *dirname, char *prefix,
         }
         newdir = pmix_os_path(false, dirname, dir_entry->d_name, NULL);
         if (-1 == stat(newdir, &buf)) {
+            free(newdir);
             continue;
         }
         /* if it is a directory, down search */


### PR DESCRIPTION


Signed-off-by: Ralph Castain <rhc@open-mpi.org>