### PR TITLE
Implement missing support for data_array of pmix_value_t's. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ config/autogen_found_items.m4
 
 examples/alloc
 examples/client
+examples/client2
 examples/debugger
 examples/debuggerd
 examples/dmodex

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -21,7 +21,7 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client dmodex dynamic fault pub tool debugger debuggerd alloc jctrl
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub tool debugger debuggerd alloc jctrl
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -31,6 +31,10 @@ endif
 client_SOURCES = client.c
 client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 client_LDADD =  $(top_builddir)/src/libpmix.la
+
+client2_SOURCES = client2.c
+client2_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+client2_LDADD =  $(top_builddir)/src/libpmix.la
 
 debugger_SOURCES = debugger.c
 debugger_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)

--- a/examples/client2.c
+++ b/examples/client2.c
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <pmix.h>
+
+static pmix_proc_t myproc;
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    volatile int *active = (volatile int*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    *active = status;
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val, *vptr;
+    pmix_proc_t proc;
+    uint32_t nprocs, n, k;
+    pmix_info_t *info;
+    bool flag;
+    volatile int active;
+    pmix_data_array_t da, *dptr;
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+
+    /* register our default event handler - again, this isn't strictly
+     * required, but is generally good practice */
+    active = -1;
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, evhandler_reg_callbk, (void*)&active);
+    while (-1 == active) {
+        sleep(1);
+    }
+    if (0 != active) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace, myproc.rank);
+        exit(active);
+    }
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* put a data array of pmix_value's */
+    val = (pmix_value_t*)malloc(32 * sizeof(pmix_value_t));
+    for (n=0; n < 32; n++) {
+        val[n].type = PMIX_UINT64;
+        val[n].data.uint64 = 2*n;
+    }
+    da.type = PMIX_VALUE;
+    da.size = 32;
+    da.array = val;
+    value.type = PMIX_DATA_ARRAY;
+    value.data.darray = &da;
+    rc = PMIx_Put(PMIX_GLOBAL, "test-key", &value);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Put failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    free(val);
+
+    /* push the data to our PMIx server */
+    if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+
+    /* call fence to synchronize with our peers - instruct
+     * the fence operation to collect and return all "put"
+     * data from our peers */
+    PMIX_INFO_CREATE(info, 1);
+    flag = true;
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    /* check the returned data */
+    for (n=0; n < nprocs; n++) {
+        proc.rank = n;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "test-key", NULL, 0, &val))) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get on rank %u failed: %d\n",
+                    myproc.nspace, myproc.rank, proc.rank, rc);
+            goto done;
+        }
+        if (PMIX_DATA_ARRAY != val->type) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get on rank %u returned wrong type: %d\n",
+                    myproc.nspace, myproc.rank, proc.rank, val->type);
+            PMIX_VALUE_RELEASE(val);
+            goto done;
+        }
+        dptr = val->data.darray;
+        if (NULL == dptr) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %d returned NULL array\n",
+                    myproc.nspace, myproc.rank, proc.rank);
+            PMIX_VALUE_RELEASE(val);
+            goto done;
+        }
+        if (PMIX_VALUE != dptr->type) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %d returned wrong array value type %d\n",
+                    myproc.nspace, myproc.rank, proc.rank, dptr->type);
+            PMIX_VALUE_RELEASE(val);
+            goto done;
+        }
+        if (32 != dptr->size) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get %d returned wrong array value size %d\n",
+                    myproc.nspace, myproc.rank, proc.rank, (int)dptr->size);
+            PMIX_VALUE_RELEASE(val);
+            goto done;
+        }
+        vptr = (pmix_value_t*)dptr->array;
+        for (k=0; k < 32; k++) {
+            if (PMIX_UINT64 != vptr[k].type) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %d returned wrong type: %d\n",
+                        myproc.nspace, myproc.rank, proc.rank, vptr[k].type);
+                PMIX_VALUE_RELEASE(val);
+                goto done;
+            }
+            if (2*k != vptr[k].data.uint64) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Get %d returned wrong value: %lu\n",
+                        myproc.nspace, myproc.rank, proc.rank, (unsigned long)vptr[k].data.uint64);
+                PMIX_VALUE_RELEASE(val);
+                goto done;
+            }
+        }
+    }
+
+ done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -990,6 +990,11 @@ pmix_status_t pmix_bfrops_base_pack_darray(pmix_buffer_t *buffer, const void *sr
                     return ret;
                 }
                 break;
