### PR TITLE
Sync NEWS from v1.2 series

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -83,6 +83,28 @@ Master (not on release branches yet)
   and to themselves
 
 
+1.2.4 -- 13 Oct. 2017
+----------------------
+- Silence some unnecessary warning messages (PR #487)
+- Coverity fix - TOCTOU (PR #465)
+- automake 1.13 configure fix (PR #486)
+- Update RPM spec file (rpmbuild -ta, and --rebuild fixes) (PR #523)
+- Support singletons in PMI-1/PMI-2 (PR #537)
+
+
+1.2.3 -- 24 Aug. 2017
+----------------------
+- Resolve visibility issues for public APIs (PR #451)
+- Atomics update - remove custom ASM atomics (PR #458)
+- Fix job-fence test (PR #423)
+- Replace stale PMIX_DECLSPEC with PMIX_EXPORT (PR #448)
+- Memory barrier fixes for thread shifting (PR #387)
+- Fix race condition in dmodex (PR #346)
+- Allow disable backward compatability for PMI-1/2 (PR #350)
+- Fix segv in PMIx_server_deregister_nspace (PR #343)
+- Fix possible hang in PMIx_Abort (PR #339)
+
+
 1.2.2 -- 21 March 2017
 ----------------------
 - Compiler fix for Sun/Oracle CC (PR #322)


### PR DESCRIPTION
Since 1.2.4 is likely/hopefully the last in that series. I thought it would be good to sync the NEWS file with master. Probably should push to this the v2.x release branch too.

bot:notest