+            case PMIX_VALUE:
+                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_value(buffer, p[i].array, p[i].size, PMIX_QUERY))) {
+                    return ret;
+                }
+                break;
             case PMIX_ALLOC_DIRECTIVE:
                 if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_alloc_directive(buffer, p[i].array, p[i].size, PMIX_ALLOC_DIRECTIVE))) {
                     return ret;

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1515,6 +1515,15 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
                     return ret;
                 }
                 break;
+            case PMIX_VALUE:
+                ptr[i].array = (pmix_value_t*)malloc(m * sizeof(pmix_value_t));
+                if (NULL == ptr[i].array) {
+                    return PMIX_ERR_NOMEM;
+                }
+                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, ptr[i].type))) {
+                    return ret;
+                }
+                break;
             /**** DEPRECATED ****/
             case PMIX_INFO_ARRAY:
                 ptr[i].array = (pmix_info_array_t*)malloc(m * sizeof(pmix_info_array_t));

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -707,7 +707,7 @@ pmix_status_t pmix12_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
     pmix_app_t *app;
     int32_t i, j, nvals;
     pmix_status_t ret;
-    int argc;
+    int argc=0;
 
     app = (pmix_app_t *) src;
 

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -502,28 +502,6 @@ static inline void _rwlock_release(session_t *s) {
 }
 #endif
 
-static inline const char *_unique_id(void)
-{
-    static const char *str = NULL;
-    if (!str) {
-        /* see: pmix_server.c initialize_server_base()
-         * to get format of uri
-         */
-        if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
-            static char buf[100];
-            snprintf(buf, sizeof(buf) - 1, "pmix-%d", getpid());
-            str = buf;
-        } else {
-            str = getenv("PMIX_SERVER_URI");
-            if (str) {
-                str = strrchr(str, '/');
-            }
-            str = (str ? str + 1 : "$$$");
-        }
-    }
-    return str;
-}
-
 static inline int _esh_dir_del(const char *path)
 {
     DIR *dir;

--- a/src/mca/pshmem/mmap/pshmem_mmap.c
+++ b/src/mca/pshmem/mmap/pshmem_mmap.c
@@ -107,7 +107,9 @@ static int _mmap_segment_create(pmix_pshmem_seg_t *sm_seg, const char *file_name
         rc = PMIX_SUCCESS;
     }
 
-map_memory:
+#ifdef HAVE_POSIX_FALLOCATE
+  map_memory:
+#endif
     if (MAP_FAILED == (seg_addr = mmap(NULL, size,
                                        PROT_READ | PROT_WRITE, MAP_SHARED,
                                        sm_seg->seg_id, 0))) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -87,8 +87,6 @@ static void server_message_handler(struct pmix_peer_t *pr,
                                    pmix_ptl_hdr_t *hdr,
                                    pmix_buffer_t *buf, void *cbdata);
 
-static inline int _my_client(const char *nspace, pmix_rank_t rank);
-
 PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                                            pmix_info_t info[], size_t ninfo)
 {
@@ -2348,22 +2346,4 @@ static void server_message_handler(struct pmix_peer_t *pr,
         }
         PMIX_SERVER_QUEUE_REPLY(peer, hdr->tag, reply);
     }
-}
-
-static inline int _my_client(const char *nspace, pmix_rank_t rank)
-{
-    pmix_peer_t *peer;
-    int i;
-    int local = 0;
-
-    for (i = 0; i < pmix_server_globals.clients.size; i++) {
-        if (NULL != (peer = (pmix_peer_t *)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {
-            if (0 == strcmp(peer->info->pname.nspace, nspace) && peer->info->pname.rank == rank) {
-                local = 1;
-                break;
-            }
-        }
-    }
-
-    return local;
 }


### PR DESCRIPTION
Add an example that tests it. Cleanup a few warnings

Signed-off-by: Ralph Castain <rhc@open-mpi.org>