### PR TITLE
Introduce PMIx-based tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,13 @@ src/include/frameworks.h
 src/mca/pinstalldirs/config/pinstall_dirs.h
 src/mca/pdl/base/static-components.h
 src/mca/pinstalldirs/base/static-components.h
+
+src/tools/pevent/pevent
+src/tools/pinfo/pinfo
+src/tools/plookup/plookup
+src/tools/pps/pps
+src/tools/ptop/ptop
+
 src/util/show_help_lex.c
 src/util/keyval/keyval_lex.c
 

--- a/autogen.pl
+++ b/autogen.pl
@@ -254,7 +254,7 @@ sub mca_generate_framework_header(\$\@) {
 
     foreach my $framework (@frameworks) {
         # There is no common framework object
-        if ($framework ne "common") {
+        if ($framework ne "common" and $framework ne "src") {
             my $framework_name = "pmix_${framework}_base_framework";
             $framework_array_output .= "    &$framework_name,\n";
             $framework_decl_output .= "extern pmix_mca_base_framework_t $framework_name;\n";
@@ -269,7 +269,7 @@ sub mca_generate_framework_header(\$\@) {
 #ifndef $ifdef_string
 #define $ifdef_string
 
-#include <pmix/mca/base/mca_base_framework.h>
+#include <src/mca/base/pmix_mca_base_framework.h>
 
 $framework_decl_output
 static pmix_mca_base_framework_t *pmix_frameworks[] = {

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -123,6 +123,24 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_RELEASE_VERSION], [$PMIX_RELEASE_VERSION],
                        [The library release version is always available, contrary to VERSION])
 
+    PMIX_GREEK_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --greek`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_SUBST(PMIX_GREEK_VERSION)
+
+    PMIX_REPO_REV="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --repo-rev`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_SUBST(PMIX_REPO_REV)
+
+    PMIX_RELEASE_DATE="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --release-date`"
+    if test "$?" != "0"; then
+        AC_MSG_ERROR([Cannot continue])
+    fi
+    AC_SUBST(PMIX_RELEASE_DATE)
+
     # Debug mode?
     AC_MSG_CHECKING([if want pmix maintainer support])
     pmix_debug=
@@ -174,6 +192,21 @@ AC_DEFUN([PMIX_SETUP_CORE],[
           [AC_MSG_RESULT([no])
            PMIX_EXTRA_LIB=])
     AC_SUBST(PMIX_EXTRA_LIB)
+
+    #
+    # Package/brand string
+    #
+    AC_MSG_CHECKING([if want package/brand string])
+    AC_ARG_WITH([pmix-package-string],
+         [AC_HELP_STRING([--with-pmix-package-string=STRING],
+                         [Use a branding string throughout PMIx])])
+    if test "$with_pmix_package_string" = "" || test "$with_pmix_package_string" = "no"; then
+        with_package_string="PMIx $PMIX_CONFIGURE_USER@$PMIX_CONFIGURE_HOST Distribution"
+    fi
+    AC_DEFINE_UNQUOTED([PMIX_PACKAGE_STRING], ["$with_package_string"],
+         [package/branding string for PMIx])
+    AC_MSG_RESULT([$with_package_string])
+
 
     # GCC specifics.
     if test "x$GCC" = "xyes"; then
@@ -794,6 +827,10 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/Makefile]
         pmix_config_prefix[src/util/keyval/Makefile]
         pmix_config_prefix[src/mca/base/Makefile]
+        pmix_config_prefix[src/tools/pevent/Makefile]
+        pmix_config_prefix[src/tools/pinfo/Makefile]
+        pmix_config_prefix[src/tools/plookup/Makefile]
+        pmix_config_prefix[src/tools/pps/Makefile]
         )
 
     # publish any embedded flags so external wrappers can use them
@@ -1059,6 +1096,13 @@ else
 fi
 
 AM_CONDITIONAL([WANT_INSTALL_HEADERS], [test $WANT_INSTALL_HEADERS -eq 1])
+
+#
+# Do we want to install binaries?
+#
+AM_CONDITIONAL([PMIX_INSTALL_BINARIES], [test "$pmix_mode" != "embedded"])
+
+
 ])dnl
 
 # This must be a standalone routine so that it can be called both by

--- a/config/pmix_check_compiler_version.m4
+++ b/config/pmix_check_compiler_version.m4
@@ -22,7 +22,7 @@ AC_DEFUN([PMIX_CHECK_COMPILER_VERSION_ID],
     PMIX_CHECK_COMPILER(FAMILYID)
     PMIX_CHECK_COMPILER_STRINGIFY(FAMILYNAME)
     PMIX_CHECK_COMPILER(VERSION)
-    PMIX_CHECK_COMPILER_STRINGIFY(VERSION_STR)
+    PMIX_CHECK_COMPILER_STRING(VERSION_STR)
 ])dnl
 
 
@@ -31,10 +31,11 @@ AC_DEFUN([PMIX_CHECK_COMPILER], [
     AC_CACHE_CHECK([for compiler $lower], pmix_cv_compiler_[$1],
     [
             CPPFLAGS_orig=$CPPFLAGS
-            CPPFLAGS="-I${top_pmix_srcdir}/src/include $CPPFLAGS"
+            CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
             AC_TRY_RUN([
 #include <stdio.h>
 #include <stdlib.h>
+#include "pmix_portable_platform.h"
 
 int main (int argc, char * argv[])
 {
@@ -57,16 +58,51 @@ int main (int argc, char * argv[])
                        [The compiler $lower which PMIx was built with])
 ])dnl
 
+AC_DEFUN([PMIX_CHECK_COMPILER_STRING], [
+    lower=m4_tolower($1)
+    AC_CACHE_CHECK([for compiler $lower], pmix_cv_compiler_[$1],
+    [
+            CPPFLAGS_orig=$CPPFLAGS
+            CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
+            AC_TRY_RUN([
+#include <stdio.h>
+#include <stdlib.h>
+#include "pmix_portable_platform.h"
+
+int main (int argc, char * argv[])
+{
+    FILE * f;
+    f=fopen("conftestval", "w");
+    if (!f) exit(1);
+    fprintf (f, "%s", PLATFORM_COMPILER_$1);
+    return 0;
+}
+            ], [
+                eval pmix_cv_compiler_$1=`cat conftestval`;
+            ], [
+                eval pmix_cv_compiler_$1=UNKNOWN
+            ], [
+                eval pmix_cv_compiler_$1=UNKNOWN
+            ])
+            CPPFLAGS=$CPPFLAGS_orig
+    ])
+    AC_DEFINE_UNQUOTED([PMIX_BUILD_PLATFORM_COMPILER_$1], $pmix_cv_compiler_[$1],
+                       [The compiler $lower which PMIx was built with])
+])dnl
+
+
+
 
 AC_DEFUN([PMIX_CHECK_COMPILER_STRINGIFY], [
     lower=m4_tolower($1)
     AC_CACHE_CHECK([for compiler $lower], pmix_cv_compiler_[$1],
     [
             CPPFLAGS_orig=$CPPFLAGS
-            CPPFLAGS="-I${top_pmix_srcdir}/src/include $CPPFLAGS"
+            CPPFLAGS="-I${top_srcdir}/src/include $CPPFLAGS"
             AC_TRY_RUN([
 #include <stdio.h>
 #include <stdlib.h>
+#include "pmix_portable_platform.h"
 
 int main (int argc, char * argv[])
 {

--- a/config/pmix_functions.m4
+++ b/config/pmix_functions.m4
@@ -13,7 +13,7 @@ dnl                         All rights reserved.
 dnl Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
 dnl Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2009-2016 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2017      Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl
@@ -102,21 +102,21 @@ PMIX_CONFIGURE_DATE="`date`"
 # Save these details so that they can be used in pmix_info later
 #
 AC_SUBST(PMIX_CONFIGURE_USER)
+AC_DEFINE_UNQUOTED([PMIX_CONFIGURE_USER], "$PMIX_CONFIGURE_USER",
+                   [User who built PMIx])
 AC_SUBST(PMIX_CONFIGURE_HOST)
-AC_SUBST(PMIX_CONFIGURE_DATE)])dnl
+AC_DEFINE_UNQUOTED([PMIX_CONFIGURE_HOST], "$PMIX_CONFIGURE_HOST",
+                   [Hostname where PMIx was built])
+AC_SUBST(PMIX_CONFIGURE_DATE)
+AC_DEFINE_UNQUOTED([PMIX_CONFIGURE_DATE], "$PMIX_CONFIGURE_DATE",
+                   [Date when PMIx was built])
+])dnl
 
 dnl #######################################################################
 dnl #######################################################################
 dnl #######################################################################
 
 AC_DEFUN([PMIX_BASIC_SETUP],[
-#
-# Save some stats about this build
-#
-
-PMIX_CONFIGURE_USER="`whoami`"
-PMIX_CONFIGURE_HOST="`(hostname || uname -n) 2> /dev/null | sed 1q`"
-PMIX_CONFIGURE_DATE="`date`"
 
 #
 # Make automake clean emacs ~ files for "make clean"

--- a/config/pmix_set_mca_prefix.m4
+++ b/config/pmix_set_mca_prefix.m4
@@ -1,0 +1,41 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# PMIX_SET_MCA_PREFIX([mca_prefix]
+#
+# This macro sets a prefix for the MCA parameter system.  Specifically,
+# OMPI_MCA_<foo> becomes <mca_prefix>_<foo>
+#
+# --------------------------------------------------------
+AC_DEFUN([PMIX_SET_MCA_PREFIX],[
+    AS_IF([test "$pmix_mca_prefix_set" = "yes"],
+          [AC_MSG_WARN([PMIX mca prefix was already set!])
+           AC_MSG_WARN([This is a configury programming error])
+           AC_MSG_ERROR([Cannot continue])])
+
+    MCA_PREFIX=$1
+    pmix_mca_prefix_set=yes
+    AC_DEFINE_UNQUOTED([PMIX_MCA_PREFIX], ["$MCA_PREFIX"], [MCA prefix string for envars])
+])dnl
+
+#
+# Set the MCA cmd line identifier - i.e., change "-mca" to "-<foo>"
+#
+AC_DEFUN([PMIX_SET_MCA_CMD_LINE_ID],[
+    AS_IF([test "$pmix_mca_cmd_id_set" = "yes"],
+          [AC_MSG_WARN([PMIX mca cmd line id was already set!])
+           AC_MSG_WARN([This is a configury programming error])
+           AC_MSG_ERROR([Cannot continue])])
+
+    MCA_CMD_LINE_ID=$1
+    pmix_mca_cmd_id_set=yes
+    AC_DEFINE_UNQUOTED([PMIX_MCA_CMD_LINE_ID], ["$MCA_CMD_LINE_ID"], [MCA cmd line identifier])
+])dnl

--- a/config/pmix_setup_cli.m4
+++ b/config/pmix_setup_cli.m4
@@ -1,0 +1,38 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2017      Intel, Inc. All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+
+dnl PMIX_CAPTURE_CONFIGURE_CLI
+dnl
+dnl Capture configure command line and do the AC substitution
+dnl
+dnl Arguments: the variable in which command line will be captured
+dnl
+dnl Dependencies: None
+dnl
+AC_DEFUN([PMIX_CAPTURE_CONFIGURE_CLI],[
+    # Capture configure command line do the AC substitution
+    PMIX_VAR_SCOPE_PUSH([sed_quote_subst arg quoted_arg])
+    $1=
+    for arg in "$[]@"; do
+        sed_quote_subst='s/\(@<:@`"$\\@:>@\)/\\\1/g'
+        case "$arg" in
+          *@<:@\\\`\"\$[]@:>@*)
+	    quoted_arg=\'`echo "$arg" | sed $sed_quote_subst`\' ;;
+          *)
+            quoted_arg="\'$arg\'" ;;
+        esac
+
+        eval "$1=\$$1\\ \$quoted_arg"
+    done
+    PMIX_VAR_SCOPE_POP
+    AC_SUBST($1)
+])

--- a/configure.ac
+++ b/configure.ac
@@ -51,16 +51,20 @@ AC_CONFIG_AUX_DIR(./config)
 # -I in ACLOCAL_AMFLAGS in the top-level Makefile.am.
 AC_CONFIG_MACRO_DIR(./config)
 
+PMIX_CAPTURE_CONFIGURE_CLI([PMIX_CONFIGURE_CLI])
+
 # Get our platform support file.  This has to be done very, very early
 # because it twiddles random bits of autoconf
 PMIX_LOAD_PLATFORM
 
 PMIX_TOP_BUILDDIR="`pwd`"
 AC_SUBST(PMIX_TOP_BUILDDIR)
+top_buildir=`pwd`
 cd "$srcdir"
 PMIX_TOP_SRCDIR="`pwd`"
 AC_SUBST(PMIX_TOP_SRCDIR)
 cd "$PMIX_TOP_BUILDDIR"
+top_srcdir=`pwd`
 
 AC_MSG_NOTICE([builddir: $PMIX_TOP_BUILDDIR])
 AC_MSG_NOTICE([srcdir: $PMIX_TOP_SRCDIR])
@@ -164,6 +168,10 @@ AM_PROG_LEX
 ############################################################################
 # Configuration options
 ############################################################################
+
+# Set the MCA prefix
+PMIX_SET_MCA_PREFIX([PMIX_MCA_])
+PMIX_SET_MCA_CMD_LINE_ID([pmca])
 
 # Define PMIx configure arguments
 PMIX_DEFINE_ARGS

--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -461,7 +461,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %files
 %defattr(-, root, root, -)
 %if %(test "%{_prefix}" = "/usr" && echo 1 || echo 0)
-#%{_bindir}/*
+%{_bindir}/*
 %{_includedir}/*
 %{_libdir}/*
 %{_datadir}
@@ -472,7 +472,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %if !%{sysconfdir_in_prefix}
 %{_sysconfdir}/*
 %endif
-# If %{install_in_opt}, then we're instaling PMIx to
+# If %{install_in_opt}, then we're installing PMIx to
 # /opt/pmix<version>.  But be sure to also explicitly mention
 # /opt/pmix so that it can be removed by RPM when everything under
 # there is also removed.
@@ -497,6 +497,9 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 #
 #############################################################################
 %changelog
+* Tue Oct 17 2017 Ralph Castain <rhc@open-mpi.org>
+- Add PMIx bin directory
+
 * Thu Sep 21 2017 Ralph Castain <rhc@open-mpi.org>
 - Add PMIx etc directory
 

--- a/examples/debugger.c
+++ b/examples/debugger.c
@@ -23,24 +23,63 @@
  *
  */
 
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <pthread.h>
 
 #include <pmix_tool.h>
 
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
 
 /* define a structure for collecting returned
  * info from a query */
 typedef struct {
-    volatile bool active;
+    mylock_t lock;
     pmix_info_t *info;
     size_t ninfo;
 } myquery_data_t;
 
 static int attach_to_running_job(char *nspace);
-static bool waiting_for_debugger = true;
+static mylock_t waiting_for_debugger;
 static pmix_proc_t myproc;
 
 /* this is a callback function for the PMIx_Query
@@ -83,7 +122,7 @@ static void cbfunc(pmix_status_t status,
     }
 
     /* release the block */
-    mq->active = false;
+    DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
 /* this is the event notification function we pass down below
@@ -124,7 +163,7 @@ static void release_fn(size_t evhdlr_registration_id,
         cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
     }
     /* flag that the debugger is complete so we can exit */
-    waiting_for_debugger = false;
+    DEBUG_WAKEUP_THREAD(&waiting_for_debugger);
 }
 
 /* event handler registration is done asynchronously because it
@@ -138,31 +177,72 @@ static void evhandler_reg_callbk(pmix_status_t status,
                                  size_t evhandler_ref,
                                  void *cbdata)
 {
-    volatile int *active = (volatile int*)cbdata;
+    mylock_t *lock = (mylock_t*)cbdata;
 
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
                    myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
     }
-    *active = status;
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
 }
+
+static pmix_status_t spawn_debugger(char *appspace)
+{
+    pmix_status_t rc;
+    pmix_info_t *dinfo;
+    pmix_app_t *debugger;
+    size_t dninfo;
+    char cwd[1024];
+    char dspace[PMIX_MAX_NSLEN+1];
+
+    /* setup the debugger */
+    PMIX_APP_CREATE(debugger, 1);
+    debugger[0].cmd = strdup("./debuggerd");
+    PMIX_ARGV_APPEND(rc, debugger[0].argv, "./debuggerd");
+    getcwd(cwd, 1024);  // point us to our current directory
+    debugger[0].cwd = strdup(cwd);
+    /* provide directives so the daemons go where we want, and
+     * let the RM know these are debugger daemons */
+    dninfo = 5;
+    PMIX_INFO_CREATE(dinfo, dninfo);
+    PMIX_INFO_LOAD(&dinfo[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
+    PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
+    PMIX_INFO_LOAD(&dinfo[2], PMIX_DEBUG_JOB, appspace, PMIX_STRING); // the nspace being debugged
+    PMIX_INFO_LOAD(&dinfo[3], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
+    PMIX_INFO_LOAD(&dinfo[4], PMIX_DEBUG_WAITING_FOR_NOTIFY, NULL, PMIX_BOOL);  // tell the daemon that the proc is waiting to be released
+    /* spawn the daemons */
+    fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
+    if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
+        fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
+    }
+    fprintf(stderr, "SPAWNED DEBUGGERD\n");
+    /* cleanup */
+    PMIX_INFO_FREE(dinfo, dninfo);
+    PMIX_APP_FREE(debugger, 1);
+
+    return rc;
+}
+
+#define DBGR_LOOP_LIMIT  10
 
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
-    pmix_info_t *info, *dinfo;
-    pmix_app_t *app, *debugger;
-    size_t ninfo, napps, dninfo;
-    char *tdir, *nspace = NULL;
-    char appspace[PMIX_MAX_NSLEN+1], dspace[PMIX_MAX_NSLEN+1];
+    pmix_info_t *info;
+    pmix_app_t *app;
+    size_t ninfo, napps;
+    char *tdir, *filename, *sdir, *str, *nspace = NULL;
+    char appspace[PMIX_MAX_NSLEN+1];
     int i;
     pmix_query_t *query;
     size_t nq, n;
     myquery_data_t myquery_data;
     bool cospawn = false, stop_on_exec = false;
     char cwd[1024];
-    volatile int active;
     pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
+    char hostname[1024];
+    mylock_t mylock;
 
     /* Process any arguments we were given */
     for (i=1; i < argc; i++) {
@@ -191,33 +271,15 @@ int main(int argc, char **argv)
             exit(1);
         }
     }
+    info = NULL;
+    ninfo = 0;
 
-    /* we need to provide some info to the PMIx tool library so
-     * it can find the server's contact info. The simplest way
-     * of doing this here is to look for an environmental variable
-     * that tells us where to look. The PMIx reference server only
-     * allows one instantiation of the server per user, so setting
-     * this up is something a user could do in their login script.
-     * The reference server is based on OpenMPI, and so the contact
-     * info will always be found at:
-     *
-     * $TMPDIR/ompi.<nodename>.<numerical-userid>/dvm
-     *
-     * NOTE: we will eliminate this requirement in a future version
-     */
+    DEBUG_CONSTRUCT_LOCK(&waiting_for_debugger);
 
-    if (NULL == (tdir = getenv("PMIX_SERVER_TMPDIR"))) {
-        fprintf(stderr, "Tool usage requires that the PMIX_SERVER_TMPDIR envar\n");
-        fprintf(stderr, "be set to point at the directory where the PMIx Reference\n");
-        fprintf(stderr, "Server leaves its contact info file.\n");
-        exit(1);
-    }
-
-    /* init us - pass along the location of the contact file */
-    ninfo = 1;
-    PMIX_INFO_CREATE(info, ninfo);
-    PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TMPDIR, tdir, PMIX_STRING);
-
+    /* use the system connection first, if available */
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* init as a tool */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
         fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
         exit(rc);
@@ -227,27 +289,19 @@ int main(int argc, char **argv)
     fprintf(stderr, "Tool ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
 
     /* register a default event handler */
-    active = -1;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, evhandler_reg_callbk, (void*)&active);
-    while (-1 == active) {
-        usleep(10);
-    }
-    if (0 != active) {
-        exit(active);
-    }
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
 
     /* register another handler specifically for when the debugger
      * job completes */
-    active = -1;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(&code, 1, NULL, 0,
-                                release_fn, evhandler_reg_callbk, (void*)&active);
-    while (-1 == active) {
-        usleep(10);
-    }
-    if (0 != active) {
-        exit(active);
-    }
+                                release_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
 
     /* if we are attaching to a running job, then attach to it */
     if (NULL != nspace) {
@@ -270,18 +324,17 @@ int main(int argc, char **argv)
         PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_SPAWN_SUPPORT);
         PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_DEBUG_SUPPORT);
         /* setup the caddy to retrieve the data */
+        DEBUG_CONSTRUCT_LOCK(&myquery_data.lock);
         myquery_data.info = NULL;
         myquery_data.ninfo = 0;
-        myquery_data.active = true;
         /* execute the query */
         fprintf(stderr, "Debugger: querying capabilities\n");
         if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&myquery_data))) {
             fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
             goto done;
         }
-        while (myquery_data.active) {
-            usleep(10);
-        }
+        DEBUG_WAIT_THREAD(&myquery_data.lock);
+        DEBUG_DESTRUCT_LOCK(&myquery_data.lock);
 
         /* we should have received back two info structs, one containing
          * a comma-delimited list of PMIx spawn attributes the RM supports,
@@ -334,13 +387,11 @@ int main(int argc, char **argv)
             /* setup the executable */
             app[0].cmd = strdup("client");
             PMIX_ARGV_APPEND(rc, app[0].argv, "./client");
-            if (NULL == getcwd(cwd, 1024)) {  // point us to our current directory
-                goto done;
-            }
+            getcwd(cwd, 1024);  // point us to our current directory
             app[0].cwd = strdup(cwd);
             app[0].maxprocs = 2;
             /* provide job-level directives so the apps do what the user requested */
-            ninfo = 2;
+            ninfo = 4;
             PMIX_INFO_CREATE(info, ninfo);
             PMIX_INFO_LOAD(&info[0], PMIX_MAPBY, "slot", PMIX_STRING);  // map by slot
             if (stop_on_exec) {
@@ -348,113 +399,59 @@ int main(int argc, char **argv)
             } else {
                 PMIX_INFO_LOAD(&info[1], PMIX_DEBUG_STOP_IN_INIT, NULL, PMIX_BOOL);  // procs are to pause in PMIx_Init for debugger attach
             }
+            PMIX_INFO_LOAD(&info[2], PMIX_FWD_STDOUT, NULL, PMIX_BOOL);  // forward stdout to me
+            PMIX_INFO_LOAD(&info[3], PMIX_FWD_STDERR, NULL, PMIX_BOOL);  // forward stderr to me
+
             /* spawn the job - the function will return when the app
              * has been launched */
             fprintf(stderr, "Debugger: spawning %s\n", app[0].cmd);
             if (PMIX_SUCCESS != (rc = PMIx_Spawn(info, ninfo, app, napps, appspace))) {
-                fprintf(stderr, "Application failed to launch with error: %s\n", PMIx_Error_string(rc));
+                fprintf(stderr, "Application failed to launch with error: %s(%d)\n", PMIx_Error_string(rc), rc);
                 goto done;
             }
             PMIX_INFO_FREE(info, ninfo);
             PMIX_APP_FREE(app, napps);
 
-            /* setup the debugger */
-            PMIX_APP_CREATE(debugger, 1);
-            debugger[0].cmd = strdup("./debuggerd");
-            PMIX_ARGV_APPEND(rc, debugger[0].argv, "./debuggerd");
-            debugger[0].cwd = strdup(cwd);
-            /* provide directives so the daemons go where we want, and
-             * let the RM know these are debugger daemons */
-            dninfo = 5;
-            PMIX_INFO_CREATE(dinfo, dninfo);
-            PMIX_INFO_LOAD(&dinfo[0], PMIX_MAPBY, "ppr:1:node", PMIX_STRING);  // instruct the RM to launch one copy of the executable on each node
-            PMIX_INFO_LOAD(&dinfo[1], PMIX_DEBUGGER_DAEMONS, NULL, PMIX_BOOL); // these are debugger daemons
-            PMIX_INFO_LOAD(&dinfo[2], PMIX_DEBUG_JOB, appspace, PMIX_STRING); // the nspace being debugged
-            PMIX_INFO_LOAD(&dinfo[3], PMIX_NOTIFY_COMPLETION, NULL, PMIX_BOOL); // notify us when the debugger job completes
-            PMIX_INFO_LOAD(&dinfo[4], PMIX_DEBUG_WAITING_FOR_NOTIFY, NULL, PMIX_BOOL);  // tell the daemon that the proc is waiting to be released
-            /* spawn the daemons */
-            fprintf(stderr, "Debugger: spawning %s\n", debugger[0].cmd);
-            if (PMIX_SUCCESS != (rc = PMIx_Spawn(dinfo, dninfo, debugger, 1, dspace))) {
-                fprintf(stderr, "Debugger daemons failed to launch with error: %s\n", PMIx_Error_string(rc));
+            /* now launch the debugger daemons */
+            if (PMIX_SUCCESS != (rc = spawn_debugger(appspace))) {
                 goto done;
             }
-
-            /* cleanup */
-            PMIX_INFO_FREE(dinfo, dninfo);
-            PMIX_APP_FREE(debugger, 1);
         }
 
 
         /* this is where a debugger tool would wait until the debug operation is complete */
-        while (waiting_for_debugger) {
-            sleep(1);
-        }
+        DEBUG_WAIT_THREAD(&waiting_for_debugger);
     }
 
   done:
+    DEBUG_DESTRUCT_LOCK(&waiting_for_debugger);
     PMIx_tool_finalize();
 
     return(rc);
 }
 
-typedef struct {
-    volatile bool active;
-    pmix_status_t status;
-    pmix_info_t *info;
-    size_t ninfo;
-} mydbug_query_t;
-
-
-static void infocbfunc(pmix_status_t status,
-                       pmix_info_t *info, size_t ninfo,
-                       void *cbdata,
-                       pmix_release_cbfunc_t release_fn,
-                       void *release_cbdata)
-{
-    mydbug_query_t *q = (mydbug_query_t*)cbdata;
-    size_t n;
-
-    q->status = status;
-    q->info = NULL;
-    q->ninfo = ninfo;
-    if (0 < ninfo) {
-        PMIX_INFO_CREATE(q->info, q->ninfo);
-        for (n=0; n < ninfo; n++) {
-            PMIX_INFO_XFER(&q->info[n], &info[n]);
-        }
-    }
-    if (NULL != release_fn) {
-        release_fn(release_cbdata);
-    }
-    q->active = false;
-}
-
 static int attach_to_running_job(char *nspace)
 {
     pmix_status_t rc;
+    pmix_proc_t myproc;
     pmix_query_t *query;
     size_t nq;
-    mydbug_query_t *q;
+    myquery_data_t *q;
 
     /* query the active nspaces so we can verify that the
      * specified one exists */
     nq = 1;
     PMIX_QUERY_CREATE(query, nq);
-    query[0].keys = (char**)malloc(2 * sizeof(char*));
-    query[0].keys[0] = strdup(PMIX_QUERY_NAMESPACES);
-    query[0].keys[1] = NULL;
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
 
-    q = (mydbug_query_t*)malloc(sizeof(mydbug_query_t));
-    q->active = true;
-
-    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, infocbfunc, (void*)q))) {
+    q = (myquery_data_t*)malloc(sizeof(myquery_data_t));
+    DEBUG_CONSTRUCT_LOCK(&q->lock);
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)q))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Query_info failed: %d\n", myproc.nspace, myproc.rank, rc);
         return -1;
     }
-    /* wait for a response */
-    while (q->active) {
-        sleep(1);
-    }
+    DEBUG_WAIT_THREAD(&q->lock);
+    DEBUG_DESTRUCT_LOCK(&q->lock);
 
     if (NULL == q->info) {
         fprintf(stderr, "Query returned no info\n");

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,7 @@ include client/Makefile.include
 include server/Makefile.include
 include runtime/Makefile.include
 include tool/Makefile.include
+include tools/Makefile.include
 include common/Makefile.include
 
 MAINTAINERCLEANFILES = Makefile.in config.h config.h.in

--- a/src/include/Makefile.include
+++ b/src/include/Makefile.include
@@ -37,7 +37,8 @@ headers += \
         include/prefetch.h \
         include/types.h \
         include/pmix_config_top.h \
-        include/pmix_config_bottom.h
+        include/pmix_config_bottom.h \
+        include/pmix_portable_platform.h
 
 endif ! PMIX_EMBEDDED_MODE
 

--- a/src/include/pmix_portable_platform.h
+++ b/src/include/pmix_portable_platform.h
@@ -1,0 +1,401 @@
+/*
+ * Header file with preprocessor magic to figure out, which compiler the user has been calling!
+ *
+ * This code is adapted from the file other/portable_platform.h of GASnet-1.14.0:
+ *  - Ripping out the required parts.
+ *  - Get rid of brackets as it messes up autoconf
+ *  - Delete version tests for older PGI versions (#include "omp.h" not acceptabe)
+ *  - Indent ('#' should be in column 0)
+ *
+ * External packages (i.e., romio) depend on top_build_dir/ompi/include, therefore
+ * although this is not changed in the configure process, this has to be set as
+ * a .in file...
+ * ---------------------------------------------------------------------------
+ */
+#ifndef PMIX_PORTABLE_PLATFORM_H
+#define PMIX_PORTABLE_PLATFORM_H
+
+/* All files in this directory and all sub-directories (except where otherwise noted)
+ * are subject to the following licensing terms:
+ *
+ * ---------------------------------------------------------------------------
+ * "Copyright (c) 2000-2003 The Regents of the University of California.
+ * All rights reserved.
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without written agreement is
+ * hereby granted, provided that the above copyright notice and the following
+ * two paragraphs appear in all copies of this software.
+ *
+ * IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT
+ * OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF
+ * CALIFORNIA HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE UNIVERSITY OF CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS
+ * ON AN "AS IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATION TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS."
+ * ---------------------------------------------------------------------------
+ *
+ * Please see the license.txt files within the gm-conduit, lapi-conduit and
+ * vapi-conduit directories for the licensing terms governing those
+ * contributed components.
+ *
+ * The authors/contributors of GASNet include:
+ *
+ *  Dan Bonachea <bonachea@cs.berkeley.edu>:
+ *    General infrastructure & documentation
+ *    mpi-conduit
+ *    elan-conduit
+ *    smp-conduit
+ *    udp-conduit
+ *    extended-ref
+ *    template-conduit
+ *  Christian Bell <csbell@cs.berkeley.edu>: gm-conduit, shmem-conduit
+ *  Mike Welcome <mlwelcome@lbl.gov>: lapi-conduit, portals-conduit
+ *  Paul H. Hargrove <phhargrove@lbl.gov>: vapi-conduit, ibv-conduit
+ *  Rajesh Nishtala <rajeshn@cs.berkeley.edu>: collectives, dcmf-conduit
+ *  Parry Husbands (PJRHusbands@lbl.gov): lapi-conduit
+ *
+ * For more information about GASNet, visit our home page at:
+ *  http://gasnet.cs.berkeley.edu/
+ * Or send email to:
+ *  <upc@lbl.gov>
+ *
+ * Source code contributions (fixes, patches, extensions etc.) should be
+ * sent to <upc@lbl.gov> to be reviewed for acceptance into the primary
+ * distribution. Contributions are most likely to be accepted if they
+ * are provided as public domain, or under a BSD-style license such as
+ * the one above.
+ *
+ */
+#ifndef _STRINGIFY
+#define _STRINGIFY_HELPER(x) #x
+#define _STRINGIFY(x) _STRINGIFY_HELPER(x)
+#endif
+
+#if defined(__INTEL_COMPILER)
+#    define PLATFORM_COMPILER_FAMILYNAME INTEL
+#    define PLATFORM_COMPILER_FAMILYID 2
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_INTEL_CXX  1
+#    else
+#        define PLATFORM_COMPILER_INTEL_C  1
+#    endif
+#    define _PLATFORM_COMPILER_INTEL_MIN_BUILDDATE 19700000 /* year 1970: predates most intel products :) */
+#    ifdef __INTEL_COMPILER_BUILD_DATE
+#        define _PLATFORM_INTEL_COMPILER_BUILD_DATE __INTEL_COMPILER_BUILD_DATE
+#    else
+#        define _PLATFORM_INTEL_COMPILER_BUILD_DATE _PLATFORM_COMPILER_INTEL_MIN_BUILDDATE
+#    endif
+     /* patch number is a decimal build date: YYYYMMDD */
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat)         \
+         (((((maj) * 10) | (min)) << 20) |                      \
+            ((pat) < _PLATFORM_COMPILER_INTEL_MIN_BUILDDATE ?   \
+             _PLATFORM_COMPILER_INTEL_MIN_BUILDDATE : ((pat)-_PLATFORM_COMPILER_INTEL_MIN_BUILDDATE)))
+#    define PLATFORM_COMPILER_VERSION \
+         PLATFORM_COMPILER_VERSION_INT(__INTEL_COMPILER/10, __INTEL_COMPILER/100, _PLATFORM_INTEL_COMPILER_BUILD_DATE)
+#    define PLATFORM_COMPILER_VERSION_STR \
+         _STRINGIFY(__INTEL_COMPILER) "." _STRINGIFY(_PLATFORM_INTEL_COMPILER_BUILD_DATE)
+
+#elif defined(__PATHSCALE__)
+#    define PLATFORM_COMPILER_PATHSCALE  1
+#    define PLATFORM_COMPILER_FAMILYNAME PATHSCALE
+#    define PLATFORM_COMPILER_FAMILYID 3
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_PATHSCALE_CXX  1
+#    else
+#        define PLATFORM_COMPILER_PATHSCALE_C  1
+#    endif
+#    define PLATFORM_COMPILER_VERSION \
+         PLATFORM_COMPILER_VERSION_INT(__PATHCC__,__PATHCC_MINOR__,__PATHCC_PATCHLEVEL__)
+#    define PLATFORM_COMPILER_VERSION_STR __PATHSCALE__
+
+#elif defined(__PGI)
+#    define PLATFORM_COMPILER_PGI  1
+#    define PLATFORM_COMPILER_FAMILYNAME PGI
+#    define PLATFORM_COMPILER_FAMILYID 4
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_PGI_CXX  1
+#    else
+#        define PLATFORM_COMPILER_PGI_C  1
+#    endif
+#    if __PGIC__ == 99
+      /* bug 2230: PGI versioning was broken for some platforms in 7.0
+         no way to know exact version, but provide something slightly more accurate */
+#      define PLATFORM_COMPILER_VERSION 0x070000
+#      define PLATFORM_COMPILER_VERSION_STR "7.?-?"
+#    elif defined(__PGIC__) && defined(__PGIC_MINOR__) && defined(__PGIC_PATCHLEVEL__)
+#      define PLATFORM_COMPILER_VERSION \
+            PLATFORM_COMPILER_VERSION_INT(__PGIC__,__PGIC_MINOR__,__PGIC_PATCHLEVEL__)
+#      define PLATFORM_COMPILER_VERSION_STR \
+            _STRINGIFY(__PGIC__) "." _STRINGIFY(__PGIC_MINOR__) "-" _STRINGIFY(__PGIC_PATCHLEVEL__)
+#    else
+       /* PGI before 6.1-4 lacks any version ID preprocessor macros - so use this filthy hack */
+       /* XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        * We cannot do these within mpi.h.in, as we should not include ompi.h
+        * Hopefully, compilers with integrated preprocessors will not analyse code within the #if 0-block
+        * XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+        */
+#if 0
+#        ifdef PLATFORM_PGI_IS_ANCIENT
+         /* Include below might fail for ancient versions lacking this header, but testing shows it
+            works back to at least 5.1-3 (Nov 2003), and based on docs probably back to 3.2 (Sep 2000) */
+#            define PLATFORM_COMPILER_VERSION 0
+#        elif defined(__x86_64__) /* bug 1753 - 64-bit omp.h upgrade happenned in <6.0-8,6.1-1) */
+#            include "omp.h"
+#            if defined(_PGOMP_H)
+                 /* 6.1.1 or newer */
+#                define PLATFORM_COMPILER_VERSION 0x060101
+#                define PLATFORM_COMPILER_VERSION_STR ">=6.1-1"
+#            else
+                 /* 6.0.8 or older */
+#                define PLATFORM_COMPILER_VERSION 0
+#                define PLATFORM_COMPILER_VERSION_STR "<=6.0-8"
+#            endif
+#        else /* 32-bit omp.h upgrade happenned in <5.2-4,6.0-8 */
+#            include "omp.h"
+#            if defined(_PGOMP_H)
+                 /* 6.0-8 or newer */
+#                define PLATFORM_COMPILER_VERSION 0x060008
+#                define PLATFORM_COMPILER_VERSION_STR ">=6.0-8"
+#            else
+                 /* 5.2-4 or older */
+#                define PLATFORM_COMPILER_VERSION 0
+#                define PLATFORM_COMPILER_VERSION_STR "<=5.2-4"
+#            endif
+#        endif
+#endif /* 0 */
+       /* XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX */
+#    endif
+
+#elif defined(__xlC__)
+#    define PLATFORM_COMPILER_XLC  1
+#    define PLATFORM_COMPILER_FAMILYNAME XLC
+#    define PLATFORM_COMPILER_FAMILYID 5
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_XLC_CXX  1
+#    else
+#        define PLATFORM_COMPILER_XLC_C  1
+#    endif
+#    define PLATFORM_COMPILER_VERSION __xlC__
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+         ( ((maj) << 8) | ((min) << 4) | (pat) )
+
+#elif defined(__DECC) || defined(__DECCXX)
+#    define PLATFORM_COMPILER_COMPAQ  1
+#    define PLATFORM_COMPILER_FAMILYNAME COMPAQ
+#    define PLATFORM_COMPILER_FAMILYID 6
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_COMPAQ_CXX  1
+#    else
+#        define PLATFORM_COMPILER_COMPAQ_C  1
+#    endif
+#    if defined(__DECC_VER)
+#        define PLATFORM_COMPILER_VERSION __DECC_VER
+#    elif defined(__DECCXX_VER)
+#        define PLATFORM_COMPILER_VERSION __DECCXX_VER
+#    endif
+
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+         ( ((maj) * 10000000) + ((min) * 100000) + (90000) + (pat) )
+         /* 90000 = official ver, 80000 = customer special ver, 60000 = field test ver */
+
+#elif defined(__SUNPRO_C) || defined(__SUNPRO_CC)
+#    define PLATFORM_COMPILER_SUN  1
+#    define PLATFORM_COMPILER_FAMILYNAME SUN
+#    define PLATFORM_COMPILER_FAMILYID 7
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_SUN_CXX  1
+#    else
+#        define PLATFORM_COMPILER_SUN_C  1
+#    endif
+#    if defined(__SUNPRO_C) && __SUNPRO_C > 0
+#        define PLATFORM_COMPILER_VERSION __SUNPRO_C
+#    elif defined(__SUNPRO_CC) && __SUNPRO_CC > 0
+#        define PLATFORM_COMPILER_VERSION __SUNPRO_CC
+#    endif
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+         ( ((maj) << 8) | ((min) << 4) | (pat) )
+
+#elif defined(__HP_cc) || defined(__HP_aCC)
+#    define PLATFORM_COMPILER_HP  1
+#    define PLATFORM_COMPILER_FAMILYNAME HP
+#    define PLATFORM_COMPILER_FAMILYID 8
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_HP_CXX  1
+#    else
+#        define PLATFORM_COMPILER_HP_C  1
+#    endif
+#    if defined(__HP_cc) && __HP_cc > 0
+#        define PLATFORM_COMPILER_VERSION __HP_cc
+#    elif defined(__HP_aCC) && __HP_aCC > 0
+#        define PLATFORM_COMPILER_VERSION __HP_aCC
+#    endif
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+         ( ((maj) << 16) | ((min) << 8) | (pat) )
+
+#elif defined(_SGI_COMPILER_VERSION) || \
+   (defined(_COMPILER_VERSION) && defined(__sgi) && !defined(__GNUC__)) /* 7.3.0 and earlier lack _SGI_COMPILER_VERSION */
+#    define PLATFORM_COMPILER_SGI  1
+#    define PLATFORM_COMPILER_FAMILYNAME SGI
+#    define PLATFORM_COMPILER_FAMILYID 9
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_SGI_CXX  1
+#    else
+#        define PLATFORM_COMPILER_SGI_C  1
+#    endif
+#    if defined(_SGI_COMPILER_VERSION) && _SGI_COMPILER_VERSION > 0
+#        define PLATFORM_COMPILER_VERSION _SGI_COMPILER_VERSION
+#    elif defined(_COMPILER_VERSION) && _COMPILER_VERSION > 0
+#        define PLATFORM_COMPILER_VERSION _COMPILER_VERSION
+#    endif
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+         ( ((maj) << 8) | ((min) << 4) | (pat) )
+
+#elif defined(_CRAYC)
+#    define PLATFORM_COMPILER_CRAY  1
+#    define PLATFORM_COMPILER_FAMILYNAME CRAY
+#    define PLATFORM_COMPILER_FAMILYID 10
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_CRAY_CXX  1
+#    else
+#        define PLATFORM_COMPILER_CRAY_C  1
+#    endif
+#    if defined(_RELEASE) && defined(_RELEASE_MINOR) /* X1 and XT */
+#        define PLATFORM_COMPILER_VERSION \
+             PLATFORM_COMPILER_VERSION_INT(_RELEASE,_RELEASE_MINOR,0)
+#     elif defined(_RELEASE) /* T3E */
+#        define PLATFORM_COMPILER_VERSION \
+             PLATFORM_COMPILER_VERSION_INT(_RELEASE,0,0)
+#     endif
+#     ifdef _RELEASE_STRING /* X1 and XT */
+#        define PLATFORM_COMPILER_VERSION_STR _RELEASE_STRING
+#     endif
+
+#elif defined(__KCC)
+#    define PLATFORM_COMPILER_KAI  1
+#    define PLATFORM_COMPILER_FAMILYNAME KAI
+#    define PLATFORM_COMPILER_FAMILYID 11
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_KAI_CXX  1
+#    else
+#        define PLATFORM_COMPILER_KAI_C  1
+#    endif
+
+#elif defined(__MTA__)
+#    define PLATFORM_COMPILER_MTA  1
+#    define PLATFORM_COMPILER_FAMILYNAME MTA
+#    define PLATFORM_COMPILER_FAMILYID 12
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_MTA_CXX  1
+#    else
+#        define PLATFORM_COMPILER_MTA_C  1
+#    endif
+
+#elif defined(_SX)
+#    define PLATFORM_COMPILER_NECSX  1
+#    define PLATFORM_COMPILER_FAMILYNAME NECSX
+#    define PLATFORM_COMPILER_FAMILYID 13
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_NECSX_CXX  1
+#    else
+#        define PLATFORM_COMPILER_NECSX_C  1
+#    endif
+
+#elif defined(_MSC_VER)
+#    define PLATFORM_COMPILER_MICROSOFT  1
+#    define PLATFORM_COMPILER_FAMILYNAME MICROSOFT
+#    define PLATFORM_COMPILER_FAMILYID 14
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_MICROSOFT_CXX  1
+#    else
+#        define PLATFORM_COMPILER_MICROSOFT_C  1
+#    endif
+#    define PLATFORM_COMPILER_VERSION _MSC_VER
+
+#elif defined(__TINYC__)
+#    define PLATFORM_COMPILER_TINY  1
+#    define PLATFORM_COMPILER_FAMILYNAME TINY
+#    define PLATFORM_COMPILER_FAMILYID 15
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_TINY_CXX  1
+#    else
+#        define PLATFORM_COMPILER_TINY_C  1
+#    endif
+
+#elif defined(__LCC__)
+#    define PLATFORM_COMPILER_LCC 1
+#    define PLATFORM_COMPILER_FAMILYNAME LCC
+#    define PLATFORM_COMPILER_FAMILYID 16
+#    ifdef __cplusplus
+#        define PLATFORM_COMPILER_LCC_CXX  1
+#    else
+#        define PLATFORM_COMPILER_LCC_C  1
+#    endif
+
+#else /* unknown compiler */
+#     define PLATFORM_COMPILER_UNKNOWN  1
+#endif
+
+/* this stanza comes last, because many vendor compilers lie and claim
+   to be GNU C for compatibility reasons and/or because they share a frontend */
+#if defined(__GNUC__)
+#    undef PLATFORM_COMPILER_UNKNOWN
+#    ifndef PLATFORM_COMPILER_FAMILYID
+#        define PLATFORM_COMPILER_GNU  1
+#        define PLATFORM_COMPILER_FAMILYNAME GNU
+#        define PLATFORM_COMPILER_FAMILYID 1
+#        ifdef __cplusplus
+#            define PLATFORM_COMPILER_GNU_CXX  1
+#        else
+#            define PLATFORM_COMPILER_GNU_C  1
+#        endif
+#        if defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#            define PLATFORM_COMPILER_VERSION \
+                 PLATFORM_COMPILER_VERSION_INT(__GNUC__,__GNUC_MINOR__,__GNUC_PATCHLEVEL__)
+#        elif defined(__GNUC_MINOR__) /* older versions of egcs lack __GNUC_PATCHLEVEL__ */
+#            define PLATFORM_COMPILER_VERSION \
+                 PLATFORM_COMPILER_VERSION_INT(__GNUC__,__GNUC_MINOR__,0)
+#        else
+#            define PLATFORM_COMPILER_VERSION \
+                 PLATFORM_COMPILER_VERSION_INT(__GNUC__,0,0)
+#        endif
+#        define PLATFORM_COMPILER_VERSION_STR __PLATFORM_COMPILER_GNU_VERSION_STR
+#    else
+#        define _PLATFORM_COMPILER_GNU_VERSION_STR __PLATFORM_COMPILER_GNU_VERSION_STR
+#    endif
+     /* gather any advertised GNU version number info, even for non-gcc compilers */
+#    if defined(__GNUC_MINOR__) && defined(__GNUC_PATCHLEVEL__)
+#        define __PLATFORM_COMPILER_GNU_VERSION_STR \
+             _STRINGIFY(__GNUC__) "." _STRINGIFY(__GNUC_MINOR__) "." _STRINGIFY(__GNUC_PATCHLEVEL__)
+#    elif defined(__GNUC_MINOR__)
+#        define __PLATFORM_COMPILER_GNU_VERSION_STR \
+             _STRINGIFY(__GNUC__) "." _STRINGIFY(__GNUC_MINOR__) ".?"
+#    else
+#        define __PLATFORM_COMPILER_GNU_VERSION_STR \
+             _STRINGIFY(__GNUC__) ".?.?"
+#    endif
+#elif defined(PLATFORM_COMPILER_UNKNOWN) /* unknown compiler */
+#    define PLATFORM_COMPILER_FAMILYNAME UNKNOWN
+#    define PLATFORM_COMPILER_FAMILYID 0
+#endif
+
+/* Default Values */
+#ifndef PLATFORM_COMPILER_VERSION
+#    define PLATFORM_COMPILER_VERSION 0 /* don't know */
+#endif
+
+#ifndef PLATFORM_COMPILER_VERSION_STR
+#    define PLATFORM_COMPILER_VERSION_STR _STRINGIFY(PLATFORM_COMPILER_VERSION)
+#endif
+
+#ifndef PLATFORM_COMPILER_VERSION_INT
+#    define PLATFORM_COMPILER_VERSION_INT(maj,min,pat) \
+        (((maj) << 16) | ((min) << 8) | (pat))
+#endif
+
+
+#endif /* PMIX_PORTABLE_PLATFORM_H */

--- a/src/mca/base/Makefile.am
+++ b/src/mca/base/Makefile.am
@@ -10,6 +10,7 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2010-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -43,6 +44,7 @@ headers = \
 libpmix_mca_base_la_SOURCES = \
         $(headers) \
         pmix_mca_base_close.c \
+        pmix_mca_base_cmd_line.c \
         pmix_mca_base_component_compare.c \
         pmix_mca_base_component_find.c \
         pmix_mca_base_component_repository.c \

--- a/src/mca/base/base.h
+++ b/src/mca/base/base.h
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,6 +37,7 @@
 #include "src/mca/mca.h"
 #include "src/mca/base/pmix_mca_base_var.h"
 #include "src/mca/base/pmix_mca_base_framework.h"
+#include "src/util/cmd_line.h"
 #include "src/util/output.h"
 
 BEGIN_C_DECLS
@@ -49,7 +50,7 @@ struct pmix_mca_base_component_list_item_t {
     const pmix_mca_base_component_t *cli_component;
 };
 typedef struct pmix_mca_base_component_list_item_t pmix_mca_base_component_list_item_t;
-PMIX_CLASS_DECLARATION(pmix_mca_base_component_list_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_component_list_item_t);
 
 /*
  * Structure for making priority lists of components
@@ -61,16 +62,17 @@ struct pmix_mca_base_component_priority_list_item_t {
 typedef struct pmix_mca_base_component_priority_list_item_t
     pmix_mca_base_component_priority_list_item_t;
 
-PMIX_CLASS_DECLARATION(pmix_mca_base_component_priority_list_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_component_priority_list_item_t);
 
 /*
  * Public variables
  */
-extern char *pmix_mca_base_component_path;
-extern bool pmix_mca_base_component_show_load_errors;
-extern bool pmix_mca_base_component_disable_dlopen;
-extern char *pmix_mca_base_system_default_path;
-extern char *pmix_mca_base_user_default_path;
+PMIX_EXPORT extern char *pmix_mca_base_component_path;
+PMIX_EXPORT extern bool pmix_mca_base_component_show_load_errors;
+PMIX_EXPORT extern bool pmix_mca_base_component_track_load_errors;
+PMIX_EXPORT extern bool pmix_mca_base_component_disable_dlopen;
+PMIX_EXPORT extern char *pmix_mca_base_system_default_path;
+PMIX_EXPORT extern char *pmix_mca_base_user_default_path;
 
 /*
  * Standard verbosity levels
@@ -114,7 +116,7 @@ enum {
  * invoked during the initialization stage and specifically
  * invoked in the special case of the *_info command.
  */
-int pmix_mca_base_open(void);
+PMIX_EXPORT int pmix_mca_base_open(void);
 
 /**
  * Last function called in the MCA
@@ -128,17 +130,17 @@ int pmix_mca_base_open(void);
  * It must be the last MCA function invoked.  It is normally invoked
  * during the finalize stage.
  */
-int pmix_mca_base_close(void);
+PMIX_EXPORT int pmix_mca_base_close(void);
 
 /**
  * A generic select function
  *
  */
-int pmix_mca_base_select(const char *type_name, int output_id,
-                         pmix_list_t *components_available,
-                         pmix_mca_base_module_t **best_module,
-                         pmix_mca_base_component_t **best_component,
-                         int *priority_out);
+PMIX_EXPORT int pmix_mca_base_select(const char *type_name, int output_id,
+                                     pmix_list_t *components_available,
+                                     pmix_mca_base_module_t **best_module,
+                                     pmix_mca_base_component_t **best_component,
+                                     int *priority_out);
 
 /**
  * A function for component query functions to discover if they have
@@ -148,32 +150,40 @@ int pmix_mca_base_select(const char *type_name, int output_id,
  *            available for selection.
  *
  */
-int pmix_mca_base_is_component_required(pmix_list_t *components_available,
-                                        pmix_mca_base_component_t *component,
-                                        bool exclusive,
-                                        bool *is_required);
+PMIX_EXPORT int pmix_mca_base_is_component_required(pmix_list_t *components_available,
+                                                    pmix_mca_base_component_t *component,
+                                                    bool exclusive,
+                                                    bool *is_required);
+
+/* mca_base_cmd_line.c */
+
+PMIX_EXPORT int pmix_mca_base_cmd_line_setup(pmix_cmd_line_t *cmd);
+PMIX_EXPORT int pmix_mca_base_cmd_line_process_args(pmix_cmd_line_t *cmd,
+                                                 char ***app_env,
+                                                 char ***global_env);
+PMIX_EXPORT void pmix_mca_base_cmd_line_wrap_args(char **args);
 
 /* pmix_mca_base_component_compare.c */
 
-int pmix_mca_base_component_compare_priority(pmix_mca_base_component_priority_list_item_t *a,
-                                             pmix_mca_base_component_priority_list_item_t *b);
-int pmix_mca_base_component_compare(const pmix_mca_base_component_t *a,
-                                    const pmix_mca_base_component_t *b);
-int pmix_mca_base_component_compatible(const pmix_mca_base_component_t *a,
-                                       const pmix_mca_base_component_t *b);
-char * pmix_mca_base_component_to_string(const pmix_mca_base_component_t *a);
+PMIX_EXPORT int pmix_mca_base_component_compare_priority(pmix_mca_base_component_priority_list_item_t *a,
+                                                         pmix_mca_base_component_priority_list_item_t *b);
+PMIX_EXPORT int pmix_mca_base_component_compare(const pmix_mca_base_component_t *a,
+                                                const pmix_mca_base_component_t *b);
+PMIX_EXPORT int pmix_mca_base_component_compatible(const pmix_mca_base_component_t *a,
+                                                   const pmix_mca_base_component_t *b);
+PMIX_EXPORT char * pmix_mca_base_component_to_string(const pmix_mca_base_component_t *a);
 
 /* pmix_mca_base_component_find.c */
 
-int pmix_mca_base_component_find (const char *directory, pmix_mca_base_framework_t *framework,
-                                  bool ignore_requested, bool open_dso_components);
+PMIX_EXPORT int pmix_mca_base_component_find (const char *directory, pmix_mca_base_framework_t *framework,
+                                              bool ignore_requested, bool open_dso_components);
 
 /**
  * Parse the requested component string and return an pmix_argv of the requested
  * (or not requested) components.
  */
-int pmix_mca_base_component_parse_requested (const char *requested, bool *include_mode,
-                                             char ***requested_component_names);
+PMIX_EXPORT int pmix_mca_base_component_parse_requested (const char *requested, bool *include_mode,
+                                                         char ***requested_component_names);
 
 /**
  * Filter a list of components based on a comma-delimted list of names and/or
@@ -193,27 +203,27 @@ int pmix_mca_base_component_parse_requested (const char *requested, bool *includ
  * This function closes and releases any components that do not match the filter_name and
  * filter flags.
  */
-int pmix_mca_base_components_filter (pmix_mca_base_framework_t *framework, uint32_t filter_flags);
+PMIX_EXPORT int pmix_mca_base_components_filter (pmix_mca_base_framework_t *framework, uint32_t filter_flags);
 
 
 
 /* Safely release some memory allocated by pmix_mca_base_component_find()
    (i.e., is safe to call even if you never called
    pmix_mca_base_component_find()). */
-int pmix_mca_base_component_find_finalize(void);
+PMIX_EXPORT int pmix_mca_base_component_find_finalize(void);
 
 /* pmix_mca_base_components_register.c */
-int pmix_mca_base_framework_components_register (struct pmix_mca_base_framework_t *framework,
-                                                 pmix_mca_base_register_flag_t flags);
+PMIX_EXPORT int pmix_mca_base_framework_components_register (struct pmix_mca_base_framework_t *framework,
+                                                             pmix_mca_base_register_flag_t flags);
 
 /* pmix_mca_base_components_open.c */
-int pmix_mca_base_framework_components_open (struct pmix_mca_base_framework_t *framework,
-                                             pmix_mca_base_open_flag_t flags);
+PMIX_EXPORT int pmix_mca_base_framework_components_open (struct pmix_mca_base_framework_t *framework,
+                                                         pmix_mca_base_open_flag_t flags);
 
-int pmix_mca_base_components_open(const char *type_name, int output_id,
-                                  const pmix_mca_base_component_t **static_components,
-                                  pmix_list_t *components_available,
-                                  bool open_dso_components);
+PMIX_EXPORT int pmix_mca_base_components_open(const char *type_name, int output_id,
+                                              const pmix_mca_base_component_t **static_components,
+                                              pmix_list_t *components_available,
+                                              bool open_dso_components);
 
 /* pmix_mca_base_components_close.c */
 /**
@@ -224,7 +234,7 @@ int pmix_mca_base_components_open(const char *type_name, int output_id,
  *
  * After calling this function the component may no longer be used.
  */
-void pmix_mca_base_component_close (const pmix_mca_base_component_t *component, int output_id);
+PMIX_EXPORT void pmix_mca_base_component_close (const pmix_mca_base_component_t *component, int output_id);
 
 /**
  * Release a component without closing it.
@@ -233,13 +243,13 @@ void pmix_mca_base_component_close (const pmix_mca_base_component_t *component, 
  *
  * After calling this function the component may no longer be used.
  */
-void pmix_mca_base_component_unload (const pmix_mca_base_component_t *component, int output_id);
+PMIX_EXPORT void pmix_mca_base_component_unload (const pmix_mca_base_component_t *component, int output_id);
 
-int pmix_mca_base_components_close(int output_id, pmix_list_t *components_available,
-                                   const pmix_mca_base_component_t *skip);
+PMIX_EXPORT int pmix_mca_base_components_close(int output_id, pmix_list_t *components_available,
+                                               const pmix_mca_base_component_t *skip);
 
-int pmix_mca_base_framework_components_close (struct pmix_mca_base_framework_t *framework,
-                                              const pmix_mca_base_component_t *skip);
+PMIX_EXPORT int pmix_mca_base_framework_components_close (struct pmix_mca_base_framework_t *framework,
+                                                          const pmix_mca_base_component_t *skip);
 
 END_C_DECLS
 

--- a/src/mca/base/pmix_mca_base_cmd_line.c
+++ b/src/mca/base/pmix_mca_base_cmd_line.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "src/util/cmd_line.h"
+#include "src/util/argv.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/show_help.h"
+#include "src/mca/base/base.h"
+#include "pmix_common.h"
+
+
+/*
+ * Private variables
+ */
+
+/*
+ * Private functions
+ */
+static int process_arg(const char *param, const char *value,
+                       char ***params, char ***values);
+static void add_to_env(char **params, char **values, char ***env);
+
+
+/*
+ * Add -mca to the possible command line options list
+ */
+int pmix_mca_base_cmd_line_setup(pmix_cmd_line_t *cmd)
+{
+    int ret = PMIX_SUCCESS;
+
+    ret = pmix_cmd_line_make_opt3(cmd, '\0', PMIX_MCA_CMD_LINE_ID, PMIX_MCA_CMD_LINE_ID, 2,
+                                  "Pass context-specific MCA parameters; they are considered global if --g"PMIX_MCA_CMD_LINE_ID" is not used and only one context is specified (arg0 is the parameter name; arg1 is the parameter value)");
+    if (PMIX_SUCCESS != ret) {
+        return ret;
+    }
+
+    ret = pmix_cmd_line_make_opt3(cmd, '\0', "g"PMIX_MCA_CMD_LINE_ID, "g"PMIX_MCA_CMD_LINE_ID, 2,
+                                  "Pass global MCA parameters that are applicable to all contexts (arg0 is the parameter name; arg1 is the parameter value)");
+
+    if (PMIX_SUCCESS != ret) {
+        return ret;
+    }
+
+    {
+        pmix_cmd_line_init_t entry =
+            {"mca_base_param_file_prefix", '\0', "am", NULL, 1,
+             NULL, PMIX_CMD_LINE_TYPE_STRING,
+             "Aggregate MCA parameter set file list",
+             PMIX_CMD_LINE_OTYPE_LAUNCH
+            };
+        ret = pmix_cmd_line_make_opt_mca(cmd, entry);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    {
+        pmix_cmd_line_init_t entry =
+            {"mca_base_envar_file_prefix", '\0', "tune", NULL, 1,
+             NULL, PMIX_CMD_LINE_TYPE_STRING,
+             "Application profile options file list",
+             PMIX_CMD_LINE_OTYPE_DEBUG
+            };
+        ret = pmix_cmd_line_make_opt_mca(cmd, entry);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return ret;
+}
+
+
+/*
+ * Look for and handle any -mca options on the command line
+ */
+int pmix_mca_base_cmd_line_process_args(pmix_cmd_line_t *cmd,
+                                        char ***context_env, char ***global_env)
+{
+    int i, num_insts, rc;
+    char **params;
+    char **values;
+
+    /* If no relevant parameters were given, just return */
+
+    if (!pmix_cmd_line_is_taken(cmd, PMIX_MCA_CMD_LINE_ID) &&
+        !pmix_cmd_line_is_taken(cmd, "g"PMIX_MCA_CMD_LINE_ID)) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Handle app context-specific parameters */
+
+    num_insts = pmix_cmd_line_get_ninsts(cmd, PMIX_MCA_CMD_LINE_ID);
+    params = values = NULL;
+    for (i = 0; i < num_insts; ++i) {
+        if (PMIX_SUCCESS != (rc = process_arg(pmix_cmd_line_get_param(cmd, PMIX_MCA_CMD_LINE_ID, i, 0),
+                                              pmix_cmd_line_get_param(cmd, PMIX_MCA_CMD_LINE_ID, i, 1),
+                                              &params, &values))) {
+            return rc;
+        }
+    }
+    if (NULL != params) {
+        add_to_env(params, values, context_env);
+        pmix_argv_free(params);
+        pmix_argv_free(values);
+    }
+
+    /* Handle global parameters */
+
+    num_insts = pmix_cmd_line_get_ninsts(cmd, "g"PMIX_MCA_CMD_LINE_ID);
+    params = values = NULL;
+    for (i = 0; i < num_insts; ++i) {
+        if (PMIX_SUCCESS != (rc = process_arg(pmix_cmd_line_get_param(cmd, "g"PMIX_MCA_CMD_LINE_ID, i, 0),
+                                              pmix_cmd_line_get_param(cmd, "g"PMIX_MCA_CMD_LINE_ID, i, 1),
+                                              &params, &values))) {
+            return rc;
+        }
+    }
+    if (NULL != params) {
+        add_to_env(params, values, global_env);
+        pmix_argv_free(params);
+        pmix_argv_free(values);
+    }
+
+    /* All done */
+
+    return PMIX_SUCCESS;
+}
+
+
+
+/*
+ * Process a single MCA argument.
+ */
+static int process_arg(const char *param, const char *value,
+                       char ***params, char ***values)
+{
+    int i;
+    char *p1;
+
+    /* check for quoted value */
+    if ('\"' == value[0] && '\"' == value[strlen(value)-1]) {
+        p1 = strdup(&value[1]);
+        p1[strlen(p1)-1] = '\0';
+    } else {
+        p1 = strdup(value);
+    }
+
+    /* Look to see if we've already got an -mca argument for the same
+       param.  Check against the list of MCA param's that we've
+       already saved arguments for - if found, return an error. */
+
+    for (i = 0; NULL != *params && NULL != (*params)[i]; ++i) {
+        if (0 == strcmp(param, (*params)[i])) {
+            /* cannot use show_help here as it may not get out prior
+             * to the process exiting */
+            fprintf(stderr,
+                    "---------------------------------------------------------------------------\n"
+                    "The following MCA parameter has been listed multiple times on the\n"
+                    "command line:\n\n"
+                    "  MCA param:   %s\n\n"
+                    "MCA parameters can only be listed once on a command line to ensure there\n"
+                    "is no ambiguity as to its value.  Please correct the situation and\n"
+                    "try again.\n"
+                    "---------------------------------------------------------------------------\n",
+                    param);
+            free(p1);
+            return PMIX_ERROR;
+        }
+    }
+
+    /* If we didn't already have an value for the same param, save
+       this one away */
+    pmix_argv_append_nosize(params, param);
+    pmix_argv_append_nosize(values, p1);
+    free(p1);
+
+    return PMIX_SUCCESS;
+}
+
+
+static void add_to_env(char **params, char **values, char ***env)
+{
+    int i;
+    char *name;
+
+    /* Loop through all the args that we've gotten and make env
+       vars of the form PMIX_MCA_PREFIX*=value. */
+
+    for (i = 0; NULL != params && NULL != params[i]; ++i) {
+        (void) pmix_mca_base_var_env_name (params[i], &name);
+        pmix_setenv(name, values[i], true, env);
+        free(name);
+    }
+}
+
+void pmix_mca_base_cmd_line_wrap_args(char **args)
+{
+    int i;
+    char *tstr;
+
+    for (i=0; NULL != args && NULL != args[i]; i++) {
+        if (0 == strcmp(args[i], "-"PMIX_MCA_CMD_LINE_ID) ||
+            0 == strcmp(args[i], "--"PMIX_MCA_CMD_LINE_ID)) {
+            if (NULL == args[i+1] || NULL == args[i+2]) {
+                /* this should be impossible as the error would
+                 * have been detected well before here, but just
+                 * be safe */
+                return;
+            }
+            i += 2;
+            asprintf(&tstr, "\"%s\"", args[i]);
+            free(args[i]);
+            args[i] = tstr;
+        }
+    }
+}

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -56,6 +56,26 @@ PMIX_CLASS_INSTANCE(pmix_mca_base_component_repository_item_t, pmix_list_item_t,
 
 #endif /* PMIX_HAVE_PDL_SUPPORT */
 
+static void clf_constructor(pmix_object_t *obj)
+{
+    pmix_mca_base_failed_component_t *cli = (pmix_mca_base_failed_component_t *) obj;
+    cli->comp = NULL;
+    cli->error_msg = NULL;
+}
+
+static void clf_destructor(pmix_object_t *obj)
+{
+    pmix_mca_base_failed_component_t *cli = (pmix_mca_base_failed_component_t *) obj;
+    cli->comp = NULL;
+    if( NULL != cli->error_msg ) {
+        free(cli->error_msg);
+        cli->error_msg = NULL;
+    }
+}
+
+PMIX_CLASS_INSTANCE(pmix_mca_base_failed_component_t, pmix_list_item_t,
+                    clf_constructor, clf_destructor);
+
 
 /*
  * Private variables
@@ -409,6 +429,17 @@ int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework
         }
         pmix_output_verbose(vl, 0, "pmix_mca_base_component_repository_open: unable to open %s: %s (ignored)",
                             ri->ri_base, err_msg);
+
+        if( pmix_mca_base_component_track_load_errors ) {
+            pmix_mca_base_failed_component_t *f_comp = PMIX_NEW(pmix_mca_base_failed_component_t);
+            f_comp->comp = ri;
+            if (0 > asprintf(&(f_comp->error_msg), "%s", err_msg)) {
+                PMIX_RELEASE(f_comp);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            pmix_list_append(&framework->framework_failed_components, &f_comp->super);
+        }
+
         return PMIX_ERR_BAD_PARAM;
     }
 

--- a/src/mca/base/pmix_mca_base_component_repository.h
+++ b/src/mca/base/pmix_mca_base_component_repository.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -59,7 +59,18 @@ struct pmix_mca_base_component_repository_item_t {
 };
 typedef struct pmix_mca_base_component_repository_item_t pmix_mca_base_component_repository_item_t;
 
-PMIX_CLASS_DECLARATION(pmix_mca_base_component_repository_item_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_component_repository_item_t);
+
+/*
+ * Structure to track information about why a component failed to load.
+ */
+struct pmix_mca_base_failed_component_t {
+    pmix_list_item_t super;
+    pmix_mca_base_component_repository_item_t *comp;
+    char *error_msg;
+};
+typedef struct pmix_mca_base_failed_component_t pmix_mca_base_failed_component_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_failed_component_t);
 
 /**
  * @brief initialize the component repository
@@ -70,14 +81,14 @@ PMIX_CLASS_DECLARATION(pmix_mca_base_component_repository_item_t);
  * pmix_mca_base_component_path MCA parameter. pmix_mca_base_open () is a
  * prerequisite call as it registers the pmix_mca_base_component_path parameter.
  */
-int pmix_mca_base_component_repository_init(void);
+PMIX_EXPORT int pmix_mca_base_component_repository_init(void);
 
 /**
  * @brief add search path for dynamically loaded components
  *
  * @param[in] path        delimited list of search paths to add
  */
-int pmix_mca_base_component_repository_add(const char *path);
+PMIX_EXPORT int pmix_mca_base_component_repository_add(const char *path);
 
 
 /**
@@ -89,13 +100,13 @@ int pmix_mca_base_component_repository_add(const char *path);
  * The list returned in {framework_components} is owned by the component
  * repository and CAN NOT be modified by the caller.
  */
-int pmix_mca_base_component_repository_get_components(pmix_mca_base_framework_t *framework,
-                                                      pmix_list_t **framework_components);
+PMIX_EXPORT int pmix_mca_base_component_repository_get_components(pmix_mca_base_framework_t *framework,
+                                                                  pmix_list_t **framework_components);
 
 /**
  * @brief finalize the mca component repository
  */
-void pmix_mca_base_component_repository_finalize(void);
+PMIX_EXPORT void pmix_mca_base_component_repository_finalize(void);
 
 /**
  * @brief open the repository item and add it to the framework's component
@@ -104,14 +115,14 @@ void pmix_mca_base_component_repository_finalize(void);
  * @param[in] framework   framework that matches the component
  * @param[in] ri          dynamic component to open
  */
-int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework,
-                                            pmix_mca_base_component_repository_item_t *ri);
+PMIX_EXPORT int pmix_mca_base_component_repository_open(pmix_mca_base_framework_t *framework,
+                                                        pmix_mca_base_component_repository_item_t *ri);
 
 
 /**
  * @brief Reduce the reference count of a component and dlclose it if necessary
  */
-void pmix_mca_base_component_repository_release(const pmix_mca_base_component_t *component);
+PMIX_EXPORT void pmix_mca_base_component_repository_release(const pmix_mca_base_component_t *component);
 
 /**
  * @brief Increase the reference count of a component
@@ -126,7 +137,7 @@ void pmix_mca_base_component_repository_release(const pmix_mca_base_component_t 
  * @note all components are automatically unloaded by the
  * pmix_mca_base_component_repository_finalize() call.
  */
-int pmix_mca_base_component_repository_retain_component(const char *type, const char *name);
+PMIX_EXPORT int pmix_mca_base_component_repository_retain_component(const char *type, const char *name);
 
 END_C_DECLS
 

--- a/src/mca/base/pmix_mca_base_framework.c
+++ b/src/mca/base/pmix_mca_base_framework.c
@@ -67,6 +67,7 @@ int pmix_mca_base_framework_register (struct pmix_mca_base_framework_t *framewor
     }
 
     PMIX_CONSTRUCT(&framework->framework_components, pmix_list_t);
+    PMIX_CONSTRUCT(&framework->framework_failed_components, pmix_list_t);
 
     if (framework->framework_flags & PMIX_MCA_BASE_FRAMEWORK_FLAG_NO_DSO) {
         flags |= PMIX_MCA_BASE_REGISTER_STATIC_ONLY;
@@ -239,6 +240,7 @@ int pmix_mca_base_framework_close (struct pmix_mca_base_framework_t *framework) 
     framework->framework_flags &= ~(PMIX_MCA_BASE_FRAMEWORK_FLAG_REGISTERED | PMIX_MCA_BASE_FRAMEWORK_FLAG_OPEN);
 
     PMIX_DESTRUCT(&framework->framework_components);
+    PMIX_LIST_DESTRUCT(&framework->framework_failed_components);
 
     framework_close_output (framework);
 

--- a/src/mca/base/pmix_mca_base_framework.h
+++ b/src/mca/base/pmix_mca_base_framework.h
@@ -156,6 +156,8 @@ typedef struct pmix_mca_base_framework_t {
     /** List of selected components (filled in by pmix_mca_base_framework_register()
         or pmix_mca_base_framework_open() */
     pmix_list_t                              framework_components;
+    /** List of components that failed to load */
+    pmix_list_t                              framework_failed_components;
 } pmix_mca_base_framework_t;
 
 

--- a/src/mca/base/pmix_mca_base_open.c
+++ b/src/mca/base/pmix_mca_base_open.c
@@ -49,6 +49,7 @@ int pmix_mca_base_opened = 0;
 char *pmix_mca_base_system_default_path = NULL;
 char *pmix_mca_base_user_default_path = NULL;
 bool pmix_mca_base_component_show_load_errors = (bool) PMIX_SHOW_LOAD_ERRORS_DEFAULT;
+bool pmix_mca_base_component_track_load_errors = false;
 bool pmix_mca_base_component_disable_dlopen = false;
 
 static char *pmix_mca_base_verbose = NULL;
@@ -118,6 +119,14 @@ int pmix_mca_base_open(void)
                                    &pmix_mca_base_component_show_load_errors);
     (void) pmix_mca_base_var_register_synonym(var_id, "pmix", "mca", NULL, "component_show_load_errors",
                                               PMIX_MCA_BASE_VAR_SYN_FLAG_DEPRECATED);
+
+    pmix_mca_base_component_track_load_errors = false;
+    var_id = pmix_mca_base_var_register("pmix", "mca", "base", "component_track_load_errors",
+                                        "Whether to track errors for components that failed to load or not",
+                                        PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                        PMIX_INFO_LVL_9,
+                                        PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                        &pmix_mca_base_component_track_load_errors);
 
     pmix_mca_base_component_disable_dlopen = false;
     var_id = pmix_mca_base_var_register("pmix", "mca", "base", "component_disable_dlopen",

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -95,7 +95,7 @@ typedef enum {
     PMIX_MCA_BASE_VAR_TYPE_MAX
 } pmix_mca_base_var_type_t;
 
-extern const char *pmix_var_type_names[];
+PMIX_EXPORT extern const char *pmix_var_type_names[];
 
 /**
  * Source of an MCA variable's value
@@ -298,7 +298,7 @@ BEGIN_C_DECLS
 /**
  * Object declarayion for pmix_mca_base_var_t
  */
-PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
 
 /**
  * Initialize the MCA variable system.
@@ -309,7 +309,7 @@ PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
  * invoked internally (by pmix_mca_base_open()) and is only documented
  * here for completeness.
  */
-int pmix_mca_base_var_init(void);
+PMIX_EXPORT int pmix_mca_base_var_init(void);
 
 /**
  * Register an MCA variable
@@ -489,7 +489,7 @@ PMIX_EXPORT int pmix_mca_base_var_register_synonym (int synonym_for, const char 
  *
  * If an enumerator is associated with this variable it will be dereferenced.
  */
-int pmix_mca_base_var_deregister(int vari);
+PMIX_EXPORT int pmix_mca_base_var_deregister(int vari);
 
 
 /**
@@ -512,9 +512,9 @@ int pmix_mca_base_var_deregister(int vari);
  * Note: The value can be changed by the registering code without using
  * the pmix_mca_base_var_* interface so the source may be incorrect.
  */
-int pmix_mca_base_var_get_value (int vari, void *value,
-                                 pmix_mca_base_var_source_t *source,
-                                 const char **source_file);
+PMIX_EXPORT int pmix_mca_base_var_get_value (int vari, void *value,
+                                             pmix_mca_base_var_source_t *source,
+                                             const char **source_file);
 
 /**
  * Sets an "override" value for an integer MCA variable.
@@ -537,9 +537,9 @@ int pmix_mca_base_var_get_value (int vari, void *value,
  * a synonym the variable the synonym represents) if the value is
  * settable.
  */
-int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
-                                 pmix_mca_base_var_source_t source,
-                                 const char *source_file);
+PMIX_EXPORT int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
+                                             pmix_mca_base_var_source_t source,
+                                             const char *source_file);
 
 /**
  * Get the string name corresponding to the MCA variable
@@ -554,8 +554,8 @@ int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
  * The string that is returned is owned by the caller; if
  * appropriate, it must be eventually freed by the caller.
  */
-int pmix_mca_base_var_env_name(const char *param_name,
-                               char **env_name);
+PMIX_EXPORT int pmix_mca_base_var_env_name(const char *param_name,
+                                           char **env_name);
 
 /**
  * Find the index for an MCA variable based on its names.
@@ -574,10 +574,10 @@ int pmix_mca_base_var_env_name(const char *param_name,
  * of any registered variable.  The returned index can be used with
  * pmix_mca_base_var_get() and pmix_mca_base_var_get_value().
  */
-int pmix_mca_base_var_find (const char *project_name,
-                            const char *type_name,
-                            const char *component_name,
-                            const char *param_name);
+PMIX_EXPORT int pmix_mca_base_var_find (const char *project_name,
+                                        const char *type_name,
+                                        const char *component_name,
+                                        const char *param_name);
 
 /**
  * Find the index for a variable based on its full name
@@ -587,7 +587,7 @@ int pmix_mca_base_var_find (const char *project_name,
  *
  * See pmix_mca_base_var_find().
  */
-int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
+PMIX_EXPORT int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
 
 /**
  * Check that two MCA variables were not both set to non-default
@@ -617,13 +617,13 @@ int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
  * are not MCA_BASE_VAR_SOURCE_DEFAULT.
  * @returns PMIX_SUCCESS otherwise.
  */
-int pmix_mca_base_var_check_exclusive (const char *project,
-                                       const char *type_a,
-                                       const char *component_a,
-                                       const char *param_a,
-                                       const char *type_b,
-                                       const char *component_b,
-                                       const char *param_b);
+PMIX_EXPORT int pmix_mca_base_var_check_exclusive (const char *project,
+                                                   const char *type_a,
+                                                   const char *component_a,
+                                                   const char *param_a,
+                                                   const char *type_b,
+                                                   const char *component_b,
+                                                   const char *param_b);
 
 /**
  * Set or unset a flag on a variable.
@@ -636,8 +636,8 @@ int pmix_mca_base_var_check_exclusive (const char *project,
  * @returns PMIX_ERR_BAD_PARAM If the variable is not registered.
  * @returns PMIX_ERROR Otherwise
  */
-int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
-                               bool set);
+PMIX_EXPORT int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
+                                           bool set);
 
 /**
  * Obtain basic info on a single variable (name, help message, etc)
@@ -651,7 +651,7 @@ int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
  * The returned pointer belongs to the MCA variable system. Do not
  * modify/free/retain the pointer.
  */
-int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
+PMIX_EXPORT int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
 
 /**
  * Obtain the number of variables that have been registered.
@@ -664,7 +664,7 @@ int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
  * returned is equal to the number of calls to pmix_mca_base_var_register with
  * unique names. ie. two calls with the same name will not affect the count.
  */
-int pmix_mca_base_var_get_count (void);
+PMIX_EXPORT int pmix_mca_base_var_get_count (void);
 
 /**
  * Obtain a list of enironment variables describing the all
@@ -683,8 +683,8 @@ int pmix_mca_base_var_get_count (void);
  * its output is in terms of an argv-style array of key=value
  * strings, suitable for using in an environment.
  */
-int pmix_mca_base_var_build_env(char ***env, int *num_env,
-                                bool internal);
+PMIX_EXPORT int pmix_mca_base_var_build_env(char ***env, int *num_env,
+                                            bool internal);
 
 /**
  * Shut down the MCA variable system (normally only invoked by the
@@ -700,7 +700,7 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env,
  * when the process is shutting down (e.g., during MPI_FINALIZE).  It
  * is only documented here for completeness.
  */
-int pmix_mca_base_var_finalize(void);
+PMIX_EXPORT int pmix_mca_base_var_finalize(void);
 
 typedef enum {
     /* Dump human-readable strings */
@@ -721,19 +721,19 @@ typedef enum {
  * This function returns an array of strings describing the variable. All strings
  * and the array must be freed by the caller.
  */
-int pmix_mca_base_var_dump(int vari, char ***out, pmix_mca_base_var_dump_type_t output_type);
+PMIX_EXPORT int pmix_mca_base_var_dump(int vari, char ***out, pmix_mca_base_var_dump_type_t output_type);
 
 #define MCA_COMPILETIME_VER "print_compiletime_version"
 #define MCA_RUNTIME_VER "print_runtime_version"
 
-int pmix_mca_base_var_cache_files (bool rel_path_search);
+PMIX_EXPORT int pmix_mca_base_var_cache_files (bool rel_path_search);
 
 /*
  * Parse a provided list of envars and add their local value, or
  * their assigned value, to the provided argv
  */
-int pmix_mca_base_var_process_env_list(char ***argv);
-int pmix_mca_base_var_process_env_list_from_file(char ***argv);
+PMIX_EXPORT int pmix_mca_base_var_process_env_list(char ***argv);
+PMIX_EXPORT int pmix_mca_base_var_process_env_list_from_file(char ***argv);
 
 END_C_DECLS
 

--- a/src/mca/base/pmix_mca_base_var_group.h
+++ b/src/mca/base/pmix_mca_base_var_group.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +58,7 @@ typedef struct pmix_mca_base_var_group_t pmix_mca_base_var_group_t;
 /**
  * Object declaration for pmix_mca_base_var_group_t
  */
-PMIX_CLASS_DECLARATION(pmix_mca_base_var_group_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_group_t);
 
 /**
  * Register an MCA variable group
@@ -74,10 +74,10 @@ PMIX_CLASS_DECLARATION(pmix_mca_base_var_group_t);
  * Create an MCA variable group. If the group already exists
  * this call is equivalent to pmix_mca_base_ver_find_group().
  */
-int pmix_mca_base_var_group_register(const char *project_name,
-                                              const char *framework_name,
-                                              const char *component_name,
-                                              const char *description);
+PMIX_EXPORT int pmix_mca_base_var_group_register(const char *project_name,
+                                                 const char *framework_name,
+                                                 const char *component_name,
+                                                 const char *description);
 
 /**
  * Register an MCA variable group for a component
@@ -89,8 +89,8 @@ int pmix_mca_base_var_group_register(const char *project_name,
  * @retval index Unique group index
  * @return pmix error code on Error
  */
-int pmix_mca_base_var_group_component_register (const pmix_mca_base_component_t *component,
-                                                         const char *description);
+PMIX_EXPORT int pmix_mca_base_var_group_component_register (const pmix_mca_base_component_t *component,
+                                                            const char *description);
 
 /**
  * Deregister an MCA param group
@@ -100,7 +100,7 @@ int pmix_mca_base_var_group_component_register (const pmix_mca_base_component_t 
  *
  * This call deregisters all associated variables and subgroups.
  */
-int pmix_mca_base_var_group_deregister (int group_index);
+PMIX_EXPORT int pmix_mca_base_var_group_deregister (int group_index);
 
 /**
  * Find an MCA group
@@ -112,9 +112,9 @@ int pmix_mca_base_var_group_deregister (int group_index);
  * @returns PMIX_SUCCESS if found
  * @returns PMIX_ERR_NOT_FOUND if not found
  */
-int pmix_mca_base_var_group_find (const char *project_name,
-                                           const char *framework_name,
-                                           const char *component_name);
+PMIX_EXPORT int pmix_mca_base_var_group_find (const char *project_name,
+                                              const char *framework_name,
+                                              const char *component_name);
 
 /**
  * Find an MCA group by its full name
@@ -125,7 +125,7 @@ int pmix_mca_base_var_group_find (const char *project_name,
  * @returns PMIX_SUCCESS if found
  * @returns PMIX_ERR_NOT_FOUND if not found
  */
-int pmix_mca_base_var_group_find_by_name (const char *full_name, int *index);
+PMIX_EXPORT int pmix_mca_base_var_group_find_by_name (const char *full_name, int *index);
 
 /**
  * Get the group at a specified index
@@ -139,8 +139,8 @@ int pmix_mca_base_var_group_find_by_name (const char *full_name, int *index);
  * The returned pointer belongs to the MCA variable system. Do not modify/release/retain
  * the pointer.
  */
-int pmix_mca_base_var_group_get (const int group_index,
-                                          const pmix_mca_base_var_group_t **group);
+PMIX_EXPORT int pmix_mca_base_var_group_get (const int group_index,
+                                             const pmix_mca_base_var_group_t **group);
 
 /**
  * Set/unset a flags for all variables in a group.
@@ -151,15 +151,15 @@ int pmix_mca_base_var_group_get (const int group_index,
  *
  * Set a flag for every variable in a group. See pmix_mca_base_var_set_flag() for more info.
  */
-int pmix_mca_base_var_group_set_var_flag (const int group_index, int flags,
-                                                   bool set);
+PMIX_EXPORT int pmix_mca_base_var_group_set_var_flag (const int group_index, int flags,
+                                                      bool set);
 
 /**
  * Get the number of registered MCA groups
  *
  * @retval count Number of registered MCA groups
  */
-int pmix_mca_base_var_group_get_count (void);
+PMIX_EXPORT int pmix_mca_base_var_group_get_count (void);
 
 /**
  * Get a relative timestamp for the MCA group system
@@ -168,6 +168,6 @@ int pmix_mca_base_var_group_get_count (void);
  *
  * This value will change if groups or variables are either added or removed.
  */
-int pmix_mca_base_var_group_get_stamp (void);
+PMIX_EXPORT int pmix_mca_base_var_group_get_stamp (void);
 
 #endif /* PMIX_MCA_BASE_VAR_GROUP_H */

--- a/src/mca/pdl/base/base.h
+++ b/src/mca/pdl/base/base.h
@@ -3,7 +3,7 @@
  *                         University Research and Technology
  *                         Corporation.  All rights reserved.
  * Copyright (c) 2015      Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@ BEGIN_C_DECLS
 /**
  * Globals
  */
-extern pmix_mca_base_framework_t pmix_pdl_base_framework;
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pdl_base_framework;
 extern pmix_pdl_base_component_t
 *pmix_pdl_base_selected_component;
 extern pmix_pdl_base_module_t *pmix_pdl;

--- a/src/mca/pinstalldirs/base/base.h
+++ b/src/mca/pinstalldirs/base/base.h
@@ -3,7 +3,7 @@
  *                         reserved.
  * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -27,7 +27,7 @@ BEGIN_C_DECLS
 /**
  * Framework structure declaration
  */
-extern pmix_mca_base_framework_t pmix_pinstalldirs_base_framework;
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pinstalldirs_base_framework;
 
 /* Just like pmix_pinstall_dirs_expand() (see pinstalldirs.h), but will
    also insert the value of the environment variable $PMIX_DESTDIR, if

--- a/src/mca/pinstalldirs/pinstalldirs.h
+++ b/src/mca/pinstalldirs/pinstalldirs.h
@@ -54,7 +54,7 @@ struct pmix_pinstall_dirs_t {
 typedef struct pmix_pinstall_dirs_t pmix_pinstall_dirs_t;
 
 /* Install directories.  Only available after pmix_init() */
-extern pmix_pinstall_dirs_t pmix_pinstall_dirs;
+PMIX_EXPORT extern pmix_pinstall_dirs_t pmix_pinstall_dirs;
 
 /**
  * Expand out path variables (such as ${prefix}) in the input string

--- a/src/tools/Makefile.include
+++ b/src/tools/Makefile.include
@@ -1,0 +1,37 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2006-2008 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
+#                         reserved.
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.include does not stand on its own - it is included from
+# src/Makefile.am
+
+SUBDIRS += \
+    tools/pevent \
+    tools/pinfo \
+    tools/plookup \
+    tools/pps
+
+DIST_SUBDIRS += \
+    tools/pevent \
+    tools/pinfo \
+    tools/plookup \
+    tools/pps

--- a/src/tools/pevent/Makefile.am
+++ b/src/tools/pevent/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+if PMIX_INSTALL_BINARIES
+
+bin_PROGRAMS = pevent
+
+dist_pmixdata_DATA = help-pevent.txt
+
+endif # PMIX_INSTALL_BINARIES
+
+pevent_SOURCES = pevent.c
+pevent_LDADD = \
+	$(top_builddir)/src/libpmix.la

--- a/src/tools/pevent/help-pevent.txt
+++ b/src/tools/pevent/help-pevent.txt
@@ -1,0 +1,47 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI PS tool
+#
+[usage]
+ompi-ps [OPTIONS]
+  Open MPI Job and Process Status Tool
+
+%s
+#
+[vpid-usage]
+Error: You specified a vpid (%d) without also specifying a jobid.
+       Use the '-j' option to specify a jobid.
+#
+[need-vpid]
+Error: You specified a jobid (%d) without also specifying a vpid.
+       Use the '-p' option to specify a vpid.
+#
+[invalid-vpid]
+Error: The specified vpid (%d) is not valid for job %d.
+#
+[stale-hnp]
+An attempt was made to obtain ps information from at least
+one non-responsive HNP:
+
+HNP name: %s
+
+You may want to cleanup stale session directories in your temporary
+directory (e.g., $TMPDIR).

--- a/src/tools/pevent/pevent.c
+++ b/src/tools/pevent/pevent.c
@@ -1,0 +1,270 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <pmix_tool.h>
+#include "src/mca/base/base.h"
+#include "src/mca/pinstalldirs/base/base.h"
+#include "src/threads/threads.h"
+#include "src/util/cmd_line.h"
+#include "src/util/keyval_parse.h"
+#include "src/util/show_help.h"
+#include "src/runtime/pmix_rte.h"
+
+typedef struct {
+    pmix_lock_t lock;
+    pmix_status_t status;
+} mylock_t;
+
+static pmix_proc_t myproc;
+
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    /* this example doesn't do anything with default events */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(&lock->lock);
+}
+
+/*****************************************
+ * Global Vars for Command line Arguments
+ *****************************************/
+typedef struct {
+    bool help;
+    bool verbose;
+    pid_t pid;
+    int code;
+    int range;
+} pmix_pevent_globals_t;
+
+pmix_pevent_globals_t pmix_pevent_globals = {0};
+
+pmix_cmd_line_init_t cmd_line_opts[] = {
+    { NULL,
+      'h', NULL, "help",
+      0,
+      &pmix_pevent_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
+      "This help message" },
+
+    { NULL,
+      'v', NULL, "verbose",
+      0,
+      &pmix_pevent_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
+      "Be Verbose" },
+
+    { NULL,
+      'p', NULL, "pid",
+      1,
+      &pmix_pevent_globals.pid, PMIX_CMD_LINE_TYPE_INT,
+      "Specify starter pid" },
+
+    { NULL,
+      'e', NULL, "event",
+      0,
+      &pmix_pevent_globals.code, PMIX_CMD_LINE_TYPE_INT,
+      "Status code of event to be sent" },
+
+    { NULL,
+      'r', NULL, "range",
+      0,
+      &pmix_pevent_globals.range, PMIX_CMD_LINE_TYPE_INT,
+      "Range of event to be sent" },
+
+    /* End of list */
+    { NULL,
+      '\0', NULL, NULL,
+      0,
+      NULL, PMIX_CMD_LINE_TYPE_NULL,
+      NULL }
+};
+
+static void opcbfunc(pmix_status_t status, void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(&lock->lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t *info;
+    mylock_t mylock;
+    pmix_status_t status;
+    pmix_data_range_t range;
+    pmix_cmd_line_t cmd_line;
+
+    /* protect against problems if someone passes us thru a pipe
+     * and then abnormally terminates the pipe early */
+    signal(SIGPIPE, SIG_IGN);
+
+    /* initialize the output system */
+    if (!pmix_output_init()) {
+        return PMIX_ERROR;
+    }
+
+    /* initialize install dirs code */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
+
+    /* initialize the help system */
+    pmix_show_help_init();
+
+    /* keyval lex-based parser */
+    if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {
+        fprintf(stderr, "pmix_util_keyval_parse_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Setup the parameter system */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_var_init())) {
+        fprintf(stderr, "pmix_mca_base_var_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Parse the command line options */
+    pmix_cmd_line_create(&cmd_line, cmd_line_opts);
+
+    pmix_mca_base_open();
+    pmix_mca_base_cmd_line_setup(&cmd_line);
+    rc = pmix_cmd_line_parse(&cmd_line, false, false, argc, argv);
+
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    PMIx_Error_string(rc));
+        }
+        return rc;
+    }
+
+    if (pmix_pevent_globals.help) {
+        char *str, *args = NULL;
+        args = pmix_cmd_line_get_usage_msg(&cmd_line);
+        str = pmix_show_help_string("help-pevent.txt", "usage", true,
+                                    args);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(args);
+        /* If we show the help message, that should be all we do */
+        exit(0);
+    }
+
+    status = (pmix_status_t)pmix_pevent_globals.code;
+    range = (pmix_data_range_t)pmix_pevent_globals.range;
+
+    /* if we were given the pid of a starter, then direct that
+     * we connect to it */
+
+    /* otherwise, use the system connection first, if available */
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* init as a tool */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
+        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+        exit(rc);
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    /* register a default event handler */
+    PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    PMIX_WAIT_THREAD(&mylock.lock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "PMIx_Register_event_handler returned bad status: %d\n", rc);
+        PMIX_DESTRUCT_LOCK(&mylock.lock);
+        goto done;
+    }
+    PMIX_DESTRUCT_LOCK(&mylock.lock);
+
+    /* generate the specified event */
+    PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    rc = PMIx_Notify_event(status, &myproc, range, NULL, 0, opcbfunc, (void*)&mylock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Notify_event failed: %d\n", rc);
+        goto done;
+    }
+    PMIX_WAIT_THREAD(&mylock.lock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "PMIx_Notify_event returned bad status: %d\n", rc);
+    }
+    PMIX_DESTRUCT_LOCK(&mylock.lock);
+
+
+  done:
+    PMIx_tool_finalize();
+
+    return(rc);
+}

--- a/src/tools/pinfo/Makefile.am
+++ b/src/tools/pinfo/Makefile.am
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CFLAGS = \
+            -DPMIX_CONFIGURE_USER="\"@PMIX_CONFIGURE_USER@\"" \
+            -DPMIX_CONFIGURE_HOST="\"@PMIX_CONFIGURE_HOST@\"" \
+            -DPMIX_CONFIGURE_DATE="\"@PMIX_CONFIGURE_DATE@\"" \
+            -DPMIX_BUILD_USER="\"$$USER\"" \
+            -DPMIX_BUILD_HOST="\"`(hostname || uname -n) 2> /dev/null | sed 1q`\"" \
+            -DPMIX_BUILD_DATE="\"`date`\"" \
+            -DPMIX_BUILD_CFLAGS="\"@CFLAGS@\"" \
+            -DPMIX_BUILD_CPPFLAGS="\"@CPPFLAGS@\"" \
+            -DPMIX_BUILD_LDFLAGS="\"@LDFLAGS@\"" \
+            -DPMIX_BUILD_LIBS="\"@LIBS@\"" \
+            -DPMIX_CC_ABSOLUTE="\"@PMIX_CC_ABSOLUTE@\"" \
+            -DPMIX_CONFIGURE_CLI="\"@PMIX_CONFIGURE_CLI@\"" \
+            -DPMIX_GREEK_VERSION="\"@PMIX_GREEK_VERSION@\"" \
+            -DPMIX_REPO_REV="\"@PMIX_REPO_REV@\"" \
+            -DPMIX_RELEASE_DATE="\"@PMIX_RELEASE_DATE@\""
+
+if PMIX_INSTALL_BINARIES
+
+bin_PROGRAMS = pinfo
+
+dist_pmixdata_DATA = help-pinfo.txt
+
+endif # PMIX_INSTALL_BINARIES
+
+pinfo_SOURCES =  \
+    pinfo.h  \
+    support.h  \
+    pinfo.c  \
+    support.c
+
+pinfo_LDADD = \
+	$(top_builddir)/src/libpmix.la

--- a/src/tools/pinfo/help-pinfo.txt
+++ b/src/tools/pinfo/help-pinfo.txt
@@ -1,0 +1,59 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010-2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for ORTE orte-info error
+# messages.
+#
+[usage]
+The orte-info command can be used to provide detailed information on
+your ORTE installation.  Syntax:
+
+%s
+#
+[lib-call-fail]
+A library call unexpectedly failed.  This is a terminal error; please
+show this message to an ORTE wizard:
+
+        Library call: %s
+         Source file: %s
+  Source line number: %d
+
+Aborting...
+#
+[developer warning: field too long]
+**************************************************************************
+*** DEVELOPER WARNING: A field in orte-info output is too long and
+*** will appear poorly in the prettyprint output.
+***
+***   Value:      "%s"
+***   Max length: %d
+**************************************************************************
+#
+[not-found]
+The specified framework could not be found:
+
+  Framework: %s
+
+This could be due to a misspelling of the framework name, or because support
+for that framework was not configured into this version of orte. Please see
+
+  orte-info --config
+
+for a full report of how orte was configured.

--- a/src/tools/pinfo/pinfo.c
+++ b/src/tools/pinfo/pinfo.c
@@ -1,0 +1,233 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2007 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2016 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#include <errno.h>
+#include <signal.h>
+
+#include "src/mca/pinstalldirs/base/base.h"
+#include "src/class/pmix_object.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/argv.h"
+#include "src/util/cmd_line.h"
+#include "src/util/error.h"
+#include "src/util/error.h"
+#include "src/util/keyval_parse.h"
+#include "src/util/output.h"
+#include "src/util/show_help.h"
+#include "src/mca/base/base.h"
+#include "src/runtime/pmix_rte.h"
+
+#include "pinfo.h"
+#include "support.h"
+
+/*
+ * Public variables
+ */
+
+pmix_cmd_line_t *pmix_info_cmd_line = NULL;
+
+const char *pmix_info_type_base = "base";
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+    bool acted = false;
+    bool want_all = false;
+    char **app_env = NULL, **global_env = NULL;
+    int i, len;
+    pmix_pointer_array_t mca_types;
+    pmix_pointer_array_t component_map;
+    pmix_info_component_map_t *map;
+
+    /* protect against problems if someone passes us thru a pipe
+     * and then abnormally terminates the pipe early */
+    signal(SIGPIPE, SIG_IGN);
+
+    /* initialize the output system */
+    if (!pmix_output_init()) {
+        return PMIX_ERROR;
+    }
+
+    /* initialize install dirs code */
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, ret);
+        return ret;
+    }
+
+    /* initialize the help system */
+    pmix_show_help_init();
+
+    /* keyval lex-based parser */
+    if (PMIX_SUCCESS != (ret = pmix_util_keyval_parse_init())) {
+        fprintf(stderr, "pmix_util_keyval_parse_init failed with %d\n", ret);
+        return PMIX_ERROR;
+    }
+
+    /* Setup the parameter system */
+    if (PMIX_SUCCESS != (ret = pmix_mca_base_var_init())) {
+        fprintf(stderr, "pmix_mca_base_var_init failed with %d\n", ret);
+        return PMIX_ERROR;
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (ret = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", ret);
+        return PMIX_ERROR;
+    }
+
+    pmix_info_cmd_line = PMIX_NEW(pmix_cmd_line_t);
+    if (NULL == pmix_info_cmd_line) {
+        ret = errno;
+        pmix_show_help("help-pmix-info.txt", "lib-call-fail", true,
+                       "pmix_cmd_line_create", __FILE__, __LINE__, NULL);
+        exit(ret);
+    }
+
+    if (PMIX_SUCCESS != (ret = pmix_info_init(argc, argv, pmix_info_cmd_line))) {
+        return ret;
+    }
+
+    /* Get MCA parameters, if any */
+
+   /* putenv() all the stuff that we got back from env (in case the
+     * user specified some --mca params on the command line).  This
+     * creates a memory leak, but that's unfortunately how putenv()
+     * works.  :-(
+     */
+
+    len = pmix_argv_count(app_env);
+    for (i = 0; i < len; ++i) {
+        putenv(app_env[i]);
+    }
+    len = pmix_argv_count(global_env);
+    for (i = 0; i < len; ++i) {
+        putenv(global_env[i]);
+    }
+
+    /* setup the mca_types array */
+    PMIX_CONSTRUCT(&mca_types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&mca_types, 256, INT_MAX, 128);
+    pmix_info_register_types(&mca_types);
+
+    /* init the component map */
+    PMIX_CONSTRUCT(&component_map, pmix_pointer_array_t);
+    pmix_pointer_array_init(&component_map, 64, INT_MAX, 32);
+
+    /* Register PMIx's params */
+    if (PMIX_SUCCESS != (ret = pmix_info_register_framework_params(&component_map))) {
+        if (PMIX_ERR_BAD_PARAM == ret) {
+            /* output what we got */
+            pmix_info_do_params(true, pmix_cmd_line_is_taken(pmix_info_cmd_line, "internal"),
+                                &mca_types, &component_map, NULL);
+        }
+        exit(1);
+    }
+
+
+    /* Execute the desired action(s) */
+    want_all = pmix_cmd_line_is_taken(pmix_info_cmd_line, "all");
+    if (want_all) {
+        pmix_info_out("Package", "package", PMIX_PACKAGE_STRING);
+        pmix_info_show_pmix_version(pmix_info_ver_full);
+    }
+    if (want_all || pmix_cmd_line_is_taken(pmix_info_cmd_line, "path")) {
+        pmix_info_do_path(want_all, pmix_info_cmd_line);
+        acted = true;
+    }
+    if (want_all || pmix_cmd_line_is_taken(pmix_info_cmd_line, "arch")) {
+        pmix_info_do_arch();
+        acted = true;
+    }
+    if (want_all || pmix_cmd_line_is_taken(pmix_info_cmd_line, "hostname")) {
+        pmix_info_do_hostname();
+        acted = true;
+    }
+    if (want_all || pmix_cmd_line_is_taken(pmix_info_cmd_line, "config")) {
+        pmix_info_do_config(true);
+        acted = true;
+    }
+    if (want_all || pmix_cmd_line_is_taken(pmix_info_cmd_line, "param") ||
+        pmix_cmd_line_is_taken(pmix_info_cmd_line, "params")) {
+        pmix_info_do_params(want_all, pmix_cmd_line_is_taken(pmix_info_cmd_line, "internal"),
+                            &mca_types, &component_map, pmix_info_cmd_line);
+        acted = true;
+    }
+    if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "type")) {
+        pmix_info_do_type(pmix_info_cmd_line);
+        acted = true;
+    }
+
+    /* If no command line args are specified, show default set */
+
+    if (!acted) {
+        pmix_info_out("Package", "package", PMIX_PACKAGE_STRING);
+        pmix_info_show_pmix_version(pmix_info_ver_full);
+        pmix_info_show_path(pmix_info_path_prefix, pmix_pinstall_dirs.prefix);
+        pmix_info_do_arch();
+        pmix_info_do_hostname();
+        pmix_info_do_config(false);
+        pmix_info_show_component_version(&mca_types, &component_map, pmix_info_type_all,
+                                         pmix_info_component_all, pmix_info_ver_full,
+                                         pmix_info_ver_all);
+    }
+
+
+    /* All done */
+
+    if (NULL != app_env) {
+        pmix_argv_free(app_env);
+    }
+    if (NULL != global_env) {
+        pmix_argv_free(global_env);
+    }
+    pmix_info_close_components();
+    PMIX_RELEASE(pmix_info_cmd_line);
+    PMIX_DESTRUCT(&mca_types);
+    for (i=0; i < component_map.size; i++) {
+        if (NULL != (map = (pmix_info_component_map_t*)pmix_pointer_array_get_item(&component_map, i))) {
+            PMIX_RELEASE(map);
+        }
+    }
+    PMIX_DESTRUCT(&component_map);
+
+    pmix_info_finalize();
+
+    return 0;
+}

--- a/src/tools/pinfo/pinfo.h
+++ b/src/tools/pinfo/pinfo.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004-2009 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_INFO_TOOL_H
+#define PMIX_INFO_TOOL_H
+#include "pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/cmd_line.h"
+#include "src/mca/mca.h"
+
+BEGIN_C_DECLS
+
+/*
+ * Globals
+ */
+
+extern bool pmix_info_pretty;
+extern pmix_cmd_line_t *pmix_info_cmd_line;
+
+extern const char *pmix_info_type_base;
+
+extern pmix_pointer_array_t mca_types;
+
+
+/*
+ * Parameter/configuration-related functions
+ */
+
+extern const char *pmix_info_component_all;
+extern const char *pmix_info_param_all;
+
+extern const char *pmix_info_path_bindir;
+extern const char *pmix_info_path_libdir;
+extern const char *pmix_info_path_incdir;
+extern const char *pmix_info_path_mandir;
+extern const char *pmix_info_path_pkglibdir;
+extern const char *pmix_info_path_sysconfdir;
+extern const char *pmix_info_path_exec_prefix;
+extern const char *pmix_info_path_sbindir;
+extern const char *pmix_info_path_libexecdir;
+extern const char *pmix_info_path_datarootdir;
+extern const char *pmix_info_path_datadir;
+extern const char *pmix_info_path_sharedstatedir;
+extern const char *pmix_info_path_localstatedir;
+extern const char *pmix_info_path_infodir;
+extern const char *pmix_info_path_pkgdatadir;
+extern const char *pmix_info_path_pkgincludedir;
+
+void pmix_info_do_config(bool want_all);
+
+extern pmix_pointer_array_t pmix_component_map;
+
+END_C_DECLS
+
+#endif /* PMIX_INFO_H */

--- a/src/tools/pinfo/support.c
+++ b/src/tools/pinfo/support.c
@@ -1,0 +1,1293 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2010-2016 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2011-2012 University of Houston. All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017 IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <string.h>
+#include <ctype.h>
+
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#include <errno.h>
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/runtime/pmix_rte.h"
+#include "src/util/output.h"
+#include "src/util/cmd_line.h"
+#include "src/util/error.h"
+#include "src/util/argv.h"
+#include "src/util/show_help.h"
+
+#include "src/include/frameworks.h"
+#include "src/include/pmix_portable_platform.h"
+
+#include "src/mca/pinstalldirs/pinstalldirs.h"
+#include "pinfo.h"
+#include "support.h"
+#include "src/mca/base/pmix_mca_base_component_repository.h"
+
+const char *pmix_info_path_prefix = "prefix";
+const char *pmix_info_path_bindir = "bindir";
+const char *pmix_info_path_libdir = "libdir";
+const char *pmix_info_path_incdir = "incdir";
+const char *pmix_info_path_mandir = "mandir";
+const char *pmix_info_path_pkglibdir = "pkglibdir";
+const char *pmix_info_path_sysconfdir = "sysconfdir";
+const char *pmix_info_path_exec_prefix = "exec_prefix";
+const char *pmix_info_path_sbindir = "sbindir";
+const char *pmix_info_path_libexecdir = "libexecdir";
+const char *pmix_info_path_datarootdir = "datarootdir";
+const char *pmix_info_path_datadir = "datadir";
+const char *pmix_info_path_sharedstatedir = "sharedstatedir";
+const char *pmix_info_path_localstatedir = "localstatedir";
+const char *pmix_info_path_infodir = "infodir";
+const char *pmix_info_path_pkgdatadir = "pkgdatadir";
+const char *pmix_info_path_pkgincludedir = "pkgincludedir";
+
+bool pmix_info_pretty = true;
+pmix_mca_base_register_flag_t pmix_info_register_flags = PMIX_MCA_BASE_REGISTER_ALL;
+
+const char *pmix_info_type_all = "all";
+const char *pmix_info_type_pmix = "pmix";
+const char *pmix_info_component_all = "all";
+const char *pmix_info_param_all = "all";
+
+const char *pmix_info_ver_full = "full";
+const char *pmix_info_ver_major = "major";
+const char *pmix_info_ver_minor = "minor";
+const char *pmix_info_ver_release = "release";
+const char *pmix_info_ver_greek = "greek";
+const char *pmix_info_ver_repo = "repo";
+
+const char *pmix_info_ver_all = "all";
+const char *pmix_info_ver_mca = "mca";
+const char *pmix_info_ver_type = "type";
+const char *pmix_info_ver_component = "component";
+
+static int pmix_info_registered = 0;
+
+static void component_map_construct(pmix_info_component_map_t *map)
+{
+    map->type = NULL;
+}
+static void component_map_destruct(pmix_info_component_map_t *map)
+{
+    if (NULL != map->type) {
+        free(map->type);
+    }
+    /* the type close functions will release the
+     * list of components
+     */
+}
+PMIX_CLASS_INSTANCE(pmix_info_component_map_t,
+                    pmix_list_item_t,
+                    component_map_construct,
+                    component_map_destruct);
+
+static void pmix_info_show_failed_component(const pmix_mca_base_component_repository_item_t* ri,
+                                            const char *error_msg);
+
+int pmix_info_init(int argc, char **argv,
+                   pmix_cmd_line_t *pmix_info_cmd_line)
+{
+    int ret;
+    bool want_help = false;
+    bool cmd_error = false;
+    char **app_env = NULL, **global_env = NULL;
+
+    /* add the cmd line options */
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 'V', NULL, "version", 0,
+                            "Show version of Open MPI");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "param", 2,
+                            "Show MCA parameters.  The first parameter is the framework (or the keyword \"all\"); the second parameter is the specific component name (or the keyword \"all\").");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "params", 2,
+                            "Synonym for --param");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "internal", 0,
+                            "Show internal MCA parameters (not meant to be modified by users)");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "path", 1,
+                            "Show paths that Open MPI was configured with.  Accepts the following parameters: prefix, bindir, libdir, incdir, mandir, pkglibdir, sysconfdir, all");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "arch", 0,
+                            "Show architecture Open MPI was compiled on");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 'c', NULL, "config", 0,
+                            "Show configuration options");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 't', NULL, "type", 1,
+                            "Show internal MCA parameters with the type specified in parameter.");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 'h', NULL, "help", 0,
+                            "Show this help message");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "pretty-print", 0,
+                            "When used in conjunction with other parameters, the output is displayed in 'pretty-print' format (default)");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "parsable", 0,
+                            "When used in conjunction with other parameters, the output is displayed in a machine-parsable format");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "parseable", 0,
+                            "Synonym for --parsable");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "hostname", 0,
+                            "Show the hostname that Open MPI was configured and built on");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 'a', NULL, "all", 0,
+                            "Show all configuration options and MCA parameters");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 'l', NULL, "level", 1,
+                            "Show only variables with at most this level (1-9)");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, 's', NULL, "selected-only", 0,
+                            "Show only variables from selected components");
+    pmix_cmd_line_make_opt3(pmix_info_cmd_line, '\0', NULL, "show-failed", 0,
+                            "Show the components that failed to load along with the reason why they failed.");
+
+    if( PMIX_SUCCESS != pmix_mca_base_open() ) {
+        pmix_show_help("help-pinfo.txt", "lib-call-fail", true, "mca_base_open", __FILE__, __LINE__ );
+        PMIX_RELEASE(pmix_info_cmd_line);
+        exit(1);
+    }
+    pmix_mca_base_cmd_line_setup(pmix_info_cmd_line);
+
+    /* Do the parsing */
+
+    ret = pmix_cmd_line_parse(pmix_info_cmd_line, false, false, argc, argv);
+    if (PMIX_SUCCESS != ret) {
+        if (PMIX_ERR_SILENT != ret) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    PMIx_Error_string(ret));
+        }
+        cmd_error = true;
+    }
+    if (!cmd_error &&
+        (pmix_cmd_line_is_taken(pmix_info_cmd_line, "help") ||
+         pmix_cmd_line_is_taken(pmix_info_cmd_line, "h"))) {
+        char *str, *usage;
+
+        want_help = true;
+        usage = pmix_cmd_line_get_usage_msg(pmix_info_cmd_line);
+        str = pmix_show_help_string("help-pmix-info.txt", "usage", true,
+                                    usage);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(usage);
+    }
+
+
+    /* If we had a cmd line parse error, or we showed the help
+       message, it's time to exit. */
+    if (cmd_error || want_help) {
+        pmix_mca_base_close();
+        PMIX_RELEASE(pmix_info_cmd_line);
+        exit(cmd_error ? 1 : 0);
+    }
+
+    pmix_mca_base_cmd_line_process_args(pmix_info_cmd_line, &app_env, &global_env);
+
+
+    /* set the flags */
+    if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "pretty-print")) {
+        pmix_info_pretty = true;
+    } else if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "parsable") || pmix_cmd_line_is_taken(pmix_info_cmd_line, "parseable")) {
+        pmix_info_pretty = false;
+    }
+
+    if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "selected-only")) {
+        /* register only selected components */
+        pmix_info_register_flags = PMIX_MCA_BASE_REGISTER_DEFAULT;
+    }
+
+    if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "show-failed")) {
+        pmix_mca_base_component_track_load_errors = true;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+void pmix_info_finalize(void)
+{
+    pmix_mca_base_close();
+}
+
+static int info_register_framework (pmix_mca_base_framework_t *framework, pmix_pointer_array_t *component_map)
+{
+    pmix_info_component_map_t *map;
+    int rc;
+    rc = pmix_mca_base_framework_register(framework, pmix_info_register_flags);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_BAD_PARAM != rc) {
+        return rc;
+    }
+
+    if (NULL != component_map) {
+        map = PMIX_NEW(pmix_info_component_map_t);
+        map->type = strdup(framework->framework_name);
+        map->components = &framework->framework_components;
+        map->failed_components = &framework->framework_failed_components;
+        pmix_pointer_array_add(component_map, map);
+    }
+
+    return rc;
+}
+
+int pmix_info_register_project_frameworks (const char *project_name, pmix_mca_base_framework_t **frameworks,
+                                           pmix_pointer_array_t *component_map)
+{
+    int i, rc=PMIX_SUCCESS;
+
+    for (i=0; NULL != frameworks[i]; i++) {
+        if (PMIX_SUCCESS != (rc = info_register_framework(frameworks[i], component_map))) {
+            if (PMIX_ERR_BAD_PARAM == rc) {
+                fprintf(stderr, "\nA \"bad parameter\" error was encountered when opening the %s %s framework\n",
+                        project_name, frameworks[i]->framework_name);
+                fprintf(stderr, "The output received from that framework includes the following parameters:\n\n");
+            } else if (PMIX_ERR_NOT_AVAILABLE != rc) {
+                fprintf(stderr, "%s_info_register: %s failed\n", project_name, frameworks[i]->framework_name);
+                rc = PMIX_ERROR;
+            } else {
+                continue;
+            }
+
+            break;
+        }
+    }
+
+    return rc;
+}
+
+void pmix_info_register_types(pmix_pointer_array_t *mca_types)
+{
+    int i;
+
+    /* add the top-level types */
+    pmix_pointer_array_add(mca_types, "mca");
+    pmix_pointer_array_add(mca_types, "pmix");
+
+    /* push all the types found by autogen */
+    for (i=0; NULL != pmix_frameworks[i]; i++) {
+        pmix_pointer_array_add(mca_types, pmix_frameworks[i]->framework_name);
+    }
+}
+
+int pmix_info_register_framework_params(pmix_pointer_array_t *component_map)
+{
+    int rc;
+
+    if (pmix_info_registered++) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Register mca/base parameters */
+    if( PMIX_SUCCESS != pmix_mca_base_open() ) {
+        pmix_show_help("help-pmix_info.txt", "lib-call-fail", true, "mca_base_open", __FILE__, __LINE__ );
+        return PMIX_ERROR;
+    }
+
+    /* Register the PMIX layer's MCA parameters */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_info_register: pmix_register_params failed\n");
+        return rc;
+    }
+
+    return pmix_info_register_project_frameworks("pmix", pmix_frameworks, component_map);
+}
+
+
+void pmix_info_close_components(void)
+{
+    int i;
+
+    assert(pmix_info_registered);
+    if (--pmix_info_registered) {
+        return;
+    }
+
+    for (i=0; NULL != pmix_frameworks[i]; i++) {
+        (void) pmix_mca_base_framework_close(pmix_frameworks[i]);
+    }
+
+    /* release our reference to MCA */
+    pmix_mca_base_close ();
+}
+
+
+void pmix_info_show_path(const char *type, const char *value)
+{
+    char *pretty, *path;
+
+    pretty = strdup(type);
+    pretty[0] = toupper(pretty[0]);
+
+    asprintf(&path, "path:%s", type);
+    pmix_info_out(pretty, path, value);
+    free(pretty);
+    free(path);
+}
+
+void pmix_info_do_path(bool want_all, pmix_cmd_line_t *cmd_line)
+{
+    int i, count;
+    char *scope;
+
+    /* Check bozo case */
+    count = pmix_cmd_line_get_ninsts(cmd_line, "path");
+    for (i = 0; i < count; ++i) {
+        scope = pmix_cmd_line_get_param(cmd_line, "path", i, 0);
+        if (0 == strcmp("all", scope)) {
+            want_all = true;
+            break;
+        }
+    }
+
+    if (want_all) {
+        pmix_info_show_path(pmix_info_path_prefix, pmix_pinstall_dirs.prefix);
+        pmix_info_show_path(pmix_info_path_exec_prefix, pmix_pinstall_dirs.exec_prefix);
+        pmix_info_show_path(pmix_info_path_bindir, pmix_pinstall_dirs.bindir);
+        pmix_info_show_path(pmix_info_path_sbindir, pmix_pinstall_dirs.sbindir);
+        pmix_info_show_path(pmix_info_path_libdir, pmix_pinstall_dirs.libdir);
+        pmix_info_show_path(pmix_info_path_incdir, pmix_pinstall_dirs.includedir);
+        pmix_info_show_path(pmix_info_path_mandir, pmix_pinstall_dirs.mandir);
+        pmix_info_show_path(pmix_info_path_pkglibdir, pmix_pinstall_dirs.pmixlibdir);
+        pmix_info_show_path(pmix_info_path_libexecdir, pmix_pinstall_dirs.libexecdir);
+        pmix_info_show_path(pmix_info_path_datarootdir, pmix_pinstall_dirs.datarootdir);
+        pmix_info_show_path(pmix_info_path_datadir, pmix_pinstall_dirs.datadir);
+        pmix_info_show_path(pmix_info_path_sysconfdir, pmix_pinstall_dirs.sysconfdir);
+        pmix_info_show_path(pmix_info_path_sharedstatedir, pmix_pinstall_dirs.sharedstatedir);
+        pmix_info_show_path(pmix_info_path_localstatedir, pmix_pinstall_dirs.localstatedir);
+        pmix_info_show_path(pmix_info_path_infodir, pmix_pinstall_dirs.infodir);
+        pmix_info_show_path(pmix_info_path_pkgdatadir, pmix_pinstall_dirs.pmixdatadir);
+        pmix_info_show_path(pmix_info_path_pkglibdir, pmix_pinstall_dirs.pmixlibdir);
+        pmix_info_show_path(pmix_info_path_pkgincludedir, pmix_pinstall_dirs.pmixincludedir);
+    } else {
+        count = pmix_cmd_line_get_ninsts(cmd_line, "path");
+        for (i = 0; i < count; ++i) {
+            scope = pmix_cmd_line_get_param(cmd_line, "path", i, 0);
+
+            if (0 == strcmp(pmix_info_path_prefix, scope)) {
+                pmix_info_show_path(pmix_info_path_prefix, pmix_pinstall_dirs.prefix);
+            } else if (0 == strcmp(pmix_info_path_bindir, scope)) {
+                pmix_info_show_path(pmix_info_path_bindir, pmix_pinstall_dirs.bindir);
+            } else if (0 == strcmp(pmix_info_path_libdir, scope)) {
+                pmix_info_show_path(pmix_info_path_libdir, pmix_pinstall_dirs.libdir);
+            } else if (0 == strcmp(pmix_info_path_incdir, scope)) {
+                pmix_info_show_path(pmix_info_path_incdir, pmix_pinstall_dirs.includedir);
+            } else if (0 == strcmp(pmix_info_path_mandir, scope)) {
+                pmix_info_show_path(pmix_info_path_mandir, pmix_pinstall_dirs.mandir);
+            } else if (0 == strcmp(pmix_info_path_pkglibdir, scope)) {
+                pmix_info_show_path(pmix_info_path_pkglibdir, pmix_pinstall_dirs.pmixlibdir);
+            } else if (0 == strcmp(pmix_info_path_sysconfdir, scope)) {
+                pmix_info_show_path(pmix_info_path_sysconfdir, pmix_pinstall_dirs.sysconfdir);
+            } else if (0 == strcmp(pmix_info_path_exec_prefix, scope)) {
+                pmix_info_show_path(pmix_info_path_exec_prefix, pmix_pinstall_dirs.exec_prefix);
+            } else if (0 == strcmp(pmix_info_path_sbindir, scope)) {
+                pmix_info_show_path(pmix_info_path_sbindir, pmix_pinstall_dirs.sbindir);
+            } else if (0 == strcmp(pmix_info_path_libexecdir, scope)) {
+                pmix_info_show_path(pmix_info_path_libexecdir, pmix_pinstall_dirs.libexecdir);
+            } else if (0 == strcmp(pmix_info_path_datarootdir, scope)) {
+                pmix_info_show_path(pmix_info_path_datarootdir, pmix_pinstall_dirs.datarootdir);
+            } else if (0 == strcmp(pmix_info_path_datadir, scope)) {
+                pmix_info_show_path(pmix_info_path_datadir, pmix_pinstall_dirs.datadir);
+            } else if (0 == strcmp(pmix_info_path_sharedstatedir, scope)) {
+                pmix_info_show_path(pmix_info_path_sharedstatedir, pmix_pinstall_dirs.sharedstatedir);
+            } else if (0 == strcmp(pmix_info_path_localstatedir, scope)) {
+                pmix_info_show_path(pmix_info_path_localstatedir, pmix_pinstall_dirs.localstatedir);
+            } else if (0 == strcmp(pmix_info_path_infodir, scope)) {
+                pmix_info_show_path(pmix_info_path_infodir, pmix_pinstall_dirs.infodir);
+            } else if (0 == strcmp(pmix_info_path_pkgdatadir, scope)) {
+                pmix_info_show_path(pmix_info_path_pkgdatadir, pmix_pinstall_dirs.pmixdatadir);
+            } else if (0 == strcmp(pmix_info_path_pkgincludedir, scope)) {
+                pmix_info_show_path(pmix_info_path_pkgincludedir, pmix_pinstall_dirs.pmixincludedir);
+            } else {
+                char *usage = pmix_cmd_line_get_usage_msg(cmd_line);
+                pmix_show_help("help-pmix_info.txt", "usage", true, usage);
+                free(usage);
+                exit(1);
+            }
+        }
+    }
+}
+
+void pmix_info_do_params(bool want_all_in, bool want_internal,
+                         pmix_pointer_array_t *mca_types,
+                         pmix_pointer_array_t *component_map,
+                         pmix_cmd_line_t *pmix_info_cmd_line)
+{
+    pmix_mca_base_var_info_lvl_t max_level = PMIX_INFO_LVL_1;
+    int count;
+    char *type, *component, *str;
+    bool found;
+    int i;
+    bool want_all = false;
+    char *p;
+
+    if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "param")) {
+        p = "param";
+    } else if (pmix_cmd_line_is_taken(pmix_info_cmd_line, "params")) {
+        p = "params";
+    } else {
+        p = "foo";  /* should never happen, but protect against segfault */
+    }
+
+    if (NULL != (str = pmix_cmd_line_get_param (pmix_info_cmd_line, "level", 0, 0))) {
+        char *tmp;
+
+        errno = 0;
+        max_level = strtol (str, &tmp, 10) + PMIX_INFO_LVL_1 - 1;
+        if (0 != errno || '\0' != tmp[0] || max_level < PMIX_INFO_LVL_1 || max_level > PMIX_INFO_LVL_9) {
+            char *usage = pmix_cmd_line_get_usage_msg(pmix_info_cmd_line);
+            pmix_show_help("help-pmix_info.txt", "invalid-level", true, str);
+            free(usage);
+            exit(1);
+        }
+    } else if (want_all_in) {
+        /* if not specified default to level 9 if all components are requested */
+        max_level = PMIX_INFO_LVL_9;
+    }
+
+    if (want_all_in) {
+        want_all = true;
+    } else {
+        /* See if the special param "all" was given to --param; that
+         * supercedes any individual type
+         */
+        count = pmix_cmd_line_get_ninsts(pmix_info_cmd_line, p);
+        for (i = 0; i < count; ++i) {
+            type = pmix_cmd_line_get_param(pmix_info_cmd_line, p, (int)i, 0);
+            if (0 == strcmp(pmix_info_type_all, type)) {
+                want_all = true;
+                break;
+            }
+        }
+    }
+
+    /* Show the params */
+
+    if (want_all) {
+        pmix_info_show_component_version(mca_types, component_map, pmix_info_type_all,
+                                         pmix_info_component_all, pmix_info_ver_full,
+                                         pmix_info_ver_all);
+        for (i = 0; i < mca_types->size; ++i) {
+            if (NULL == (type = (char *)pmix_pointer_array_get_item(mca_types, i))) {
+                continue;
+            }
+            pmix_info_show_mca_params(type, pmix_info_component_all, max_level, want_internal);
+        }
+    } else {
+        for (i = 0; i < count; ++i) {
+            type = pmix_cmd_line_get_param(pmix_info_cmd_line, p, (int)i, 0);
+            component = pmix_cmd_line_get_param(pmix_info_cmd_line, p, (int)i, 1);
+
+            for (found = false, i = 0; i < mca_types->size; ++i) {
+                if (NULL == (str = (char *)pmix_pointer_array_get_item(mca_types, i))) {
+                    continue;
+                }
+                if (0 == strcmp(str, type)) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found) {
+                char *usage = pmix_cmd_line_get_usage_msg(pmix_info_cmd_line);
+                pmix_show_help("help-pmix_info.txt", "not-found", true, type);
+                free(usage);
+                exit(1);
+            }
+
+            pmix_info_show_component_version(mca_types, component_map, type,
+                                             component, pmix_info_ver_full,
+                                             pmix_info_ver_all);
+            pmix_info_show_mca_params(type, component, max_level, want_internal);
+        }
+    }
+}
+
+void pmix_info_err_params(pmix_pointer_array_t *component_map)
+{
+    pmix_info_component_map_t *map=NULL, *mptr;
+    int i;
+
+    /* all we want to do is display the LAST entry in the
+     * component_map array as this is the one that generated the error
+     */
+    for (i=0; i < component_map->size; i++) {
+        if (NULL == (mptr = (pmix_info_component_map_t*)pmix_pointer_array_get_item(component_map, i))) {
+            continue;
+        }
+        map = mptr;
+    }
+    if (NULL == map) {
+        fprintf(stderr, "pmix_info_err_params: map not found\n");
+        return;
+    }
+    pmix_info_show_mca_params(map->type, pmix_info_component_all, PMIX_INFO_LVL_9, true);
+    fprintf(stderr, "\n");
+    return;
+}
+
+void pmix_info_do_type(pmix_cmd_line_t *pmix_info_cmd_line)
+{
+    pmix_mca_base_var_info_lvl_t max_level = PMIX_INFO_LVL_1;
+    int count;
+    char *type, *str;
+    int i, j, k, len, ret;
+    char *p;
+    const pmix_mca_base_var_t *var;
+    char** strings, *message;
+    const pmix_mca_base_var_group_t *group;
+    p = "type";
+
+    if (NULL != (str = pmix_cmd_line_get_param (pmix_info_cmd_line, "level", 0, 0))) {
+        char *tmp;
+
+        errno = 0;
+        max_level = strtol (str, &tmp, 10) + PMIX_INFO_LVL_1 - 1;
+        if (0 != errno || '\0' != tmp[0] || max_level < PMIX_INFO_LVL_1 || max_level > PMIX_INFO_LVL_9) {
+            char *usage = pmix_cmd_line_get_usage_msg(pmix_info_cmd_line);
+            pmix_show_help("help-pmix_info.txt", "invalid-level", true, str);
+            free(usage);
+            exit(1);
+        }
+    }
+
+    count = pmix_cmd_line_get_ninsts(pmix_info_cmd_line, p);
+    len = pmix_mca_base_var_get_count ();
+
+    for (k = 0; k < count; ++k) {
+        type = pmix_cmd_line_get_param(pmix_info_cmd_line, p, k, 0);
+        for (i = 0; i < len; ++i) {
+            ret = pmix_mca_base_var_get (i, &var);
+            if (PMIX_SUCCESS != ret) {
+                continue;
+            }
+            if (0 == strcmp(type, pmix_var_type_names[var->mbv_type]) && (var->mbv_info_lvl <= max_level)) {
+                ret = pmix_mca_base_var_dump(var->mbv_index, &strings, !pmix_info_pretty ? PMIX_MCA_BASE_VAR_DUMP_PARSABLE : PMIX_MCA_BASE_VAR_DUMP_READABLE);
+                if (PMIX_SUCCESS != ret) {
+                    continue;
+                }
+                (void) pmix_mca_base_var_group_get(var->mbv_group_index, &group);
+                for (j = 0 ; strings[j] ; ++j) {
+                    if (0 == j && pmix_info_pretty) {
+                        asprintf (&message, "MCA %s", group->group_framework);
+                        pmix_info_out(message, message, strings[j]);
+                        free(message);
+                    } else {
+                        pmix_info_out("", "", strings[j]);
+                    }
+                    free(strings[j]);
+                }
+                free(strings);
+            }
+        }
+    }
+}
+
+static void pmix_info_show_mca_group_params(const pmix_mca_base_var_group_t *group, pmix_mca_base_var_info_lvl_t max_level, bool want_internal)
+{
+    const int *variables, *groups;
+    const char *group_component;
+    const pmix_mca_base_var_t *var;
+    char **strings, *message;
+    bool requested = true;
+    int ret, i, j, count;
+
+    variables = PMIX_VALUE_ARRAY_GET_BASE(&group->group_vars, const int);
+    count = pmix_value_array_get_size((pmix_value_array_t *)&group->group_vars);
+
+    /* the default component name is "base". depending on how the
+     * group was registered the group may or not have this set.  */
+    group_component = group->group_component ? group->group_component : "base";
+
+    /* check if this group may be disabled due to a selection variable */
+    if (0 != strcmp (group_component, "base")) {
+        int var_id;
+
+        /* read the selection parameter */
+        var_id = pmix_mca_base_var_find (group->group_project, group->group_framework, NULL, NULL);
+        if (0 <= var_id) {
+            const pmix_mca_base_var_storage_t *value=NULL;
+            char **requested_components;
+            bool include_mode;
+
+            pmix_mca_base_var_get_value (var_id, &value, NULL, NULL);
+            if (NULL != value && NULL != value->stringval && '\0' != value->stringval[0]) {
+                pmix_mca_base_component_parse_requested (value->stringval, &include_mode, &requested_components);
+
+                for (i = 0, requested = !include_mode ; requested_components[i] ; ++i) {
+                    if (0 == strcmp (requested_components[i], group_component)) {
+                        requested = include_mode;
+                        break;
+                    }
+                }
+
+                pmix_argv_free (requested_components);
+            }
+        }
+    }
+
+    const pmix_mca_base_var_group_t *curr_group = NULL;
+    char *component_msg = NULL;
+    asprintf(&component_msg, " %s", group_component);
+
+    for (i = 0 ; i < count ; ++i) {
+        ret = pmix_mca_base_var_get(variables[i], &var);
+        if (PMIX_SUCCESS != ret || ((var->mbv_flags & PMIX_MCA_BASE_VAR_FLAG_INTERNAL) &&
+                                    !want_internal) ||
+            max_level < var->mbv_info_lvl) {
+            continue;
+        }
+
+        if (pmix_info_pretty && curr_group != group) {
+            asprintf(&message, "MCA%s %s%s", requested ? "" : " (-)",
+                     group->group_framework,
+                     component_msg ? component_msg : "");
+            pmix_info_out(message, message, "---------------------------------------------------");
+            free(message);
+            curr_group = group;
+        }
+
+        ret = pmix_mca_base_var_dump(variables[i], &strings, !pmix_info_pretty ? PMIX_MCA_BASE_VAR_DUMP_PARSABLE : PMIX_MCA_BASE_VAR_DUMP_READABLE);
+        if (PMIX_SUCCESS != ret) {
+            continue;
+        }
+
+        for (j = 0 ; strings[j] ; ++j) {
+            if (0 == j && pmix_info_pretty) {
+                asprintf (&message, "MCA%s %s%s", requested ? "" : " (-)",
+                          group->group_framework,
+                          component_msg ? component_msg : "");
+                pmix_info_out(message, message, strings[j]);
+                free(message);
+            } else {
+                pmix_info_out("", "", strings[j]);
+            }
+            free(strings[j]);
+        }
+        if (!pmix_info_pretty) {
+            /* generate an entry indicating whether this variable is disabled or not. if the
+             * format in mca_base_var/pvar.c changes this needs to be changed as well */
+            asprintf (&message, "mca:%s:%s:param:%s:disabled:%s", group->group_framework,
+                      group_component, var->mbv_full_name, requested ? "false" : "true");
+            pmix_info_out("", "", message);
+            free (message);
+        }
+        free(strings);
+    }
+
+    groups = PMIX_VALUE_ARRAY_GET_BASE(&group->group_subgroups, const int);
+    count = pmix_value_array_get_size((pmix_value_array_t *)&group->group_subgroups);
+
+    for (i = 0 ; i < count ; ++i) {
+        ret = pmix_mca_base_var_group_get(groups[i], &group);
+        if (PMIX_SUCCESS != ret) {
+            continue;
+        }
+        pmix_info_show_mca_group_params(group, max_level, want_internal);
+    }
+    free(component_msg);
+}
+
+void pmix_info_show_mca_params(const char *type, const char *component,
+                               pmix_mca_base_var_info_lvl_t max_level, bool want_internal)
+{
+    const pmix_mca_base_var_group_t *group;
+    int ret;
+
+    if (0 == strcmp (component, "all")) {
+        ret = pmix_mca_base_var_group_find("*", type, NULL);
+        if (0 > ret) {
+            return;
+        }
+
+        (void) pmix_mca_base_var_group_get(ret, &group);
+
+        pmix_info_show_mca_group_params(group, max_level, want_internal);
+    } else {
+        ret = pmix_mca_base_var_group_find("*", type, component);
+        if (0 > ret) {
+            return;
+        }
+
+        (void) pmix_mca_base_var_group_get(ret, &group);
+        pmix_info_show_mca_group_params(group, max_level, want_internal);
+    }
+}
+
+
+
+void pmix_info_do_arch()
+{
+    pmix_info_out("Configured architecture", "config:arch", PMIX_ARCH);
+}
+
+
+void pmix_info_do_hostname()
+{
+    pmix_info_out("Configure host", "config:host", PMIX_CONFIGURE_HOST);
+}
+
+
+static char *escape_quotes(const char *value)
+{
+    const char *src;
+    int num_quotes = 0;
+    for (src = value; src != NULL && *src != '\0'; ++src) {
+        if ('"' == *src) {
+            ++num_quotes;
+        }
+    }
+
+    // If there are no quotes in the string, there's nothing to do
+    if (0 == num_quotes) {
+        return NULL;
+    }
+
+    // If we have quotes, make a new string.  Copy over the old
+    // string, escaping the quotes along the way.  This is simple and
+    // clear to read; it's not particularly efficient (performance is
+    // definitely not important here).
+    char *quoted_value;
+    quoted_value = calloc(1, strlen(value) + num_quotes + 1);
+    if (NULL == quoted_value) {
+        return NULL;
+    }
+
+    char *dest;
+    for (src = value, dest = quoted_value; *src != '\0'; ++src, ++dest) {
+        if ('"' == *src) {
+            *dest++ = '\\';
+        }
+        *dest = *src;
+    }
+
+    return quoted_value;
+}
+
+
+/*
+ * Private variables - set some reasonable screen size defaults
+ */
+
+static int centerpoint = 24;
+static int screen_width = 78;
+
+/*
+ * Prints the passed message in a pretty or parsable format.
+ */
+void pmix_info_out(const char *pretty_message, const char *plain_message, const char *value)
+{
+    size_t len, max_value_width, value_offset;
+    char *spaces = NULL;
+    char *filler = NULL;
+    char *pos, *v, savev, *v_to_free;
+
+#ifdef HAVE_ISATTY
+    /* If we have isatty(), if this is not a tty, then disable
+     * wrapping for grep-friendly behavior
+     */
+    if (0 == isatty(STDOUT_FILENO)) {
+        screen_width = INT_MAX;
+    }
+#endif
+
+#ifdef TIOCGWINSZ
+    if (screen_width < INT_MAX) {
+        struct winsize size;
+        if (ioctl(STDOUT_FILENO, TIOCGWINSZ, (char*) &size) >= 0) {
+            screen_width = size.ws_col;
+        }
+    }
+#endif
+
+    /* Sanity check (allow NULL to mean "") */
+    if (NULL == value) {
+        value = "";
+    }
+
+    /* Strip leading and trailing whitespace from the string value */
+    value_offset = strspn(value, " ");
+
+    v = v_to_free = strdup(value + value_offset);
+    len = strlen(v);
+
+    if (len > 0) {
+        while (len > 0 && isspace(v[len-1])) len--;
+        v[len] = '\0';
+    }
+
+    if (pmix_info_pretty && NULL != pretty_message) {
+        if (centerpoint > (int)strlen(pretty_message)) {
+            asprintf(&spaces, "%*s", centerpoint -
+                     (int)strlen(pretty_message), " ");
+        } else {
+            spaces = strdup("");
+#if PMIX_ENABLE_DEBUG
+            if (centerpoint < (int)strlen(pretty_message)) {
+                pmix_show_help("help-pmix_info.txt",
+                               "developer warning: field too long", false,
+                               pretty_message, centerpoint);
+            }
+#endif
+        }
+        max_value_width = screen_width - strlen(spaces) - strlen(pretty_message) - 2;
+        if (0 < strlen(pretty_message)) {
+            asprintf(&filler, "%s%s: ", spaces, pretty_message);
+        } else {
+            asprintf(&filler, "%s  ", spaces);
+        }
+        free(spaces);
+        spaces = NULL;
+
+        while (true) {
+            if (strlen(v) < max_value_width) {
+                printf("%s%s\n", filler, v);
+                break;
+            } else {
+                asprintf(&spaces, "%*s", centerpoint + 2, " ");
+
+                /* Work backwards to find the first space before
+                 * max_value_width
+                 */
+                savev = v[max_value_width];
+                v[max_value_width] = '\0';
+                pos = (char*)strrchr(v, (int)' ');
+                v[max_value_width] = savev;
+                if (NULL == pos) {
+                    /* No space found < max_value_width.  Look for the first
+                     * space after max_value_width.
+                     */
+                    pos = strchr(&v[max_value_width], ' ');
+
+                    if (NULL == pos) {
+
+                        /* There's just no spaces.  So just print it and be done. */
+
+                        printf("%s%s\n", filler, v);
+                        break;
+                    } else {
+                        *pos = '\0';
+                        printf("%s%s\n", filler, v);
+                        v = pos + 1;
+                    }
+                } else {
+                    *pos = '\0';
+                    printf("%s%s\n", filler, v);
+                    v = pos + 1;
+                }
+
+                /* Reset for the next iteration */
+                free(filler);
+                filler = strdup(spaces);
+                free(spaces);
+                spaces = NULL;
+            }
+        }
+        if (NULL != filler) {
+            free(filler);
+        }
+        if (NULL != spaces) {
+            free(spaces);
+        }
+    } else {
+        if (NULL != plain_message && 0 < strlen(plain_message)) {
+            // Escape any double quotes in the value.
+            char *quoted_value;
+            quoted_value = escape_quotes(value);
+            if (NULL != quoted_value) {
+                value = quoted_value;
+            }
+
+            char *colon = strchr(value, ':');
+            if (NULL != colon) {
+                printf("%s:\"%s\"\n", plain_message, value);
+            } else {
+                printf("%s:%s\n", plain_message, value);
+            }
+
+            if (NULL != quoted_value) {
+                free(quoted_value);
+            }
+        } else {
+            printf("%s\n", value);
+        }
+    }
+    if (NULL != v_to_free) {
+        free(v_to_free);
+    }
+}
+
+/*
+ * Prints the passed integer in a pretty or parsable format.
+ */
+void pmix_info_out_int(const char *pretty_message,
+                       const char *plain_message,
+                       int value)
+{
+    char *valstr;
+
+    asprintf(&valstr, "%d", (int)value);
+    pmix_info_out(pretty_message, plain_message, valstr);
+    free(valstr);
+}
+
+/*
+ * Show all the components of a specific type/component combo (component may be
+ * a wildcard)
+ */
+void pmix_info_show_component_version(pmix_pointer_array_t *mca_types,
+                                      pmix_pointer_array_t *component_map,
+                                      const char *type_name,
+                                      const char *component_name,
+                                      const char *scope, const char *ver_type)
+{
+    bool want_all_components = false;
+    bool want_all_types = false;
+    bool found;
+    pmix_mca_base_component_list_item_t *cli;
+    pmix_mca_base_failed_component_t *cli_failed;
+    int j;
+    char *pos;
+    pmix_info_component_map_t *map;
+
+    /* see if all components wanted */
+    if (0 == strcmp(pmix_info_component_all, component_name)) {
+        want_all_components = true;
+    }
+
+    /* see if all types wanted */
+    if (0 != strcmp(pmix_info_type_all, type_name)) {
+        /* Check to see if the type is valid */
+
+        for (found = false, j = 0; j < mca_types->size; ++j) {
+            if (NULL == (pos = (char*)pmix_pointer_array_get_item(mca_types, j))) {
+                continue;
+            }
+            if (0 == strcmp(pos, type_name)) {
+                found = true;
+                break;
+            }
+        }
+
+        if (!found) {
+            return;
+        }
+    } else {
+        want_all_types = true;
+    }
+
+    /* Now that we have a valid type, find the right components */
+    for (j=0; j < component_map->size; j++) {
+        if (NULL == (map = (pmix_info_component_map_t*)pmix_pointer_array_get_item(component_map, j))) {
+            continue;
+        }
+        if ((want_all_types || 0 == strcmp(type_name, map->type)) && map->components) {
+            /* found it! */
+            PMIX_LIST_FOREACH(cli, map->components, pmix_mca_base_component_list_item_t) {
+                const pmix_mca_base_component_t *component = cli->cli_component;
+                if (want_all_components ||
+                    0 == strcmp(component->pmix_mca_component_name, component_name)) {
+                    pmix_info_show_mca_version(component, scope, ver_type);
+                }
+            }
+
+            /* found it! */
+            PMIX_LIST_FOREACH(cli_failed, map->failed_components, pmix_mca_base_failed_component_t) {
+                pmix_mca_base_component_repository_item_t *ri = cli_failed->comp;
+                if (want_all_components ||
+                    0 == strcmp(component_name, ri->ri_name) ) {
+                    pmix_info_show_failed_component(ri, cli_failed->error_msg);
+                }
+            }
+
+            if (!want_all_types) {
+                break;
+            }
+        }
+    }
+}
+
+
+static void pmix_info_show_failed_component(const pmix_mca_base_component_repository_item_t* ri,
+                                            const char *error_msg)
+{
+    char *message, *content;
+
+    if (pmix_info_pretty) {
+        asprintf(&message, "MCA %s", ri->ri_type);
+        asprintf(&content, "%s (failed to load) %s", ri->ri_name, error_msg);
+
+        pmix_info_out(message, NULL, content);
+
+        free(message);
+        free(content);
+    } else {
+        asprintf(&message, "mca:%s:%s:failed", ri->ri_type, ri->ri_name);
+        asprintf(&content, "%s", error_msg);
+
+        pmix_info_out(NULL, message, content);
+
+        free(message);
+        free(content);
+    }
+}
+
+/*
+ * Given a component, display its relevant version(s)
+ */
+void pmix_info_show_mca_version(const pmix_mca_base_component_t* component,
+                                const char *scope, const char *ver_type)
+{
+    bool printed;
+    bool want_mca = false;
+    bool want_type = false;
+    bool want_component = false;
+    char *message, *content;
+    char *mca_version;
+    char *api_version;
+    char *component_version;
+    char *tmp;
+
+    if (0 == strcmp(ver_type, pmix_info_ver_all) ||
+        0 == strcmp(ver_type, pmix_info_ver_mca)) {
+        want_mca = true;
+    }
+
+    if (0 == strcmp(ver_type, pmix_info_ver_all) ||
+        0 == strcmp(ver_type, pmix_info_ver_type)) {
+        want_type = true;
+    }
+
+    if (0 == strcmp(ver_type, pmix_info_ver_all) ||
+        0 == strcmp(ver_type, pmix_info_ver_component)) {
+        want_component = true;
+    }
+
+    mca_version = pmix_info_make_version_str(scope, component->pmix_mca_major_version,
+                                             component->pmix_mca_minor_version,
+                                             component->pmix_mca_release_version, "",
+                                             "");
+    api_version = pmix_info_make_version_str(scope, component->pmix_mca_type_major_version,
+                                             component->pmix_mca_type_minor_version,
+                                             component->pmix_mca_type_release_version, "",
+                                             "");
+    component_version = pmix_info_make_version_str(scope, component->pmix_mca_component_major_version,
+                                                   component->pmix_mca_component_minor_version,
+                                                   component->pmix_mca_component_release_version,
+                                                   "", "");
+    if (pmix_info_pretty) {
+        asprintf(&message, "MCA %s", component->pmix_mca_type_name);
+        printed = false;
+        asprintf(&content, "%s (", component->pmix_mca_component_name);
+
+        if (want_mca) {
+            asprintf(&tmp, "%sMCA v%s", content, mca_version);
+            free(content);
+            content = tmp;
+            printed = true;
+        }
+
+        if (want_type) {
+            if (printed) {
+                asprintf(&tmp, "%s, ", content);
+                free(content);
+                content = tmp;
+            }
+            asprintf(&tmp, "%sAPI v%s", content, api_version);
+            free(content);
+            content = tmp;
+            printed = true;
+        }
+
+        if (want_component) {
+            if (printed) {
+                asprintf(&tmp, "%s, ", content);
+                free(content);
+                content = tmp;
+            }
+            asprintf(&tmp, "%sComponent v%s", content, component_version);
+            free(content);
+            content = tmp;
+            printed = true;
+        }
+        if (NULL != content) {
+            asprintf(&tmp, "%s)", content);
+            free(content);
+        } else {
+            tmp = NULL;
+        }
+
+        pmix_info_out(message, NULL, tmp);
+        free(message);
+        if (NULL != tmp) {
+            free(tmp);
+        }
+
+    } else {
+        asprintf(&message, "mca:%s:%s:version", component->pmix_mca_type_name, component->pmix_mca_component_name);
+        if (want_mca) {
+            asprintf(&tmp, "mca:%s", mca_version);
+            pmix_info_out(NULL, message, tmp);
+            free(tmp);
+        }
+        if (want_type) {
+            asprintf(&tmp, "api:%s", api_version);
+            pmix_info_out(NULL, message, tmp);
+            free(tmp);
+        }
+        if (want_component) {
+            asprintf(&tmp, "component:%s", component_version);
+            pmix_info_out(NULL, message, tmp);
+            free(tmp);
+        }
+        free(message);
+    }
+
+    if (NULL != mca_version) {
+        free(mca_version);
+    }
+    if (NULL != api_version) {
+        free(api_version);
+    }
+    if (NULL != component_version) {
+        free(component_version);
+    }
+}
+
+
+char *pmix_info_make_version_str(const char *scope,
+                                 int major, int minor, int release,
+                                 const char *greek,
+                                 const char *repo)
+{
+    char *str = NULL, *tmp;
+    char temp[BUFSIZ];
+
+    temp[BUFSIZ - 1] = '\0';
+    if (0 == strcmp(scope, pmix_info_ver_full) ||
+        0 == strcmp(scope, pmix_info_ver_all)) {
+        snprintf(temp, BUFSIZ - 1, "%d.%d.%d", major, minor, release);
+        str = strdup(temp);
+        if (NULL != greek) {
+            asprintf(&tmp, "%s%s", str, greek);
+            free(str);
+            str = tmp;
+        }
+    } else if (0 == strcmp(scope, pmix_info_ver_major)) {
+        snprintf(temp, BUFSIZ - 1, "%d", major);
+    } else if (0 == strcmp(scope, pmix_info_ver_minor)) {
+        snprintf(temp, BUFSIZ - 1, "%d", minor);
+    } else if (0 == strcmp(scope, pmix_info_ver_release)) {
+        snprintf(temp, BUFSIZ - 1, "%d", release);
+    } else if (0 == strcmp(scope, pmix_info_ver_greek)) {
+        str = strdup(greek);
+    } else if (0 == strcmp(scope, pmix_info_ver_repo)) {
+        str = strdup(repo);
+    }
+
+    if (NULL == str) {
+        str = strdup(temp);
+    }
+
+    return str;
+}
+
+void pmix_info_show_pmix_version(const char *scope)
+{
+    char *tmp, *tmp2;
+
+    asprintf(&tmp, "%s:version:full", pmix_info_type_pmix);
+    tmp2 = pmix_info_make_version_str(scope,
+                                      PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
+                                      PMIX_RELEASE_VERSION,
+                                      PMIX_GREEK_VERSION,
+                                      PMIX_REPO_REV);
+    pmix_info_out("PMIX", tmp, tmp2);
+    free(tmp);
+    free(tmp2);
+    asprintf(&tmp, "%s:version:repo", pmix_info_type_pmix);
+    pmix_info_out("PMIX repo revision", tmp, PMIX_REPO_REV);
+    free(tmp);
+    asprintf(&tmp, "%s:version:release_date", pmix_info_type_pmix);
+    pmix_info_out("PMIX release date", tmp, PMIX_RELEASE_DATE);
+    free(tmp);
+}
+
+/*
+ * do_config
+ * Accepts:
+ *  - want_all: boolean flag; TRUE -> display all options
+ *                FALSE -> display selected options
+ *
+ * This function displays all the options with which the current
+ * installation of pmix was configured. There are many options here
+ * that are carried forward from OMPI-7 and are not mca parameters
+ * in OMPI-10. I have to dig through the invalid options and replace
+ * them with OMPI-10 options.
+ */
+void pmix_info_do_config(bool want_all)
+{
+    char *debug;
+    char *have_dl;
+    char *symbol_visibility;
+
+    /* setup the strings that don't require allocations*/
+    debug = PMIX_ENABLE_DEBUG ? "yes" : "no";
+    have_dl = PMIX_HAVE_PDL_SUPPORT ? "yes" : "no";
+    symbol_visibility = PMIX_HAVE_VISIBILITY ? "yes" : "no";
+
+    /* output values */
+    pmix_info_out("Configured by", "config:user", PMIX_CONFIGURE_USER);
+    pmix_info_out("Configured on", "config:timestamp", PMIX_CONFIGURE_DATE);
+    pmix_info_out("Configure host", "config:host", PMIX_CONFIGURE_HOST);
+    pmix_info_out("Configure command line", "config:cli", PMIX_CONFIGURE_CLI);
+
+    pmix_info_out("Built by", "build:user", PMIX_BUILD_USER);
+    pmix_info_out("Built on", "build:timestamp", PMIX_BUILD_DATE);
+    pmix_info_out("Built host", "build:host", PMIX_BUILD_HOST);
+
+    pmix_info_out("C compiler", "compiler:c:command", PMIX_CC);
+    pmix_info_out("C compiler absolute", "compiler:c:absolute", PMIX_CC_ABSOLUTE);
+    pmix_info_out("C compiler family name", "compiler:c:familyname", _STRINGIFY(PMIX_BUILD_PLATFORM_COMPILER_FAMILYNAME));
+    pmix_info_out("C compiler version", "compiler:c:version", _STRINGIFY(PMIX_BUILD_PLATFORM_COMPILER_VERSION_STR));
+
+    if (want_all) {
+        pmix_info_out_int("C char size", "compiler:c:sizeof:char", sizeof(char));
+        pmix_info_out_int("C bool size", "compiler:c:sizeof:bool", sizeof(bool));
+        pmix_info_out_int("C short size", "compiler:c:sizeof:short", sizeof(short));
+        pmix_info_out_int("C int size", "compiler:c:sizeof:int", sizeof(int));
+        pmix_info_out_int("C long size", "compiler:c:sizeof:long", sizeof(long));
+        pmix_info_out_int("C float size", "compiler:c:sizeof:float", sizeof(float));
+        pmix_info_out_int("C double size", "compiler:c:sizeof:double", sizeof(double));
+        pmix_info_out_int("C pointer size", "compiler:c:sizeof:pointer", sizeof(void *));
+        pmix_info_out_int("C char align", "compiler:c:align:char", PMIX_ALIGNMENT_CHAR);
+        pmix_info_out("C bool align", "compiler:c:align:bool", "skipped");
+        pmix_info_out_int("C int align", "compiler:c:align:int", PMIX_ALIGNMENT_INT);
+        pmix_info_out_int("C float align", "compiler:c:align:float", PMIX_ALIGNMENT_FLOAT);
+        pmix_info_out_int("C double align", "compiler:c:align:double", PMIX_ALIGNMENT_DOUBLE);
+    }
+
+    if (want_all) {
+        pmix_info_out("Build CFLAGS", "option:build:cflags", PMIX_BUILD_CFLAGS);
+        pmix_info_out("Build LDFLAGS", "option:build:ldflags", PMIX_BUILD_LDFLAGS);
+        pmix_info_out("Build LIBS", "option:build:libs", PMIX_BUILD_LIBS);
+    }
+
+    pmix_info_out("Internal debug support", "option:debug", debug);
+    pmix_info_out("dl support", "option:dlopen", have_dl);
+    pmix_info_out("Symbol vis. support", "options:visibility", symbol_visibility);
+}

--- a/src/tools/pinfo/support.h
+++ b/src/tools/pinfo/support.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2017 IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file **/
+
+#ifndef PMIX_INFO_REGISTER_H
+#define PMIX_INFO_REGISTER_H
+
+#include "pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/cmd_line.h"
+#include "src/mca/base/base.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT extern const char *pmix_info_path_prefix;
+
+PMIX_EXPORT extern const char *pmix_info_type_all;
+PMIX_EXPORT extern const char *pmix_info_type_pmix;
+PMIX_EXPORT extern const char *pmix_info_component_all;
+extern const char *pmix_info_param_all;
+
+PMIX_EXPORT extern const char *pmix_info_ver_full;
+extern const char *pmix_info_ver_major;
+extern const char *pmix_info_ver_minor;
+extern const char *pmix_info_ver_release;
+extern const char *pmix_info_ver_greek;
+extern const char *pmix_info_ver_repo;
+
+PMIX_EXPORT extern const char *pmix_info_ver_all;
+extern const char *pmix_info_ver_mca;
+extern const char *pmix_info_ver_type;
+extern const char *pmix_info_ver_component;
+
+
+/*
+ * Component-related functions
+ */
+typedef struct {
+    pmix_list_item_t super;
+    char *type;
+    pmix_list_t *components;
+    pmix_list_t *failed_components;
+} pmix_info_component_map_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_info_component_map_t);
+
+
+PMIX_EXPORT int pmix_info_init(int argc, char **argv,
+                               pmix_cmd_line_t *pmix_info_cmd_line);
+
+PMIX_EXPORT void pmix_info_finalize(void);
+
+PMIX_EXPORT void pmix_info_register_types(pmix_pointer_array_t *mca_types);
+
+PMIX_EXPORT int pmix_info_register_framework_params(pmix_pointer_array_t *component_map);
+
+PMIX_EXPORT void pmix_info_close_components(void);
+PMIX_EXPORT void pmix_info_err_params(pmix_pointer_array_t *component_map);
+
+PMIX_EXPORT void pmix_info_do_params(bool want_all_in, bool want_internal,
+                                     pmix_pointer_array_t *mca_type,
+                                     pmix_pointer_array_t *component_map,
+                                     pmix_cmd_line_t *pmix_info_cmd_line);
+
+PMIX_EXPORT void pmix_info_show_path(const char *type, const char *value);
+
+PMIX_EXPORT void pmix_info_do_path(bool want_all, pmix_cmd_line_t *cmd_line);
+
+PMIX_EXPORT void pmix_info_show_mca_params(const char *type,
+                                           const char *component,
+                                           pmix_mca_base_var_info_lvl_t max_level,
+                                           bool want_internal);
+
+PMIX_EXPORT void pmix_info_show_mca_version(const pmix_mca_base_component_t *component,
+                                            const char *scope, const char *ver_type);
+
+PMIX_EXPORT void pmix_info_show_component_version(pmix_pointer_array_t *mca_types,
+                                                  pmix_pointer_array_t *component_map,
+                                                  const char *type_name,
+                                                  const char *component_name,
+                                                  const char *scope, const char *ver_type);
+
+PMIX_EXPORT char *pmix_info_make_version_str(const char *scope,
+                                             int major, int minor, int release,
+                                             const char *greek,
+                                             const char *repo);
+
+PMIX_EXPORT void pmix_info_show_pmix_version(const char *scope);
+
+PMIX_EXPORT void pmix_info_do_arch(void);
+
+PMIX_EXPORT void pmix_info_do_hostname(void);
+
+PMIX_EXPORT void pmix_info_do_type(pmix_cmd_line_t *pmix_info_cmd_line);
+
+PMIX_EXPORT void pmix_info_out(const char *pretty_message, const char *plain_message, const char *value);
+
+PMIX_EXPORT void pmix_info_out_int(const char *pretty_message,
+                                   const char *plain_message,
+                                   int value);
+
+PMIX_EXPORT int pmix_info_register_project_frameworks (const char *project_name,
+                                                       pmix_mca_base_framework_t **frameworks,
+                                                       pmix_pointer_array_t *component_map);
+
+END_C_DECLS
+
+#endif

--- a/src/tools/plookup/Makefile.am
+++ b/src/tools/plookup/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+if PMIX_INSTALL_BINARIES
+
+bin_PROGRAMS = plookup
+
+dist_pmixdata_DATA = help-plookup.txt
+
+endif # PMIX_INSTALL_BINARIES
+
+plookup_SOURCES = plookup.c
+plookup_LDADD = \
+	$(top_builddir)/src/libpmix.la

--- a/src/tools/plookup/help-plookup.txt
+++ b/src/tools/plookup/help-plookup.txt
@@ -1,0 +1,47 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI PS tool
+#
+[usage]
+ompi-ps [OPTIONS]
+  Open MPI Job and Process Status Tool
+
+%s
+#
+[vpid-usage]
+Error: You specified a vpid (%d) without also specifying a jobid.
+       Use the '-j' option to specify a jobid.
+#
+[need-vpid]
+Error: You specified a jobid (%d) without also specifying a vpid.
+       Use the '-p' option to specify a vpid.
+#
+[invalid-vpid]
+Error: The specified vpid (%d) is not valid for job %d.
+#
+[stale-hnp]
+An attempt was made to obtain ps information from at least
+one non-responsive HNP:
+
+HNP name: %s
+
+You may want to cleanup stale session directories in your temporary
+directory (e.g., $TMPDIR).

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -1,0 +1,291 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <pmix_tool.h>
+#include "src/mca/base/base.h"
+#include "src/mca/pinstalldirs/base/base.h"
+#include "src/threads/threads.h"
+#include "src/util/cmd_line.h"
+#include "src/util/keyval_parse.h"
+#include "src/util/show_help.h"
+#include "src/runtime/pmix_rte.h"
+
+typedef struct {
+    pmix_lock_t lock;
+    pmix_status_t status;
+} mylock_t;
+
+static pmix_proc_t myproc;
+
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    /* this example doesn't do anything with default events */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(&lock->lock);
+}
+
+/*****************************************
+ * Global Vars for Command line Arguments
+ *****************************************/
+typedef struct {
+    bool help;
+    bool verbose;
+    pid_t pid;
+    bool wait;
+    int timeout;
+} pmix_plookup_globals_t;
+
+pmix_plookup_globals_t pmix_plookup_globals = {0};
+
+pmix_cmd_line_init_t cmd_line_opts[] = {
+    { NULL,
+      'h', NULL, "help",
+      0,
+      &pmix_plookup_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
+      "This help message" },
+
+    { NULL,
+      'v', NULL, "verbose",
+      0,
+      &pmix_plookup_globals.verbose, PMIX_CMD_LINE_TYPE_BOOL,
+      "Be Verbose" },
+
+    { NULL,
+      'p', NULL, "pid",
+      1,
+      &pmix_plookup_globals.pid, PMIX_CMD_LINE_TYPE_INT,
+      "Specify starter pid" },
+
+    { NULL,
+      'w', NULL, "wait",
+      0,
+      &pmix_plookup_globals.wait, PMIX_CMD_LINE_TYPE_BOOL,
+      "Wait for data to be available" },
+
+    { NULL,
+      't', NULL, "timeout",
+      0,
+      &pmix_plookup_globals.timeout, PMIX_CMD_LINE_TYPE_INT,
+      "Max number of seconds to wait for data to become available" },
+
+    /* End of list */
+    { NULL,
+      '\0', NULL, NULL,
+      0,
+      NULL, PMIX_CMD_LINE_TYPE_NULL,
+      NULL }
+};
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t *info = NULL;
+    size_t ninfo = 0, n;
+    mylock_t mylock;
+    pmix_cmd_line_t cmd_line;
+    pmix_pdata_t *pdata = NULL;
+    size_t ndata;
+    int count;
+    char **keys = NULL;
+
+    /* protect against problems if someone passes us thru a pipe
+     * and then abnormally terminates the pipe early */
+    signal(SIGPIPE, SIG_IGN);
+
+    /* initialize the output system */
+    if (!pmix_output_init()) {
+        return PMIX_ERROR;
+    }
+
+    /* initialize install dirs code */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
+
+    /* initialize the help system */
+    pmix_show_help_init();
+
+    /* keyval lex-based parser */
+    if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {
+        fprintf(stderr, "pmix_util_keyval_parse_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Setup the parameter system */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_var_init())) {
+        fprintf(stderr, "pmix_mca_base_var_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Parse the command line options */
+    pmix_cmd_line_create(&cmd_line, cmd_line_opts);
+
+    pmix_mca_base_open();
+    pmix_mca_base_cmd_line_setup(&cmd_line);
+    rc = pmix_cmd_line_parse(&cmd_line, false, false, argc, argv);
+
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    PMIx_Error_string(rc));
+        }
+        return rc;
+    }
+
+    if (pmix_plookup_globals.help) {
+        char *str, *args = NULL;
+        args = pmix_cmd_line_get_usage_msg(&cmd_line);
+        str = pmix_show_help_string("help-plookup.txt", "usage", true,
+                                    args);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(args);
+        /* If we show the help message, that should be all we do */
+        exit(0);
+    }
+
+    if (pmix_plookup_globals.wait) {
+        ++ninfo;
+        if (0 < pmix_plookup_globals.timeout) {
+            ++ninfo;
+        }
+    }
+
+    /* determine how many keys were given */
+    pmix_cmd_line_get_tail(&cmd_line, &count, &keys);
+    if (0 == count) {
+        /* must give us at least one key */
+        fprintf(stderr, "%s: Must provide at least one key to lookup\n", argv[0]);
+        exit(1);
+    }
+    ndata = count;
+
+    /* if we were given the pid of a starter, then direct that
+     * we connect to it */
+
+    /* otherwise, use the system connection first, if available */
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* init as a tool */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
+        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+        exit(rc);
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    /* register a default event handler */
+    PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    PMIX_WAIT_THREAD(&mylock.lock);
+    if (PMIX_SUCCESS != mylock.status) {
+        fprintf(stderr, "PMIx_Register_event_handler returned bad status: %d\n", rc);
+        PMIX_DESTRUCT_LOCK(&mylock.lock);
+        goto done;
+    }
+    PMIX_DESTRUCT_LOCK(&mylock.lock);
+
+    /* setup any info for the lookup */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        PMIX_INFO_LOAD(&info[0], PMIX_WAIT, NULL, PMIX_BOOL);
+        if (1 < ninfo) {
+            PMIX_INFO_LOAD(&info[1], PMIX_TIMEOUT, &pmix_plookup_globals.timeout, PMIX_INT);
+        }
+    }
+
+    /* setup the keys */
+    PMIX_PDATA_CREATE(pdata, ndata);
+    for (n=0; n < ndata; n++) {
+        (void)strncpy(pdata[n].key, keys[n], PMIX_MAX_KEYLEN);
+    }
+    /* perform the lookup */
+    rc = PMIx_Lookup(pdata, ndata, info, ninfo);
+
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "PMIx_Lookup failed: %d\n", rc);
+        goto done;
+    }
+
+    for (n=0; n < ndata; n++) {
+        fprintf(stderr, "Key: %s\n", pdata[n].key);
+    }
+    PMIX_PDATA_FREE(pdata, ndata);
+
+  done:
+    PMIx_tool_finalize();
+
+    return(rc);
+}

--- a/src/tools/pps/Makefile.am
+++ b/src/tools/pps/Makefile.am
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+if PMIX_INSTALL_BINARIES
+
+bin_PROGRAMS = pps
+
+dist_pmixdata_DATA = help-pps.txt
+
+endif # PMIX_INSTALL_BINARIES
+
+pps_SOURCES = pps.c
+pps_LDADD = \
+	$(top_builddir)/src/libpmix.la

--- a/src/tools/pps/help-pps.txt
+++ b/src/tools/pps/help-pps.txt
@@ -1,0 +1,47 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English help file for Open MPI PS tool
+#
+[usage]
+ompi-ps [OPTIONS]
+  Open MPI Job and Process Status Tool
+
+%s
+#
+[vpid-usage]
+Error: You specified a vpid (%d) without also specifying a jobid.
+       Use the '-j' option to specify a jobid.
+#
+[need-vpid]
+Error: You specified a jobid (%d) without also specifying a vpid.
+       Use the '-p' option to specify a vpid.
+#
+[invalid-vpid]
+Error: The specified vpid (%d) is not valid for job %d.
+#
+[stale-hnp]
+An attempt was made to obtain ps information from at least
+one non-responsive HNP:
+
+HNP name: %s
+
+You may want to cleanup stale session directories in your temporary
+directory (e.g., $TMPDIR).

--- a/src/tools/pps/pps.c
+++ b/src/tools/pps/pps.c
@@ -1,0 +1,864 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2007      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2007-2016 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @fie
+ * PMIX PS command
+ *
+ */
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+#include <stdio.h>
+#include <errno.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif  /* HAVE_UNISTD_H */
+#include <stdlib.h>
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif  /* HAVE_SYS_STAT_H */
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif  /* HAVE_SYS_TYPES_H */
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif  /* HAVE_SYS_WAIT_H */
+#include <string.h>
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif  /* HAVE_DIRENT_H */
+
+#include "src/threads/threads.h"
+#include "src/util/basename.h"
+#include "src/util/cmd_line.h"
+#include "src/util/keyval_parse.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/show_help.h"
+#include "src/mca/base/base.h"
+#include "src/mca/pinstalldirs/base/base.h"
+#include "src/runtime/pmix_rte.h"
+
+#include "src/include/pmix_globals.h"
+#include <pmix_tool.h>
+#include <pmix.h>
+
+typedef struct {
+    pmix_lock_t lock;
+    pmix_status_t status;
+} mylock_t;
+
+/* define a structure for collecting returned
+ * info from a query */
+typedef struct {
+    mylock_t lock;
+    pmix_info_t *info;
+    size_t ninfo;
+} myquery_data_t;
+
+static pmix_proc_t myproc;
+
+/******************
+ * Local Functions
+ ******************/
+#if 0
+static int gather_information(pmix_ps_mpirun_info_t *hnpinfo);
+static int gather_active_jobs(pmix_ps_mpirun_info_t *hnpinfo);
+static int gather_nodes(pmix_ps_mpirun_info_t *hnpinfo);
+static int gather_vpid_info(pmix_ps_mpirun_info_t *hnpinfo);
+
+static int pretty_print(pmix_ps_mpirun_info_t *hnpinfo);
+static int pretty_print_nodes(pmix_node_t **nodes, pmix_std_cntr_t num_nodes);
+static int pretty_print_jobs(pmix_job_t **jobs, pmix_std_cntr_t num_jobs);
+static int pretty_print_vpids(pmix_job_t *job);
+static void pretty_print_dashed_line(int len);
+
+static char *pretty_node_state(pmix_node_state_t state);
+
+static int parseable_print(pmix_ps_mpirun_info_t *hnpinfo);
+#endif
+
+/*****************************************
+ * Global Vars for Command line Arguments
+ *****************************************/
+typedef struct {
+    bool help;
+    bool parseable;
+    bool nodes;
+    char *nspace;
+    pid_t pid;
+} pmix_ps_globals_t;
+
+pmix_ps_globals_t pmix_ps_globals = {0};
+
+pmix_cmd_line_init_t cmd_line_opts[] = {
+    { NULL,
+      'h', NULL, "help",
+      0,
+      &pmix_ps_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
+      "This help message" },
+
+    { NULL,
+      '\0', NULL, "parseable",
+      0,
+      &pmix_ps_globals.parseable, PMIX_CMD_LINE_TYPE_BOOL,
+      "Provide parseable output" },
+
+    { NULL,
+      '\0', NULL, "nspace",
+      0,
+     &pmix_ps_globals.nspace, PMIX_CMD_LINE_TYPE_STRING,
+      "Nspace of job whose status is being requested" },
+
+    { NULL,
+      'p', NULL, "pid",
+      1,
+      &pmix_ps_globals.pid, PMIX_CMD_LINE_TYPE_INT,
+      "Specify pid of starter to be contacted (default is to system server" },
+
+    { NULL,
+      'n', NULL, "nodes",
+      0,
+      &pmix_ps_globals.nodes, PMIX_CMD_LINE_TYPE_BOOL,
+      "Display Node Information" },
+
+    /* End of list */
+    { NULL,
+      '\0', NULL, NULL,
+      0,
+      NULL, PMIX_CMD_LINE_TYPE_NULL,
+      NULL }
+};
+
+/* this is a callback function for the PMIx_Query
+ * API. The query will callback with a status indicating
+ * if the request could be fully satisfied, partially
+ * satisfied, or completely failed. The info parameter
+ * contains an array of the returned data, with the
+ * info->key field being the key that was provided in
+ * the query call. Thus, you can correlate the returned
+ * data in the info->value field to the requested key.
+ *
+ * Once we have dealt with the returned data, we must
+ * call the release_fn so that the PMIx library can
+ * cleanup */
+static void cbfunc(pmix_status_t status,
+                   pmix_info_t *info, size_t ninfo,
+                   void *cbdata,
+                   pmix_release_cbfunc_t release_fn,
+                   void *release_cbdata)
+{
+    myquery_data_t *mq = (myquery_data_t*)cbdata;
+    size_t n;
+
+    /* save the returned info - the PMIx library "owns" it
+     * and will release it and perform other cleanup actions
+     * when release_fn is called */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(mq->info, ninfo);
+        mq->ninfo = ninfo;
+        for (n=0; n < ninfo; n++) {
+            fprintf(stderr, "Transferring %s\n", info[n].key);
+            PMIX_INFO_XFER(&mq->info[n], &info[n]);
+        }
+    }
+
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    /* release the block */
+    PMIX_WAKEUP_THREAD(&mq->lock.lock);
+}
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. */
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    /* this example doesn't do anything with default events */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lock->status = status;
+    PMIX_WAKEUP_THREAD(&lock->lock);
+}
+
+int
+main(int argc, char *argv[])
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_info_t *info;
+    pmix_query_t *query;
+    size_t nq;
+    myquery_data_t myquery_data;
+    mylock_t mylock;
+    pmix_cmd_line_t cmd_line;
+
+    /* protect against problems if someone passes us thru a pipe
+     * and then abnormally terminates the pipe early */
+    signal(SIGPIPE, SIG_IGN);
+
+    /* initialize the output system */
+    if (!pmix_output_init()) {
+        return PMIX_ERROR;
+    }
+
+    /* initialize install dirs code */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pinstalldirs_base_framework, 0))) {
+        fprintf(stderr, "pmix_pinstalldirs_base_open() failed -- process will likely abort (%s:%d, returned %d instead of PMIX_SUCCESS)\n",
+                __FILE__, __LINE__, rc);
+        return rc;
+    }
+
+    /* initialize the help system */
+    pmix_show_help_init();
+
+    /* keyval lex-based parser */
+    if (PMIX_SUCCESS != (rc = pmix_util_keyval_parse_init())) {
+        fprintf(stderr, "pmix_util_keyval_parse_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Setup the parameter system */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_var_init())) {
+        fprintf(stderr, "pmix_mca_base_var_init failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* register params for pmix */
+    if (PMIX_SUCCESS != (rc = pmix_register_params())) {
+        fprintf(stderr, "pmix_register_params failed with %d\n", rc);
+        return PMIX_ERROR;
+    }
+
+    /* Parse the command line options */
+    pmix_cmd_line_create(&cmd_line, cmd_line_opts);
+
+    pmix_mca_base_open();
+    pmix_mca_base_cmd_line_setup(&cmd_line);
+    rc = pmix_cmd_line_parse(&cmd_line, false, false, argc, argv);
+
+    if (PMIX_SUCCESS != rc) {
+        if (PMIX_ERR_SILENT != rc) {
+            fprintf(stderr, "%s: command line error (%s)\n", argv[0],
+                    PMIx_Error_string(rc));
+        }
+        return rc;
+    }
+
+    if (pmix_ps_globals.help) {
+        char *str, *args = NULL;
+        args = pmix_cmd_line_get_usage_msg(&cmd_line);
+        str = pmix_show_help_string("help-pps.txt", "usage", true,
+                                    args);
+        if (NULL != str) {
+            printf("%s", str);
+            free(str);
+        }
+        free(args);
+        /* If we show the help message, that should be all we do */
+        exit(0);
+    }
+
+    /* if we were given the pid of a starter, then direct that
+     * we connect to it */
+
+    /* otherwise, use the system connection first, if available */
+    PMIX_INFO_CREATE(info, 1);
+    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_SYSTEM_FIRST, NULL, PMIX_BOOL);
+    /* init as a tool */
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, 1))) {
+        fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
+        exit(rc);
+    }
+    PMIX_INFO_FREE(info, 1);
+
+    /* register a default event handler */
+    PMIX_CONSTRUCT_LOCK(&mylock.lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    PMIX_WAIT_THREAD(&mylock.lock);
+    PMIX_DESTRUCT_LOCK(&mylock.lock);
+
+    /* if we were given a specific nspace to ask about, then do so */
+
+    /* if we were asked to provide the status of the nodes, then do that */
+
+    /* otherwise, query the active nspaces */
+    nq = 1;
+    PMIX_QUERY_CREATE(query, nq);
+    PMIX_ARGV_APPEND(rc, query[0].keys, PMIX_QUERY_NAMESPACES);
+    /* setup the caddy to retrieve the data */
+    PMIX_CONSTRUCT_LOCK(&myquery_data.lock.lock);
+    myquery_data.info = NULL;
+    myquery_data.ninfo = 0;
+    /* execute the query */
+    fprintf(stderr, "pps: querying nspaces\n");
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(query, nq, cbfunc, (void*)&myquery_data))) {
+        fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
+        goto done;
+    }
+    PMIX_WAIT_THREAD(&myquery_data.lock.lock);
+    PMIX_DESTRUCT_LOCK(&myquery_data.lock.lock);
+
+    /* we should have received back one info struct containing
+     * a comma-delimited list of nspaces */
+    if (1 != myquery_data.ninfo) {
+        /* this is an error */
+        fprintf(stderr, "PMIx Query returned an incorrect number of results: %lu\n", myquery_data.ninfo);
+        PMIX_INFO_FREE(myquery_data.info, myquery_data.ninfo);
+        goto done;
+    }
+
+    fprintf(stderr, "Active nspaces: %s\n", myquery_data.info[0].value.data.string);
+
+    /***************
+     * Cleanup
+     ***************/
+  done:
+    PMIx_tool_finalize();
+
+    return rc;
+}
+
+#if 0
+static int pretty_print(pmix_ps_mpirun_info_t *hnpinfo) {
+    char *header;
+    int len_hdr;
+
+    /*
+     * Print header and remember header length
+     */
+    len_hdr = asprintf(&header, "Information from mpirun %s", PMIX_JOBID_PRINT(hnpinfo->hnp->name.jobid));
+
+    printf("\n\n%s\n", header);
+    free(header);
+    pretty_print_dashed_line(len_hdr);
+
+    /*
+     * Print Node Information
+     */
+    if( pmix_ps_globals.nodes )
+        pretty_print_nodes(hnpinfo->nodes, hnpinfo->num_nodes);
+
+    /*
+     * Print Job Information
+     */
+    pretty_print_jobs(hnpinfo->jobs, hnpinfo->num_jobs);
+
+    return PMIX_SUCCESS;
+}
+
+static int pretty_print_nodes(pmix_node_t **nodes, pmix_std_cntr_t num_nodes) {
+    int line_len;
+    int len_name    = 0,
+        len_state   = 0,
+        len_slots   = 0,
+        len_slots_i = 0,
+        len_slots_m = 0;
+    pmix_node_t *node;
+    pmix_std_cntr_t i;
+
+    /*
+     * Caculate segment lengths
+     */
+    len_name    = (int) strlen("Node Name");
+    len_state   = (int) strlen("State");
+    len_slots   = (int) strlen("Slots");
+    len_slots_i = (int) strlen("Slots In Use");
+    len_slots_m = (int) strlen("Slots Max");
+
+    for(i=0; i < num_nodes; i++) {
+        node = nodes[i];
+
+        if( NULL != node->name &&
+            (int)strlen(node->name) > len_name)
+            len_name = (int) strlen(node->name);
+
+        if( (int)strlen(pretty_node_state(node->state)) > len_state )
+            len_state = (int)strlen(pretty_node_state(node->state));
+    }
+
+    line_len = (len_name    + 3 +
+                len_state   + 3 +
+                len_slots   + 3 +
+                len_slots_i + 3 +
+                len_slots_m) + 2;
+
+    /*
+     * Print the header
+     */
+    printf("%*s | ", len_name,    "Node Name");
+    printf("%*s | ", len_state,   "State");
+    printf("%*s | ", len_slots,   "Slots");
+    printf("%*s | ", len_slots_m, "Slots Max");
+    printf("%*s | ", len_slots_i, "Slots In Use");
+    printf("\n");
+
+    pretty_print_dashed_line(line_len);
+
+    /*
+     * Print Info
+     */
+    for(i=0; i < num_nodes; i++) {
+        node = nodes[i];
+
+        printf("%*s | ", len_name,    node->name);
+        printf("%*s | ", len_state,   pretty_node_state(node->state));
+        printf("%*d | ", len_slots,   (uint)node->slots);
+        printf("%*d | ", len_slots_m, (uint)node->slots_max);
+        printf("%*d | ", len_slots_i, (uint)node->slots_inuse);
+        printf("\n");
+
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static int pretty_print_jobs(pmix_job_t **jobs, pmix_std_cntr_t num_jobs) {
+    int len_jobid = 0,
+        len_state = 0,
+        len_slots = 0,
+        len_vpid_r = 0,
+        len_ckpt_s = 0,
+        len_ckpt_r = 0,
+        len_ckpt_l = 0;
+    int line_len;
+    pmix_job_t *job;
+    pmix_std_cntr_t i;
+    char *jobstr;
+    pmix_jobid_t mask=0x0000ffff;
+
+    for(i=0; i < num_jobs; i++) {
+        job = jobs[i];
+
+        /* check the jobid to see if this is the daemons' job */
+        if ((0 == (mask & job->jobid)) && !pmix_ps_globals.daemons) {
+            continue;
+        }
+
+        /* setup the printed name - do -not- free this! */
+        jobstr = PMIX_JOBID_PRINT(job->jobid);
+
+        /*
+         * Caculate segment lengths
+         */
+        len_jobid  = strlen(jobstr);;
+        len_state  = (int) (strlen(pmix_job_state_to_str(job->state)) < strlen("State") ?
+                            strlen("State") :
+                            strlen(pmix_job_state_to_str(job->state)));
+        len_slots  = 6;
+        len_vpid_r = (int) strlen("Num Procs");
+        len_ckpt_s = -3;
+        len_ckpt_r = -3;
+        len_ckpt_l = -3;
+
+        line_len = (len_jobid  + 3 +
+                    len_state  + 3 +
+                    len_slots  + 3 +
+                    len_vpid_r + 3 +
+                    len_ckpt_s + 3 +
+                    len_ckpt_r + 3 +
+                    len_ckpt_l)
+                    + 2;
+
+        /*
+         * Print Header
+         */
+        printf("\n");
+        printf("%*s | ", len_jobid  , "JobID");
+        printf("%*s | ", len_state  , "State");
+        printf("%*s | ", len_slots  , "Slots");
+        printf("%*s | ", len_vpid_r , "Num Procs");
+        printf("\n");
+
+        pretty_print_dashed_line(line_len);
+
+        /*
+         * Print Info
+         */
+        printf("%*s | ",  len_jobid ,  PMIX_JOBID_PRINT(job->jobid));
+        printf("%*s | ",  len_state ,  pmix_job_state_to_str(job->state));
+        printf("%*d | ",  len_slots ,  (uint)job->total_slots_alloc);
+        printf("%*d | ",  len_vpid_r,  job->num_procs);
+        printf("\n");
+
+
+        pretty_print_vpids(job);
+        printf("\n\n"); /* give a little room between job outputs */
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static int pretty_print_vpids(pmix_job_t *job) {
+    int len_o_proc_name = 0,
+        len_proc_name   = 0,
+        len_rank        = 0,
+        len_pid         = 0,
+        len_state       = 0,
+        len_node        = 0,
+        len_ckpt_s      = 0,
+        len_ckpt_r      = 0,
+        len_ckpt_l      = 0;
+    int i, line_len;
+    pmix_vpid_t v;
+    pmix_proc_t *vpid;
+    pmix_app_context_t *app;
+    char *o_proc_name;
+    char **nodename = NULL;
+
+    if (0 == job->num_procs) {
+        return PMIX_SUCCESS;
+    }
+
+    /*
+     * Caculate segment lengths
+     */
+    len_o_proc_name = (int)strlen("PMIX Name");
+    len_proc_name   = (int)strlen("Process Name");
+    len_rank        = (int)strlen("Local Rank");
+    len_pid         = 6;
+    len_state       = 0;
+    len_node        = 0;
+    len_ckpt_s      = -3;
+    len_ckpt_r      = -3;
+    len_ckpt_l      = -3;
+
+    nodename = (char **) malloc(job->num_procs * sizeof(char *));
+    for(v=0; v < job->num_procs; v++) {
+        char *rankstr;
+        vpid = (pmix_proc_t*)job->procs->addr[v];
+
+        /*
+         * Find my app context
+         */
+        if( 0 >= (int)job->num_apps ) {
+            if( 0 == vpid->name.vpid ) {
+                if( (int)strlen("pmixrun") > len_proc_name)
+                    len_proc_name = strlen("pmixrun");
+            }
+            else {
+                if( (int)strlen("pmixd") > len_proc_name)
+                    len_proc_name = strlen("pmixd");
+            }
+        }
+        for( i = 0; i < (int)job->num_apps; ++i) {
+            app = (pmix_app_context_t*)job->apps->addr[i];
+            if( app->idx == vpid->app_idx ) {
+                if( (int)strlen(app->app) > len_proc_name)
+                    len_proc_name = strlen(app->app);
+                break;
+            }
+        }
+
+        o_proc_name = pmix_util_print_name_args(&vpid->name);
+        if ((int)strlen(o_proc_name) > len_o_proc_name)
+            len_o_proc_name = strlen(o_proc_name);
+
+        asprintf(&rankstr, "%u", (uint)vpid->local_rank);
+        if ((int)strlen(rankstr) > len_rank)
+            len_rank = strlen(rankstr);
+        free(rankstr);
+
+        nodename[v] = NULL;
+        if( pmix_get_attribute(&vpid->attributes, PMIX_PROC_NODENAME, (void**)&nodename[v], PMIX_STRING) &&
+            (int)strlen(nodename[v]) > len_node) {
+            len_node = strlen(nodename[v]);
+        } else if ((int)strlen("Unknown") > len_node) {
+            len_node = strlen("Unknown");
+        }
+
+        if( (int)strlen(pmix_proc_state_to_str(vpid->state)) > len_state)
+            len_state = strlen(pmix_proc_state_to_str(vpid->state));
+
+    }
+
+    line_len = (len_o_proc_name + 3 +
+                len_proc_name   + 3 +
+                len_rank        + 3 +
+                len_pid         + 3 +
+                len_state       + 3 +
+                len_node        + 3 +
+                len_ckpt_s      + 3 +
+                len_ckpt_r      + 3 +
+                len_ckpt_l)
+                + 2;
+
+    /*
+     * Print Header
+     */
+    printf("\t");
+    printf("%*s | ", len_proc_name   , "Process Name");
+    printf("%*s | ", len_o_proc_name , "PMIX Name");
+    printf("%*s | ", len_rank        , "Local Rank");
+    printf("%*s | ", len_pid         , "PID");
+    printf("%*s | ", len_node        , "Node");
+    printf("%*s | ", len_state       , "State");
+    printf("\n");
+
+    printf("\t");
+    pretty_print_dashed_line(line_len);
+
+    /*
+     * Print Info
+     */
+    for(v=0; v < job->num_procs; v++) {
+        vpid = (pmix_proc_t*)job->procs->addr[v];
+
+        printf("\t");
+
+        if( 0 >= (int)job->num_apps ) {
+            if( 0 == vpid->name.vpid ) {
+                printf("%*s | ", len_proc_name, "pmixrun");
+            } else {
+                printf("%*s | ", len_proc_name, "pmixd");
+            }
+        }
+        for( i = 0; i < (int)job->num_apps; ++i) {
+            app = (pmix_app_context_t*)job->apps->addr[i];
+            if( app->idx == vpid->app_idx ) {
+                printf("%*s | ", len_proc_name, app->app);
+                break;
+            }
+        }
+
+        o_proc_name = pmix_util_print_name_args(&vpid->name);
+
+        printf("%*s | ",  len_o_proc_name, o_proc_name);
+        printf("%*u | ",  len_rank       , (uint)vpid->local_rank);
+        printf("%*d | ",  len_pid        , vpid->pid);
+        printf("%*s | ",  len_node       , (NULL == nodename[v]) ? "Unknown" : nodename[v]);
+        printf("%*s | ",  len_state      , pmix_proc_state_to_str(vpid->state));
+
+        if (NULL != nodename[v]) {
+            free(nodename[v]);
+        }
+        printf("\n");
+
+    }
+    if (NULL != nodename) {
+        free(nodename);
+    }
+    return PMIX_SUCCESS;
+}
+
+static void pretty_print_dashed_line(int len) {
+    static const char dashes[9] = "--------";
+
+    while (len >= 8) {
+        printf("%8.8s", dashes);
+        len -= 8;
+    }
+    printf("%*.*s\n", len, len, dashes);
+}
+
+static int gather_information(pmix_ps_mpirun_info_t *hnpinfo) {
+    int ret;
+
+    if( PMIX_SUCCESS != (ret = gather_active_jobs(hnpinfo) )) {
+        goto cleanup;
+    }
+
+    if( PMIX_SUCCESS != (ret = gather_nodes(hnpinfo) )) {
+        goto cleanup;
+    }
+
+    if( PMIX_SUCCESS != (ret = gather_vpid_info(hnpinfo) )) {
+        goto cleanup;
+    }
+
+ cleanup:
+    return ret;
+}
+
+static int gather_active_jobs(pmix_ps_mpirun_info_t *hnpinfo) {
+    int ret;
+
+    if (PMIX_SUCCESS != (ret = pmix_util_comm_query_job_info(&(hnpinfo->hnp->name), pmix_ps_globals.jobid,
+                                                             &hnpinfo->num_jobs, &hnpinfo->jobs))) {
+        PMIX_ERROR_LOG(ret);
+    }
+
+    return ret;
+}
+
+static int gather_nodes(pmix_ps_mpirun_info_t *hnpinfo) {
+    int ret;
+
+    if (PMIX_SUCCESS != (ret = pmix_util_comm_query_node_info(&(hnpinfo->hnp->name), NULL,
+                                                             &hnpinfo->num_nodes, &hnpinfo->nodes))) {
+        PMIX_ERROR_LOG(ret);
+    }
+    pmix_output(0, "RECEIVED %d NODES", hnpinfo->num_nodes);
+    return ret;
+}
+
+static int gather_vpid_info(pmix_ps_mpirun_info_t *hnpinfo) {
+    int ret;
+    pmix_std_cntr_t i;
+    int cnt;
+    pmix_job_t *job;
+    pmix_proc_t **procs;
+
+    /*
+     * For each Job in the HNP
+     */
+    for(i=0; i < hnpinfo->num_jobs; i++) {
+        job = hnpinfo->jobs[i];
+
+        /*
+         * Skip getting the vpid's for the HNP, unless asked to do so
+         * The HNP is always the first in the array
+         */
+        if( 0 == i && !pmix_ps_globals.daemons) {
+            continue;
+        }
+
+        /* query the HNP for info on the procs in this job */
+        if (PMIX_SUCCESS != (ret = pmix_util_comm_query_proc_info(&(hnpinfo->hnp->name),
+                                                                  job->jobid,
+                                                                  PMIX_VPID_WILDCARD,
+                                                                  &cnt,
+                                                                  &procs))) {
+            PMIX_ERROR_LOG(ret);
+        }
+        job->procs->addr = (void**)procs;
+        job->procs->size = cnt;
+        job->num_procs = cnt;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static char *pretty_node_state(pmix_node_state_t state) {
+    switch(state) {
+    case PMIX_NODE_STATE_DOWN:
+        return strdup("Down");
+        break;
+    case PMIX_NODE_STATE_UP:
+        return strdup("Up");
+        break;
+    case PMIX_NODE_STATE_REBOOT:
+        return strdup("Reboot");
+        break;
+    case PMIX_NODE_STATE_UNKNOWN:
+    default:
+        return strdup("Unknown");
+        break;
+    }
+}
+
+static int parseable_print(pmix_ps_mpirun_info_t *hnpinfo)
+{
+    pmix_job_t **jobs;
+    pmix_node_t **nodes;
+    pmix_proc_t *proc;
+    pmix_app_context_t *app;
+    char *appname;
+    int i, j;
+    char *nodename;
+
+    /* don't include the daemon job in the number of jobs reppmixd */
+    printf("mpirun:%lu:num nodes:%d:num jobs:%d\n",
+           (unsigned long)hnpinfo->hnp->pid, hnpinfo->num_nodes, hnpinfo->num_jobs-1);
+
+    if (pmix_ps_globals.nodes) {
+        nodes = hnpinfo->nodes;
+        for (i=0; i < hnpinfo->num_nodes; i++) {
+            printf("node:%s:state:%s:slots:%d:in use:%d\n",
+                   nodes[i]->name, pretty_node_state(nodes[i]->state),
+                   nodes[i]->slots, nodes[i]->slots_inuse);
+        }
+    }
+
+    jobs = hnpinfo->jobs;
+    /* skip job=0 as that's the daemon job */
+    for (i=1; i < hnpinfo->num_jobs; i++) {
+        printf("jobid:%d:state:%s:slots:%d:num procs:%d\n",
+               PMIX_LOCAL_JOBID(jobs[i]->jobid),
+               pmix_job_state_to_str(jobs[i]->state),
+               jobs[i]->total_slots_alloc,
+               jobs[i]->num_procs);
+        /* print the proc info */
+        for (j=0; j < jobs[i]->procs->size; j++) {
+            if (NULL == (proc = (pmix_proc_t*)pmix_pointer_array_get_item(jobs[i]->procs, j))) {
+                continue;
+            }
+            app = (pmix_app_context_t*)pmix_pointer_array_get_item(jobs[i]->apps, proc->app_idx);
+            if (NULL == app) {
+                appname = strdup("NULL");
+            } else {
+                appname = pmix_basename(app->app);
+            }
+            nodename = NULL;
+            pmix_get_attribute(&proc->attributes, PMIX_PROC_NODENAME, (void**)&nodename, PMIX_STRING);
+            printf("process:%s:rank:%s:pid:%lu:node:%s:state:%s\n",
+                   appname, PMIX_VPID_PRINT(proc->name.vpid),
+                   (unsigned long)proc->pid,
+                   (NULL == nodename) ? "unknown" : nodename,
+                   pmix_proc_state_to_str(proc->state));
+            free(appname);
+            if (NULL != nodename) {
+                free(nodename);
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+#endif

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      NVIDIA Corporation.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -30,6 +30,7 @@ LEX_OUTPUT_ROOT = lex.pmix_show_help_yy
 headers += \
         util/alfg.h \
         util/argv.h \
+        util/cmd_line.h \
         util/error.h \
         util/printf.h \
         util/output.h \
@@ -55,6 +56,7 @@ headers += \
 sources += \
         util/alfg.c \
         util/argv.c \
+        util/cmd_line.c \
         util/error.c \
         util/printf.c \
         util/output.c \

--- a/src/util/cmd_line.c
+++ b/src/util/cmd_line.c
@@ -1,0 +1,1406 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2013 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2012-2015 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "pmix_config.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <ctype.h>
+
+#include "src/class/pmix_object.h"
+#include "src/class/pmix_list.h"
+#include "src/threads/mutex.h"
+#include "src/util/argv.h"
+#include "src/util/cmd_line.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "pmix_common.h"
+
+
+/*
+ * Some usage message constants
+ *
+ * Max width for param listings before the description will be listed
+ * on the next line
+ */
+#define PARAM_WIDTH 25
+/*
+ * Max length of any line in the usage message
+ */
+#define MAX_WIDTH 76
+
+/*
+ * Description of a command line option
+ */
+struct pmix_cmd_line_option_t {
+    pmix_list_item_t super;
+
+    char clo_short_name;
+    char *clo_single_dash_name;
+    char *clo_long_name;
+
+    int clo_num_params;
+    char *clo_description;
+
+    pmix_cmd_line_type_t clo_type;
+    char *clo_mca_param_env_var;
+    void *clo_variable_dest;
+    bool clo_variable_set;
+    pmix_cmd_line_otype_t clo_otype;
+};
+typedef struct pmix_cmd_line_option_t pmix_cmd_line_option_t;
+static void option_constructor(pmix_cmd_line_option_t *cmd);
+static void option_destructor(pmix_cmd_line_option_t *cmd);
+
+PMIX_CLASS_INSTANCE(pmix_cmd_line_option_t,
+                    pmix_list_item_t,
+                    option_constructor, option_destructor);
+
+/*
+ * An option that was used in the argv that was parsed
+ */
+struct pmix_cmd_line_param_t {
+    pmix_list_item_t super;
+
+    /* Note that clp_arg points to storage "owned" by someone else; it
+       has the original option string by referene, not by value.
+       Hence, it should not be free()'ed. */
+
+    char *clp_arg;
+
+    /* Pointer to the existing option.  This is also by reference; it
+       should not be free()ed. */
+
+    pmix_cmd_line_option_t *clp_option;
+
+    /* This argv array is a list of all the parameters of this option.
+       It is owned by this parameter, and should be freed when this
+       param_t is freed. */
+
+    int clp_argc;
+    char **clp_argv;
+};
+typedef struct pmix_cmd_line_param_t pmix_cmd_line_param_t;
+static void param_constructor(pmix_cmd_line_param_t *cmd);
+static void param_destructor(pmix_cmd_line_param_t *cmd);
+PMIX_CLASS_INSTANCE(pmix_cmd_line_param_t,
+                    pmix_list_item_t,
+                    param_constructor, param_destructor);
+
+/*
+ * Instantiate the pmix_cmd_line_t class
+ */
+static void cmd_line_constructor(pmix_cmd_line_t *cmd);
+static void cmd_line_destructor(pmix_cmd_line_t *cmd);
+PMIX_CLASS_INSTANCE(pmix_cmd_line_t,
+                    pmix_object_t,
+                    cmd_line_constructor,
+                    cmd_line_destructor);
+
+/*
+ * Private variables
+ */
+static char special_empty_token[] = {
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, '\0'
+};
+
+/*
+ * Private functions
+ */
+static int make_opt(pmix_cmd_line_t *cmd, pmix_cmd_line_init_t *e);
+static void free_parse_results(pmix_cmd_line_t *cmd);
+static int split_shorts(pmix_cmd_line_t *cmd,
+                        char *token, char **args,
+                        int *output_argc, char ***output_argv,
+                        int *num_args_used, bool ignore_unknown);
+static pmix_cmd_line_option_t *find_option(pmix_cmd_line_t *cmd,
+                                           const char *option_name) __pmix_attribute_nonnull__(1) __pmix_attribute_nonnull__(2);
+static int set_dest(pmix_cmd_line_option_t *option, char *sval);
+static void fill(const pmix_cmd_line_option_t *a, char result[3][BUFSIZ]);
+static int qsort_callback(const void *a, const void *b);
+static pmix_cmd_line_otype_t get_help_otype(pmix_cmd_line_t *cmd);
+static char *build_parsable(pmix_cmd_line_option_t *option);
+
+
+/*
+ * Create an entire command line handle from a table
+ */
+int pmix_cmd_line_create(pmix_cmd_line_t *cmd,
+                         pmix_cmd_line_init_t *table)
+{
+    int ret = PMIX_SUCCESS;
+
+    /* Check bozo case */
+
+    if (NULL == cmd) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_CONSTRUCT(cmd, pmix_cmd_line_t);
+
+    if (NULL != table) {
+        ret = pmix_cmd_line_add(cmd, table);
+    }
+    return ret;
+}
+
+/* Add a table to an existing cmd line object */
+int pmix_cmd_line_add(pmix_cmd_line_t *cmd,
+                      pmix_cmd_line_init_t *table)
+{
+    int i, ret;
+
+    /* Ensure we got a table */
+    if (NULL == table) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Loop through the table */
+
+    for (i = 0; ; ++i) {
+        /* Is this the end? */
+        if ('\0' == table[i].ocl_cmd_short_name &&
+            NULL == table[i].ocl_cmd_single_dash_name &&
+            NULL == table[i].ocl_cmd_long_name) {
+            break;
+        }
+
+        /* Nope -- it's an entry.  Process it. */
+        ret = make_opt(cmd, &table[i]);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+/*
+ * Append a command line entry to the previously constructed command line
+ */
+int pmix_cmd_line_make_opt_mca(pmix_cmd_line_t *cmd,
+                               pmix_cmd_line_init_t entry)
+{
+    /* Ensure we got an entry */
+    if ('\0' == entry.ocl_cmd_short_name &&
+        NULL == entry.ocl_cmd_single_dash_name &&
+        NULL == entry.ocl_cmd_long_name) {
+        return PMIX_SUCCESS;
+    }
+
+    return make_opt(cmd, &entry);
+}
+
+
+/*
+ * Create a command line option, --long-name and/or -s (short name).
+ */
+int pmix_cmd_line_make_opt3(pmix_cmd_line_t *cmd, char short_name,
+                            const char *sd_name, const char *long_name,
+                            int num_params, const char *desc)
+{
+    pmix_cmd_line_init_t e;
+
+    e.ocl_mca_param_name = NULL;
+
+    e.ocl_cmd_short_name = short_name;
+    e.ocl_cmd_single_dash_name = sd_name;
+    e.ocl_cmd_long_name = long_name;
+
+    e.ocl_num_params = num_params;
+
+    e.ocl_variable_dest = NULL;
+    e.ocl_variable_type = PMIX_CMD_LINE_TYPE_NULL;
+
+    e.ocl_description = desc;
+
+    return make_opt(cmd, &e);
+}
+
+
+/*
+ * Parse a command line according to a pre-built PMIX command line
+ * handle.
+ */
+int pmix_cmd_line_parse(pmix_cmd_line_t *cmd, bool ignore_unknown, bool ignore_unknown_option,
+                        int argc, char **argv)
+{
+    int i, j, orig, ret;
+    pmix_cmd_line_option_t *option;
+    pmix_cmd_line_param_t *param;
+    bool is_unknown_option;
+    bool is_unknown_token;
+    bool is_option;
+    char **shortsv;
+    int shortsc;
+    int num_args_used;
+    bool have_help_option = false;
+    bool printed_error = false;
+    bool help_without_arg = false;
+
+    /* Bozo check */
+
+    if (0 == argc || NULL == argv) {
+        return PMIX_SUCCESS;
+    }
+
+    /* Thread serialization */
+
+    pmix_mutex_lock(&cmd->lcl_mutex);
+
+    /* Free any parsed results that are already on this handle */
+
+    free_parse_results(cmd);
+
+    /* Analyze each token */
+
+    cmd->lcl_argc = argc;
+    cmd->lcl_argv = pmix_argv_copy(argv);
+
+    /* Check up front: do we have a --help option? */
+
+    option = find_option(cmd, "help");
+    if (NULL != option) {
+        have_help_option = true;
+    }
+
+    /* Now traverse the easy-to-parse sequence of tokens.  Note that
+       incrementing i must happen elsehwere; it can't be the third
+       clause in the "if" statement. */
+
+    param = NULL;
+    option = NULL;
+    for (i = 1; i < cmd->lcl_argc; ) {
+        is_unknown_option = false;
+        is_unknown_token = false;
+        is_option = false;
+
+        /* Are we done?  i.e., did we find the special "--" token?  If
+           so, copy everying beyond it into the tail (i.e., don't
+           bother copying the "--" into the tail). */
+
+        if (0 == strcmp(cmd->lcl_argv[i], "--")) {
+            ++i;
+            while (i < cmd->lcl_argc) {
+                pmix_argv_append(&cmd->lcl_tail_argc, &cmd->lcl_tail_argv,
+                                 cmd->lcl_argv[i]);
+                ++i;
+            }
+
+            break;
+        }
+
+        /* If it's not an option, then this is an error.  Note that
+           this is different than an unrecognized token; an
+           unrecognized option is *always* an error. */
+
+        else if ('-' != cmd->lcl_argv[i][0]) {
+            is_unknown_token = true;
+        }
+
+        /* Nope, this is supposedly an option.  Is it a long name? */
+
+        else if (0 == strncmp(cmd->lcl_argv[i], "--", 2)) {
+            is_option = true;
+            option = find_option(cmd, cmd->lcl_argv[i] + 2);
+        }
+
+        /* It could be a short name.  Is it? */
+
+        else {
+            option = find_option(cmd, cmd->lcl_argv[i] + 1);
+
+            /* If we didn't find it, try to split it into shorts.  If
+               we find the short option, replace lcl_argv[i] and
+               insert the rest into lcl_argv starting after position
+               i.  If we don't find the short option, don't do
+               anything to lcl_argv so that it can fall through to the
+               error condition, below. */
+
+            if (NULL == option) {
+                shortsv = NULL;
+                shortsc = 0;
+                ret = split_shorts(cmd, cmd->lcl_argv[i] + 1,
+                                   &(cmd->lcl_argv[i + 1]),
+                                   &shortsc, &shortsv,
+                                   &num_args_used, ignore_unknown);
+                if (PMIX_SUCCESS == ret) {
+                    option = find_option(cmd, shortsv[0] + 1);
+
+                    if (NULL != option) {
+                        pmix_argv_delete(&cmd->lcl_argc,
+                                         &cmd->lcl_argv, i,
+                                         1 + num_args_used);
+                        pmix_argv_insert(&cmd->lcl_argv, i, shortsv);
+                        cmd->lcl_argc = pmix_argv_count(cmd->lcl_argv);
+                    } else {
+                        is_unknown_option = true;
+                    }
+                    pmix_argv_free(shortsv);
+                } else {
+                    is_unknown_option = true;
+                }
+            }
+
+            if (NULL != option) {
+                is_option = true;
+            }
+        }
+
+        /* If we figured out above that this is an option, handle it */
+
+        if (is_option) {
+            if (NULL == option) {
+                is_unknown_option = true;
+            } else {
+                is_unknown_option = false;
+                orig = i;
+                ++i;
+
+                /* Suck down the following parameters that belong to
+                   this option.  If we run out of parameters, or find
+                   that any of them are the special_empty_param
+                   (insertted by split_shorts()), then print an error
+                   and return. */
+
+                param = PMIX_NEW(pmix_cmd_line_param_t);
+                if (NULL == param) {
+                    pmix_mutex_unlock(&cmd->lcl_mutex);
+                    return PMIX_ERR_OUT_OF_RESOURCE;
+                }
+                param->clp_arg = cmd->lcl_argv[i];
+                param->clp_option = option;
+
+                /* If we have any parameters to this option, suck down
+                   tokens starting one beyond the token that we just
+                   recognized */
+
+                for (j = 0; j < option->clo_num_params; ++j, ++i) {
+                    /* If we run out of parameters, error, unless its a help request
+                       which can have 0 or 1 arguments */
+                    if (i >= cmd->lcl_argc) {
+                    /* If this is a help request, can have no arguments */
+                        if((NULL != option->clo_single_dash_name &&
+                           0 == strcmp(option->clo_single_dash_name, "h")) ||
+                           (NULL != option->clo_long_name &&
+                           0 == strcmp(option->clo_long_name, "help"))) {
+                            help_without_arg = true;
+                            continue;
+                        }
+                        fprintf(stderr, "%s: Error: option \"%s\" did not "
+                                "have enough parameters (%d)\n",
+                                cmd->lcl_argv[0],
+                                cmd->lcl_argv[orig],
+                                option->clo_num_params);
+                        if (have_help_option) {
+                            fprintf(stderr, "Type '%s --help' for usage.\n",
+                                    cmd->lcl_argv[0]);
+                        }
+                        PMIX_RELEASE(param);
+                        printed_error = true;
+                        goto error;
+                    } else {
+                        if (0 == strcmp(cmd->lcl_argv[i],
+                                        special_empty_token)) {
+                            fprintf(stderr, "%s: Error: option \"%s\" did not "
+                                    "have enough parameters (%d)\n",
+                                    cmd->lcl_argv[0],
+                                    cmd->lcl_argv[orig],
+                                    option->clo_num_params);
+                            if (have_help_option) {
+                                fprintf(stderr, "Type '%s --help' for usage.\n",
+                                        cmd->lcl_argv[0]);
+                            }
+                            if (NULL != param->clp_argv) {
+                                pmix_argv_free(param->clp_argv);
+                            }
+                            PMIX_RELEASE(param);
+                            printed_error = true;
+                            goto error;
+                        }
+
+                        /* Otherwise, save this parameter */
+
+                        else {
+                            /* Save in the argv on the param entry */
+
+                            pmix_argv_append(&param->clp_argc,
+                                             &param->clp_argv,
+                                             cmd->lcl_argv[i]);
+
+                            /* If it's the first, save it in the
+                               variable dest and/or MCA parameter */
+
+                            if (0 == j &&
+                                (NULL != option->clo_mca_param_env_var ||
+                                 NULL != option->clo_variable_dest)) {
+                                if (PMIX_SUCCESS != (ret = set_dest(option, cmd->lcl_argv[i]))) {
+                                    pmix_mutex_unlock(&cmd->lcl_mutex);
+                                    return ret;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                /* If there are no options to this command or it is
+                   a help request with no argument, see if we need to
+                   set a boolean value to "true". */
+
+                if (0 == option->clo_num_params || help_without_arg) {
+                    if (PMIX_SUCCESS != (ret = set_dest(option, "1"))) {
+                        pmix_mutex_unlock(&cmd->lcl_mutex);
+                        return ret;
+                    }
+                }
+
+                /* If we succeeded in all that, save the param to the
+                   list on the pmix_cmd_line_t handle */
+
+                if (NULL != param) {
+                    pmix_list_append(&cmd->lcl_params, &param->super);
+                }
+            }
+        }
+
+        /* If we figured out above that this was an unknown option,
+           handle it.  Copy everything (including the current token)
+           into the tail.  If we're not ignoring unknowns, then print
+           an error and return. */
+        if (is_unknown_option || is_unknown_token) {
+            if (!ignore_unknown || (is_unknown_option && !ignore_unknown_option)) {
+                fprintf(stderr, "%s: Error: unknown option \"%s\"\n",
+                        cmd->lcl_argv[0], cmd->lcl_argv[i]);
+                printed_error = true;
+                if (have_help_option) {
+                    fprintf(stderr, "Type '%s --help' for usage.\n",
+                            cmd->lcl_argv[0]);
+                }
+            }
+        error:
+            while (i < cmd->lcl_argc) {
+                pmix_argv_append(&cmd->lcl_tail_argc, &cmd->lcl_tail_argv,
+                                 cmd->lcl_argv[i]);
+                ++i;
+            }
+
+            /* Because i has advanced, we'll fall out of the loop */
+        }
+    }
+
+    /* Thread serialization */
+
+    pmix_mutex_unlock(&cmd->lcl_mutex);
+
+    /* All done */
+    if (printed_error) {
+        return PMIX_ERR_SILENT;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+/*
+ * Return a consolidated "usage" message for a PMIX command line handle.
+ */
+char *pmix_cmd_line_get_usage_msg(pmix_cmd_line_t *cmd)
+{
+    size_t i, len;
+    int argc;
+    size_t j;
+    char **argv;
+    char *ret, temp[MAX_WIDTH * 2], line[MAX_WIDTH * 2];
+    char *start, *desc, *ptr;
+    pmix_list_item_t *item;
+    pmix_cmd_line_option_t *option, **sorted;
+    pmix_cmd_line_otype_t otype;
+
+    /* Thread serialization */
+
+    pmix_mutex_lock(&cmd->lcl_mutex);
+
+    /* Make an argv of all the usage strings */
+
+    argc = 0;
+    argv = NULL;
+    ret = NULL;
+
+    /* First, take the original list and sort it */
+
+    sorted = (pmix_cmd_line_option_t**)malloc(sizeof(pmix_cmd_line_option_t *) *
+                                         pmix_list_get_size(&cmd->lcl_options));
+    if (NULL == sorted) {
+        pmix_mutex_unlock(&cmd->lcl_mutex);
+        return NULL;
+    }
+    i = 0;
+    PMIX_LIST_FOREACH(item, &cmd->lcl_options, pmix_list_item_t) {
+        sorted[i++] = (pmix_cmd_line_option_t *) item;
+    }
+    qsort(sorted, i, sizeof(pmix_cmd_line_option_t*), qsort_callback);
+
+    /* Find if a help argument was passed, and return its type if it was. */
+
+    otype = get_help_otype(cmd);
+
+    /* Now go through the sorted array and make the strings */
+
+    for (j = 0; j < pmix_list_get_size(&cmd->lcl_options); ++j) {
+        option = sorted[j];
+        if(otype == PMIX_CMD_LINE_OTYPE_PARSABLE) {
+            ret = build_parsable(option);
+            pmix_argv_append(&argc, &argv, ret);
+            free(ret);
+            ret = NULL;
+        } else if(otype == PMIX_CMD_LINE_OTYPE_NULL || option->clo_otype == otype) {
+            if (NULL != option->clo_description) {
+                bool filled = false;
+
+                /* Build up the output line */
+
+                memset(line, 0, sizeof(line));
+                if ('\0' != option->clo_short_name) {
+                    line[0] = '-';
+                    line[1] = option->clo_short_name;
+                    filled = true;
+                } else {
+                    line[0] = ' ';
+                    line[1] = ' ';
+                }
+                if (NULL != option->clo_single_dash_name) {
+                    line[2] = (filled) ? '|' : ' ';
+                    strncat(line, "-", sizeof(line) - 1);
+                    strncat(line, option->clo_single_dash_name, sizeof(line) - 1);
+                    filled = true;
+                }
+                if (NULL != option->clo_long_name) {
+                    if (filled) {
+                        strncat(line, "|", sizeof(line) - 1);
+                    } else {
+                        strncat(line, " ", sizeof(line) - 1);
+                    }
+                    strncat(line, "--", sizeof(line) - 1);
+                    strncat(line, option->clo_long_name, sizeof(line) - 1);
+                }
+                strncat(line, " ", sizeof(line) - 1);
+                for (i = 0; (int)i < option->clo_num_params; ++i) {
+                    len = sizeof(temp);
+                    snprintf(temp, len, "<arg%d> ", (int)i);
+                    strncat(line, temp, sizeof(line) - 1);
+                }
+                if (option->clo_num_params > 0) {
+                    strncat(line, " ", sizeof(line) - 1);
+                }
+
+                /* If we're less than param width, then start adding the
+                   description to this line.  Otherwise, finish this line
+                   and start adding the description on the next line. */
+
+                if (strlen(line) > PARAM_WIDTH) {
+                    pmix_argv_append(&argc, &argv, line);
+
+                    /* Now reset the line to be all blanks up to
+                       PARAM_WIDTH so that we can start adding the
+                       description */
+
+                    memset(line, ' ', PARAM_WIDTH);
+                    line[PARAM_WIDTH] = '\0';
+                } else {
+
+                    /* Add enough blanks to the end of the line so that we
+                       can start adding the description */
+
+                    for (i = strlen(line); i < PARAM_WIDTH; ++i) {
+                        line[i] = ' ';
+                    }
+                    line[i] = '\0';
+                }
+
+                /* Loop over adding the description to the array, breaking
+                   the string at most at MAX_WIDTH characters.  We need a
+                   modifyable description (for simplicity), so strdup the
+                   clo_description (because it's likely a cpmixler
+                   constant, and may barf if we write temporary \0's in
+                   the middle). */
+
+                desc = strdup(option->clo_description);
+                if (NULL == desc) {
+                    free(sorted);
+                    pmix_mutex_unlock(&cmd->lcl_mutex);
+                    return strdup("");
+                }
+                start = desc;
+                len = strlen(desc);
+                do {
+
+                    /* Trim off leading whitespace */
+
+                    while (isspace(*start) && start < desc + len) {
+                        ++start;
+                    }
+                    if (start >= desc + len) {
+                        break;
+                    }
+
+                    /* Last line */
+
+                    if (strlen(start) < (MAX_WIDTH - PARAM_WIDTH)) {
+                        strncat(line, start, sizeof(line) - 1);
+                        pmix_argv_append(&argc, &argv, line);
+                        break;
+                    }
+
+                    /* We have more than 1 line's worth left -- find this
+                       line's worth and add it to the array.  Then reset
+                       and loop around to get the next line's worth. */
+
+                    for (ptr = start + (MAX_WIDTH - PARAM_WIDTH);
+                         ptr > start; --ptr) {
+                        if (isspace(*ptr)) {
+                            *ptr = '\0';
+                            strncat(line, start, sizeof(line) - 1);
+                            pmix_argv_append(&argc, &argv, line);
+
+                            start = ptr + 1;
+                            memset(line, ' ', PARAM_WIDTH);
+                            line[PARAM_WIDTH] = '\0';
+                            break;
+                        }
+                    }
+
+                    /* If we got all the way back to the beginning of the
+                       string, then go forward looking for a whitespace
+                       and break there. */
+
+                    if (ptr == start) {
+                        for (ptr = start + (MAX_WIDTH - PARAM_WIDTH);
+                             ptr < start + len; ++ptr) {
+                            if (isspace(*ptr)) {
+                                *ptr = '\0';
+
+                                strncat(line, start, sizeof(line) - 1);
+                                pmix_argv_append(&argc, &argv, line);
+
+                                start = ptr + 1;
+                                memset(line, ' ', PARAM_WIDTH);
+                                line[PARAM_WIDTH] = '\0';
+                                break;
+                            }
+                        }
+
+                        /* If we reached the end of the string with no
+                           whitespace, then just add it on and be done */
+
+                        if (ptr >= start + len) {
+                            strncat(line, start, sizeof(line) - 1);
+                            pmix_argv_append(&argc, &argv, line);
+                            start = desc + len + 1;
+                        }
+                    }
+                } while (start < desc + len);
+                free(desc);
+            }
+        }
+    }
+    if(otype == PMIX_CMD_LINE_OTYPE_NULL || otype == PMIX_CMD_LINE_OTYPE_GENERAL) {
+        char *argument_line = "\nFor additional mpirun arguments, run 'mpirun --help <category>'\n\nThe following categories exist: general (Defaults to this option), debug,\n    output, input, mapping, ranking, binding, devel (arguments useful to PMIX\n    Developers), compatibility (arguments supported for backwards compatibility),\n    launch (arguments to modify launch options), and dvm (Distributed Virtual\n    Machine arguments).";
+
+        pmix_argv_append(&argc, &argv, argument_line);
+    }
+    if (NULL != argv) {
+        ret = pmix_argv_join(argv, '\n');
+        pmix_argv_free(argv);
+    } else {
+        ret = strdup("");
+    }
+    free(sorted);
+
+    /* Thread serialization */
+    pmix_mutex_unlock(&cmd->lcl_mutex);
+
+    /* All done */
+    return ret;
+}
+
+
+/*
+ * Test if a given option was taken on the parsed command line.
+ */
+bool pmix_cmd_line_is_taken(pmix_cmd_line_t *cmd, const char *opt)
+{
+    return (pmix_cmd_line_get_ninsts(cmd, opt) > 0);
+}
+
+
+/*
+ * Return the number of instances of an option found during parsing.
+ */
+int pmix_cmd_line_get_ninsts(pmix_cmd_line_t *cmd, const char *opt)
+{
+    int ret;
+    pmix_cmd_line_param_t *param;
+    pmix_cmd_line_option_t *option;
+
+    /* Thread serialization */
+
+    pmix_mutex_lock(&cmd->lcl_mutex);
+
+    /* Find the corresponding option.  If we find it, look through all
+       the parsed params and see if we have any matches. */
+
+    ret = 0;
+    option = find_option(cmd, opt);
+    if (NULL != option) {
+        PMIX_LIST_FOREACH(param, &cmd->lcl_params, pmix_cmd_line_param_t) {
+            if (param->clp_option == option) {
+                ++ret;
+            }
+        }
+    }
+
+    /* Thread serialization */
+
+    pmix_mutex_unlock(&cmd->lcl_mutex);
+
+    /* All done */
+
+    return ret;
+}
+
+
+/*
+ * Return a specific parameter for a specific instance of a option
+ * from the parsed command line.
+ */
+char *pmix_cmd_line_get_param(pmix_cmd_line_t *cmd, const char *opt, int inst,
+                              int idx)
+{
+    int num_found;
+    pmix_cmd_line_param_t *param;
+    pmix_cmd_line_option_t *option;
+
+    /* Thread serialization */
+
+    pmix_mutex_lock(&cmd->lcl_mutex);
+
+    /* Find the corresponding option.  If we find it, look through all
+       the parsed params and see if we have any matches. */
+
+    num_found = 0;
+    option = find_option(cmd, opt);
+    if (NULL != option) {
+
+        /* Ensure to check for the case where the user has asked for a
+           parameter index greater than we will have */
+
+        if (idx < option->clo_num_params) {
+            PMIX_LIST_FOREACH(param, &cmd->lcl_params, pmix_cmd_line_param_t) {
+                if (param->clp_argc > 0 && param->clp_option == option) {
+                    if (num_found == inst) {
+                        pmix_mutex_unlock(&cmd->lcl_mutex);
+                        return param->clp_argv[idx];
+                    }
+                    ++num_found;
+                }
+            }
+        }
+    }
+
+    /* Thread serialization */
+
+    pmix_mutex_unlock(&cmd->lcl_mutex);
+
+    /* All done */
+
+    return NULL;
+}
+
+
+/*
+ * Return the number of arguments parsed on a PMIX command line handle.
+ */
+int pmix_cmd_line_get_argc(pmix_cmd_line_t *cmd)
+{
+    return (NULL != cmd) ? cmd->lcl_argc : PMIX_ERROR;
+}
+
+
+/*
+ * Return a string argument parsed on a PMIX command line handle.
+ */
+char *pmix_cmd_line_get_argv(pmix_cmd_line_t *cmd, int index)
+{
+    return (NULL == cmd) ? NULL :
+        (index >= cmd->lcl_argc || index < 0) ? NULL : cmd->lcl_argv[index];
+}
+
+
+/*
+ * Return the entire "tail" of unprocessed argv from a PMIX command
+ * line handle.
+ */
+int pmix_cmd_line_get_tail(pmix_cmd_line_t *cmd, int *tailc, char ***tailv)
+{
+    if (NULL != cmd) {
+        pmix_mutex_lock(&cmd->lcl_mutex);
+        *tailc = cmd->lcl_tail_argc;
+        *tailv = pmix_argv_copy(cmd->lcl_tail_argv);
+        pmix_mutex_unlock(&cmd->lcl_mutex);
+        return PMIX_SUCCESS;
+    } else {
+        return PMIX_ERROR;
+    }
+}
+
+
+/**************************************************************************
+ * Static functions
+ **************************************************************************/
+
+static void option_constructor(pmix_cmd_line_option_t *o)
+{
+    o->clo_short_name = '\0';
+    o->clo_single_dash_name = NULL;
+    o->clo_long_name = NULL;
+    o->clo_num_params = 0;
+    o->clo_description = NULL;
+
+    o->clo_type = PMIX_CMD_LINE_TYPE_NULL;
+    o->clo_mca_param_env_var = NULL;
+    o->clo_variable_dest = NULL;
+    o->clo_variable_set = false;
+    o->clo_otype = PMIX_CMD_LINE_OTYPE_NULL;
+}
+
+
+static void option_destructor(pmix_cmd_line_option_t *o)
+{
+    if (NULL != o->clo_single_dash_name) {
+        free(o->clo_single_dash_name);
+    }
+    if (NULL != o->clo_long_name) {
+        free(o->clo_long_name);
+    }
+    if (NULL != o->clo_description) {
+        free(o->clo_description);
+    }
+    if (NULL != o->clo_mca_param_env_var) {
+        free(o->clo_mca_param_env_var);
+    }
+}
+
+
+static void param_constructor(pmix_cmd_line_param_t *p)
+{
+    p->clp_arg = NULL;
+    p->clp_option = NULL;
+    p->clp_argc = 0;
+    p->clp_argv = NULL;
+}
+
+
+static void param_destructor(pmix_cmd_line_param_t *p)
+{
+    if (NULL != p->clp_argv) {
+        pmix_argv_free(p->clp_argv);
+    }
+}
+
+
+static void cmd_line_constructor(pmix_cmd_line_t *cmd)
+{
+    /* Initialize the mutex.  Since we're creating (and therefore the
+       only thread that has this instance), there's no need to lock it
+       right now. */
+
+    PMIX_CONSTRUCT(&cmd->lcl_mutex, pmix_recursive_mutex_t);
+
+    /* Initialize the lists */
+
+    PMIX_CONSTRUCT(&cmd->lcl_options, pmix_list_t);
+    PMIX_CONSTRUCT(&cmd->lcl_params, pmix_list_t);
+
+    /* Initialize the argc/argv pairs */
+
+    cmd->lcl_argc = 0;
+    cmd->lcl_argv = NULL;
+    cmd->lcl_tail_argc = 0;
+    cmd->lcl_tail_argv = NULL;
+}
+
+
+static void cmd_line_destructor(pmix_cmd_line_t *cmd)
+{
+    pmix_list_item_t *item;
+
+    /* Free the contents of the options list (do not free the list
+       itself; it was not allocated from the heap) */
+
+    for (item = pmix_list_remove_first(&cmd->lcl_options);
+         NULL != item;
+         item = pmix_list_remove_first(&cmd->lcl_options)) {
+        PMIX_RELEASE(item);
+    }
+
+    /* Free any parsed results */
+
+    free_parse_results(cmd);
+
+    /* Destroy the lists */
+
+    PMIX_DESTRUCT(&cmd->lcl_options);
+    PMIX_DESTRUCT(&cmd->lcl_params);
+
+    /* Destroy the mutex */
+
+    PMIX_DESTRUCT(&cmd->lcl_mutex);
+}
+
+
+static int make_opt(pmix_cmd_line_t *cmd, pmix_cmd_line_init_t *e)
+{
+    pmix_cmd_line_option_t *option;
+
+    /* Bozo checks */
+
+    if (NULL == cmd) {
+        return PMIX_ERR_BAD_PARAM;
+    } else if ('\0' == e->ocl_cmd_short_name &&
+               NULL == e->ocl_cmd_single_dash_name &&
+               NULL == e->ocl_cmd_long_name) {
+        return PMIX_ERR_BAD_PARAM;
+    } else if (e->ocl_num_params < 0) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* see if the option already exists */
+    if (NULL != e->ocl_cmd_single_dash_name &&
+        NULL != find_option(cmd, e->ocl_cmd_single_dash_name)) {
+        pmix_output(0, "Duplicate cmd line entry %s", e->ocl_cmd_single_dash_name);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    if (NULL != e->ocl_cmd_long_name &&
+        NULL != find_option(cmd, e->ocl_cmd_long_name)) {
+        pmix_output(0, "Duplicate cmd line entry %s", e->ocl_cmd_long_name);
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* Allocate and fill an option item */
+    option = PMIX_NEW(pmix_cmd_line_option_t);
+    if (NULL == option) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+
+    option->clo_short_name = e->ocl_cmd_short_name;
+    if (NULL != e->ocl_cmd_single_dash_name) {
+        option->clo_single_dash_name = strdup(e->ocl_cmd_single_dash_name);
+    }
+    if (NULL != e->ocl_cmd_long_name) {
+        option->clo_long_name = strdup(e->ocl_cmd_long_name);
+    }
+    option->clo_num_params = e->ocl_num_params;
+    if (NULL != e->ocl_description) {
+        option->clo_description = strdup(e->ocl_description);
+    }
+
+    option->clo_type = e->ocl_variable_type;
+    option->clo_variable_dest = e->ocl_variable_dest;
+    if (NULL != e->ocl_mca_param_name) {
+        (void) pmix_mca_base_var_env_name (e->ocl_mca_param_name,
+                                           &option->clo_mca_param_env_var);
+    }
+
+    option->clo_otype = e->ocl_otype;
+
+    /* Append the item, serializing thread access */
+
+    pmix_mutex_lock(&cmd->lcl_mutex);
+    pmix_list_append(&cmd->lcl_options, &option->super);
+    pmix_mutex_unlock(&cmd->lcl_mutex);
+
+    /* All done */
+
+    return PMIX_SUCCESS;
+}
+
+
+static void free_parse_results(pmix_cmd_line_t *cmd)
+{
+    pmix_list_item_t *item;
+
+    /* Free the contents of the params list (do not free the list
+       itself; it was not allocated from the heap) */
+
+    for (item = pmix_list_remove_first(&cmd->lcl_params);
+         NULL != item;
+         item = pmix_list_remove_first(&cmd->lcl_params)) {
+        PMIX_RELEASE(item);
+    }
+
+    /* Free the argv's */
+
+    if (NULL != cmd->lcl_argv) {
+        pmix_argv_free(cmd->lcl_argv);
+    }
+    cmd->lcl_argv = NULL;
+    cmd->lcl_argc = 0;
+
+    if (NULL != cmd->lcl_tail_argv) {
+        pmix_argv_free(cmd->lcl_tail_argv);
+    }
+    cmd->lcl_tail_argv = NULL;
+    cmd->lcl_tail_argc = 0;
+}
+
+
+/*
+ * Traverse a token and split it into individual letter options (the
+ * token has already been certified to not be a long name and not be a
+ * short name).  Ensure to differentiate the resulting options from
+ * "single dash" names.
+ */
+static int split_shorts(pmix_cmd_line_t *cmd, char *token, char **args,
+                        int *output_argc, char ***output_argv,
+                        int *num_args_used, bool ignore_unknown)
+{
+    int i, j, len;
+    pmix_cmd_line_option_t *option;
+    char fake_token[3];
+    int num_args;
+
+    /* Setup that we didn't use any of the args */
+
+    num_args = pmix_argv_count(args);
+    *num_args_used = 0;
+
+    /* Traverse the token.  If it's empty (e.g., if someone passes a
+       "-" token, which, since the upper level calls this function as
+       (argv[i] + 1), will be empty by the time it gets down here),
+       just return that we didn't find a short option. */
+
+    len = (int)strlen(token);
+    if (0 == len) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    fake_token[0] = '-';
+    fake_token[2] = '\0';
+    for (i = 0; i < len; ++i) {
+        fake_token[1] = token[i];
+        option = find_option(cmd, fake_token + 1);
+
+        /* If we don't find the option, either return an error or pass
+           it through unmodified to the new argv */
+
+        if (NULL == option) {
+            if (!ignore_unknown) {
+                return PMIX_ERR_BAD_PARAM;
+            } else {
+                pmix_argv_append(output_argc, output_argv, fake_token);
+            }
+        }
+
+        /* If we do find the option, copy it and all of its parameters
+           to the output args.  If we run out of paramters (i.e., no
+           more tokens in the original argv), that error will be
+           handled at a higher level) */
+
+        else {
+            pmix_argv_append(output_argc, output_argv, fake_token);
+            for (j = 0; j < option->clo_num_params; ++j) {
+                if (*num_args_used < num_args) {
+                    pmix_argv_append(output_argc, output_argv,
+                                     args[*num_args_used]);
+                    ++(*num_args_used);
+                } else {
+                    pmix_argv_append(output_argc, output_argv,
+                                     special_empty_token);
+                }
+            }
+        }
+    }
+
+    /* All done */
+
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_cmd_line_option_t *find_option(pmix_cmd_line_t *cmd,
+                                           const char *option_name)
+{
+    pmix_cmd_line_option_t *option;
+
+    /* Iterate through the list of options hanging off the
+       pmix_cmd_line_t and see if we find a match in either the short
+       or long names */
+
+    PMIX_LIST_FOREACH(option, &cmd->lcl_options, pmix_cmd_line_option_t) {
+        if ((NULL != option->clo_long_name &&
+             0 == strcmp(option_name, option->clo_long_name)) ||
+            (NULL != option->clo_single_dash_name &&
+             0 == strcmp(option_name, option->clo_single_dash_name)) ||
+            (strlen(option_name) == 1 &&
+             option_name[0] == option->clo_short_name)) {
+            return option;
+        }
+    }
+
+    /* Not found */
+
+    return NULL;
+}
+
+
+static int set_dest(pmix_cmd_line_option_t *option, char *sval)
+{
+    int ival = atol(sval);
+    long lval = strtoul(sval, NULL, 10);
+    size_t i;
+
+    /* Set MCA param.  We do this in the environment because the MCA
+       parameter may not have been registered yet -- and if it isn't
+       registered, we don't really want to register a dummy one
+       because we don't know what it's type and default value should
+       be.  These are solvable problems (e.g., make a re-registration
+       overwrite everything), but it's far simpler to just leave the
+       registered table alone and set an environment variable with the
+       desired value.  The environment variable will get picked up
+       during a nromal parameter lookup, and all will be well. */
+
+    if (NULL != option->clo_mca_param_env_var) {
+        switch(option->clo_type) {
+        case PMIX_CMD_LINE_TYPE_STRING:
+        case PMIX_CMD_LINE_TYPE_INT:
+        case PMIX_CMD_LINE_TYPE_SIZE_T:
+            pmix_setenv(option->clo_mca_param_env_var, sval, true, &environ);
+            break;
+        case PMIX_CMD_LINE_TYPE_BOOL:
+            pmix_setenv(option->clo_mca_param_env_var, "1", true, &environ);
+            break;
+        default:
+            break;
+        }
+    }
+
+    /* Set variable */
+
+    if (NULL != option->clo_variable_dest) {
+        switch(option->clo_type) {
+        case PMIX_CMD_LINE_TYPE_STRING:
+            *((char**) option->clo_variable_dest) = strdup(sval);
+            break;
+        case PMIX_CMD_LINE_TYPE_INT:
+            /* check to see that the value given to us truly is an int */
+            for (i=0; i < strlen(sval); i++) {
+                if (!isdigit(sval[i]) && '-' != sval[i]) {
+                    /* show help isn't going to be available yet, so just
+                     * print the msg
+                     */
+                    fprintf(stderr, "----------------------------------------------------------------------------\n");
+                    fprintf(stderr, "Open MPI has detected that a parameter given to a command line\n");
+                    fprintf(stderr, "option does not match the expected format:\n\n");
+                    if (NULL != option->clo_long_name) {
+                        fprintf(stderr, "  Option: %s\n", option->clo_long_name);
+                    } else if ('\0' != option->clo_short_name) {
+                        fprintf(stderr, "  Option: %c\n", option->clo_short_name);
+                    } else {
+                        fprintf(stderr, "  Option: <unknown>\n");
+                    }
+                    fprintf(stderr, "  Param:  %s\n\n", sval);
+                    fprintf(stderr, "This is frequently caused by omitting to provide the parameter\n");
+                    fprintf(stderr, "to an option that requires one. Please check the command line and try again.\n");
+                    fprintf(stderr, "----------------------------------------------------------------------------\n");
+                    return PMIX_ERR_SILENT;
+                }
+            }
+            *((int*) option->clo_variable_dest) = ival;
+            break;
+        case PMIX_CMD_LINE_TYPE_SIZE_T:
+            /* check to see that the value given to us truly is a size_t */
+            for (i=0; i < strlen(sval); i++) {
+                if (!isdigit(sval[i]) && '-' != sval[i]) {
+                    /* show help isn't going to be available yet, so just
+                     * print the msg
+                     */
+                    fprintf(stderr, "----------------------------------------------------------------------------\n");
+                    fprintf(stderr, "Open MPI has detected that a parameter given to a command line\n");
+                    fprintf(stderr, "option does not match the expected format:\n\n");
+                    if (NULL != option->clo_long_name) {
+                        fprintf(stderr, "  Option: %s\n", option->clo_long_name);
+                    } else if ('\0' != option->clo_short_name) {
+                        fprintf(stderr, "  Option: %c\n", option->clo_short_name);
+                    } else {
+                        fprintf(stderr, "  Option: <unknown>\n");
+                    }
+                    fprintf(stderr, "  Param:  %s\n\n", sval);
+                    fprintf(stderr, "This is frequently caused by omitting to provide the parameter\n");
+                    fprintf(stderr, "to an option that requires one. Please check the command line and try again.\n");
+                    fprintf(stderr, "----------------------------------------------------------------------------\n");
+                    return PMIX_ERR_SILENT;
+                }
+            }
+            *((size_t*) option->clo_variable_dest) = lval;
+            break;
+        case PMIX_CMD_LINE_TYPE_BOOL:
+            *((bool*) option->clo_variable_dest) = 1;
+            break;
+        default:
+            break;
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+
+/*
+ * Helper function to qsort_callback
+ */
+static void fill(const pmix_cmd_line_option_t *a, char result[3][BUFSIZ])
+{
+    int i = 0;
+
+    result[0][0] = '\0';
+    result[1][0] = '\0';
+    result[2][0] = '\0';
+
+    if ('\0' != a->clo_short_name) {
+        snprintf(&result[i][0], BUFSIZ, "%c", a->clo_short_name);
+        ++i;
+    }
+    if (NULL != a->clo_single_dash_name) {
+        snprintf(&result[i][0], BUFSIZ, "%s", a->clo_single_dash_name);
+        ++i;
+    }
+    if (NULL != a->clo_long_name) {
+        snprintf(&result[i][0], BUFSIZ, "%s", a->clo_long_name);
+        ++i;
+    }
+}
+
+
+static int qsort_callback(const void *aa, const void *bb)
+{
+    int ret, i;
+    char str1[3][BUFSIZ], str2[3][BUFSIZ];
+    const pmix_cmd_line_option_t *a = *((const pmix_cmd_line_option_t**) aa);
+    const pmix_cmd_line_option_t *b = *((const pmix_cmd_line_option_t**) bb);
+
+    /* Icky comparison of command line options.  There are multiple
+       forms of each command line option, so we first have to check
+       which forms each option has.  Compare, in order: short name,
+       single-dash name, long name. */
+
+    fill(a, str1);
+    fill(b, str2);
+
+    for (i = 0; i < 3; ++i) {
+        if (0 != (ret = strcasecmp(str1[i], str2[i]))) {
+            return ret;
+        }
+    }
+
+    /* Shrug -- they must be equal */
+
+    return 0;
+}
+
+
+/*
+ * Helper function to find the option type specified in the help
+ * command.
+ */
+static pmix_cmd_line_otype_t get_help_otype(pmix_cmd_line_t *cmd)
+{
+    /* Initialize to NULL, if it remains so, the user asked for
+       "full" help output */
+    pmix_cmd_line_otype_t otype = PMIX_CMD_LINE_OTYPE_NULL;
+    char *arg;
+
+    arg = pmix_cmd_line_get_param(cmd, "help", 0, 0);
+
+    /* If not "help", check for "h" */
+    if(NULL == arg) {
+        arg = pmix_cmd_line_get_param(cmd, "h", 0, 0);
+    }
+
+    /* If arg is still NULL, give them the General info by default */
+    if(NULL == arg) {
+        arg = "general";
+    }
+
+    if (0 == strcmp(arg, "debug")) {
+        otype = PMIX_CMD_LINE_OTYPE_DEBUG;
+    } else if (0 == strcmp(arg, "output")) {
+        otype = PMIX_CMD_LINE_OTYPE_OUTPUT;
+    } else if (0 == strcmp(arg, "input")) {
+        otype = PMIX_CMD_LINE_OTYPE_INPUT;
+    } else if (0 == strcmp(arg, "mapping")) {
+        otype = PMIX_CMD_LINE_OTYPE_MAPPING;
+    } else if (0 == strcmp(arg, "ranking")) {
+        otype = PMIX_CMD_LINE_OTYPE_RANKING;
+    } else if (0 == strcmp(arg, "binding")) {
+        otype = PMIX_CMD_LINE_OTYPE_BINDING;
+    } else if (0 == strcmp(arg, "devel")) {
+        otype = PMIX_CMD_LINE_OTYPE_DEVEL;
+    } else if (0 == strcmp(arg, "compatibility")) {
+        otype = PMIX_CMD_LINE_OTYPE_COMPAT;
+    } else if (0 == strcmp(arg, "launch")) {
+        otype = PMIX_CMD_LINE_OTYPE_LAUNCH;
+    } else if (0 == strcmp(arg, "dvm")) {
+        otype = PMIX_CMD_LINE_OTYPE_DVM;
+    } else if (0 == strcmp(arg, "general")) {
+        otype = PMIX_CMD_LINE_OTYPE_GENERAL;
+    } else if (0 == strcmp(arg, "parsable")) {
+        otype = PMIX_CMD_LINE_OTYPE_PARSABLE;
+    }
+
+    return otype;
+}
+
+/*
+ * Helper function to build a parsable string for the help
+ * output.
+ */
+static char *build_parsable(pmix_cmd_line_option_t *option) {
+    char *line;
+    int length;
+
+    length = snprintf(NULL, 0, "%c:%s:%s:%d:%s\n", option->clo_short_name, option->clo_single_dash_name,
+                      option->clo_long_name, option->clo_num_params, option->clo_description);
+
+    line = (char *)malloc(length * sizeof(char));
+
+    if('\0' == option->clo_short_name) {
+        snprintf(line, length, "0:%s:%s:%d:%s\n", option->clo_single_dash_name, option->clo_long_name,
+                 option->clo_num_params, option->clo_description);
+    } else {
+        snprintf(line, length, "%c:%s:%s:%d:%s\n", option->clo_short_name, option->clo_single_dash_name,
+                 option->clo_long_name, option->clo_num_params, option->clo_description);
+    }
+
+    return line;
+}

--- a/src/util/cmd_line.h
+++ b/src/util/cmd_line.h
@@ -1,0 +1,622 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2017 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * General command line parsing facility for use throughout Open MPI.
+ *
+ * This scheme is inspired by the GNU getopt package.  Command line
+ * options are registered.  Each option can have up to three different
+ * matching tokens: a "short" name, a "single dash" name, and a "long"
+ * name.  Each option can also take 0 or more arguments.  Finally,
+ * each option can be repeated on the command line an arbitrary number
+ * of times.
+ *
+ * The "short" name can only be a single letter, and will be found
+ * after a single dash (e.g., "-a").  Multiple "short" names can be
+ * combined into a single command line argument (e.g., "-abc" can be
+ * equivalent to "-a -b -c").
+ *
+ * The "single dash" name is a multi-character name that only
+ * requires a single dash.  This only exists to provide backwards
+ * compatibility for some well-known command line options in prior
+ * MPI implementations (e.g., "mpirun -np 3").  It should be used
+ * sparingly.
+ *
+ * The "long" name is a multi-character name that is found after a
+ * pair of dashes.  For example, "--some-option-name".
+ *
+ * A command line option is a combination of 1 or more of a short
+ * name, single dash name, and a long name.  Any of the names may be
+ * used on the command line; they are treated as synonyms.  For
+ * example, say the following was used in for an executable named
+ * "foo":
+ *
+ * \code
+ * pmix_cmd_line_make_opt3(cmd, 'a', NULL, 'add', 1, "Add a user");
+ * \endcode
+ *
+ * In this case, the following command lines are exactly equivalent:
+ *
+ * \verbatim
+ * shell$ foo -a jsmith
+ * shell$ foo --add jsmith
+ * \endverbatim
+ *
+ * Note that this interface can also track multiple invocations of the
+ * same option.  For example, the following is both legal and able to
+ * be retrieved through this interface:
+ *
+ * \verbatim
+ * shell$ foo -a jsmith -add bjones
+ * \endverbatim
+ *
+ * The caller to this interface creates a command line handle
+ * (pmix_cmd_line_t) with OBJ_NEW() and then uses it to register the
+ * desired parameters via pmix_cmd_line_make_opt3(). Once all the
+ * parameters have been registered, the user invokes
+ * pmix_cmd_line_parse() with the command line handle and the argv/argc
+ * pair to be parsed (typically the arguments from main()).  The parser
+ * will examine the argv and find registered options and parameters.
+ * It will stop parsing when it runs into an recognized string token or
+ * the special "--" token.
+ *
+ * After the parse has occurred, various accessor functions can be
+ * used to determine which options were selected, what parameters were
+ * passed to them, etc.:
+ *
+ * - pmix_cmd_line_get_usage_msg() returns a string suitable for "help"
+ *   kinds of messages.
+ * - pmix_cmd_line_is_taken() returns a true or false indicating
+ *   whether a given command line option was found on the command
+ *   line.
+ * - pmix_cmd_line_get_argc() returns the number of tokens parsed on
+ *   the handle.
+ * - pmix_cmd_line_get_argv() returns any particular string from the
+ *   original argv.
+ * - pmix_cmd_line_get_ninsts() returns the number of times a
+ *   particular option was found on a command line.
+ * - pmix_cmd_line_get_param() returns the Nth parameter in the Mth
+ *   instance of a given parameter.
+ * - pmix_cmd_line_get_tail() returns an array of tokens not parsed
+ *   (i.e., if the parser ran into "--" or an unrecognized token).
+ *
+ * Note that a shortcut to creating a large number of options exists
+ * -- one can make a table of pmix_cmd_line_init_t instances and the
+ * table to pmix_cmd_line_create().  This creates an pmix_cmd_line_t
+ * handle that is pre-seeded with all the options from the table
+ * without the need to repeatedly invoke pmix_cmd_line_make_opt3() (or
+ * equivalent).  This pmix_cmd_line_t instance is just like any other;
+ * it is still possible to add more options via
+ * pmix_cmd_line_make_opt3(), etc.
+ */
+
+#ifndef PMIX_CMD_LINE_H
+#define PMIX_CMD_LINE_H
+
+#include "pmix_config.h"
+
+#include "src/class/pmix_object.h"
+#include "src/class/pmix_list.h"
+#include "src/threads/mutex.h"
+
+BEGIN_C_DECLS
+    /**
+     * \internal
+     *
+     * Main top-level handle.  This interface should not be used by users!
+     */
+    struct pmix_cmd_line_t {
+        /** Make this an OBJ handle */
+        pmix_object_t super;
+
+        /** Thread safety */
+        pmix_recursive_mutex_t lcl_mutex;
+
+        /** List of ompi_cmd_line_option_t's (defined internally) */
+        pmix_list_t lcl_options;
+
+        /** Duplicate of argc from pmix_cmd_line_parse() */
+        int lcl_argc;
+        /** Duplicate of argv from pmix_cmd_line_parse() */
+        char **lcl_argv;
+
+        /** Parsed output; list of ompi_cmd_line_param_t's (defined internally) */
+        pmix_list_t lcl_params;
+
+        /** List of tail (unprocessed) arguments */
+        int lcl_tail_argc;
+        /** List of tail (unprocessed) arguments */
+        char **lcl_tail_argv;
+    };
+    /**
+     * \internal
+     *
+     * Convenience typedef
+     */
+    typedef struct pmix_cmd_line_t pmix_cmd_line_t;
+
+    /**
+     * Data types supported by the parser
+     */
+    enum pmix_cmd_line_type_t {
+        PMIX_CMD_LINE_TYPE_NULL,
+        PMIX_CMD_LINE_TYPE_STRING,
+        PMIX_CMD_LINE_TYPE_INT,
+        PMIX_CMD_LINE_TYPE_SIZE_T,
+        PMIX_CMD_LINE_TYPE_BOOL,
+
+        PMIX_CMD_LINE_TYPE_MAX
+    };
+    /**
+     * \internal
+     *
+     * Convenience typedef
+     */
+    typedef enum pmix_cmd_line_type_t pmix_cmd_line_type_t;
+
+    /**
+     * Command line option type, for use in
+     * mpirun --help output.
+     */
+    enum pmix_cmd_line_otype_t {
+        PMIX_CMD_LINE_OTYPE_GENERAL,
+        PMIX_CMD_LINE_OTYPE_DEBUG,
+        PMIX_CMD_LINE_OTYPE_OUTPUT,
+        PMIX_CMD_LINE_OTYPE_INPUT,
+        PMIX_CMD_LINE_OTYPE_MAPPING,
+        PMIX_CMD_LINE_OTYPE_RANKING,
+        PMIX_CMD_LINE_OTYPE_BINDING,
+        PMIX_CMD_LINE_OTYPE_DEVEL,
+        PMIX_CMD_LINE_OTYPE_COMPAT, /* Backwards compatibility */
+        PMIX_CMD_LINE_OTYPE_LAUNCH,
+        PMIX_CMD_LINE_OTYPE_DVM,
+        PMIX_CMD_LINE_OTYPE_UNSUPPORTED,
+        PMIX_CMD_LINE_OTYPE_PARSABLE,
+        PMIX_CMD_LINE_OTYPE_NULL
+    };
+    /**
+     * \internal
+     *
+     * Convenience typedef
+     */
+    typedef enum pmix_cmd_line_otype_t pmix_cmd_line_otype_t;
+
+    /**
+     * Datatype used to construct a command line handle; see
+     * pmix_cmd_line_create().
+     */
+    struct pmix_cmd_line_init_t {
+        /** If want to set an MCA parameter, set its parameter name
+            here. */
+        const char *ocl_mca_param_name;
+
+        /** "Short" name (i.e., "-X", where "X" is a single letter) */
+        char ocl_cmd_short_name;
+        /** "Single dash" name (i.e., "-foo").  The use of these are
+            discouraged. */
+        const char *ocl_cmd_single_dash_name;
+        /** Long name (i.e., "--foo"). */
+        const char *ocl_cmd_long_name;
+
+        /** Number of parameters that this option takes */
+        int ocl_num_params;
+
+        /** If this parameter is encountered, its *first* parameter it
+            saved here.  If the parameter is encountered again, the
+            value is overwritten. */
+        void *ocl_variable_dest;
+        /** If an ocl_variable_dest is given, its datatype must be
+            supplied as well. */
+        pmix_cmd_line_type_t ocl_variable_type;
+
+        /** Description of the command line option, to be used with
+            pmix_cmd_line_get_usage_msg(). */
+        const char *ocl_description;
+
+        /** Category for mpirun --help output */
+        pmix_cmd_line_otype_t ocl_otype;
+    };
+    /**
+     * \internal
+     *
+     * Convenience typedef
+     */
+    typedef struct pmix_cmd_line_init_t pmix_cmd_line_init_t;
+
+    /**
+     * Top-level command line handle.
+     *
+     * This handle is used for accessing all command line functionality
+     * (i.e., all pmix_cmd_line*() functions).  Multiple handles can be
+     * created and simultaneously processed; each handle is independant
+     * from others.
+     *
+     * The pmix_cmd_line_t handles are [simplisticly] thread safe;
+     * processing is guaranteed to be mutually exclusive if multiple
+     * threads invoke functions on the same handle at the same time --
+     * access will be serialized in an unspecified order.
+     *
+     * Once finished, handles should be released with OBJ_RELEASE().  The
+     * destructor for pmix_cmd_line_t handles will free all memory
+     * associated with the handle.
+     */
+    PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_cmd_line_t);
+
+    /**
+     * Make a command line handle from a table of initializers.
+     *
+     * @param cmd PMIX command line handle.
+     * @param table Table of pmix_cmd_line_init_t instances for all
+     * the options to be included in the resulting command line
+     * handler.
+     *
+     * @retval PMIX_SUCCESS Upon success.
+     *
+     * This function takes a table of pmix_cmd_line_init_t instances
+     * to pre-seed an PMIX command line handle.  The last instance in
+     * the table must have '\0' for the short name and NULL for the
+     * single-dash and long names.  The handle is expected to have
+     * been OBJ_NEW'ed or OBJ_CONSTRUCT'ed already.
+     *
+     * Upon return, the command line handle is just like any other.  A
+     * sample using this syntax:
+     *
+     * \code
+     * pmix_cmd_line_init_t cmd_line_init[] = {
+     *    { NULL, NULL, NULL, 'h', NULL, "help", 0,
+     *      &orterun_globals.help, PMIX_CMD_LINE_TYPE_BOOL,
+     *      "This help message" },
+     *
+     *    { NULL, NULL, NULL, '\0', NULL, "wd", 1,
+     *      &orterun_globals.wd, PMIX_CMD_LINE_TYPE_STRING,
+     *      "Set the working directory of the started processes" },
+     *
+     *    { NULL, NULL, NULL, '\0', NULL, NULL, 0,
+     *      NULL, PMIX_CMD_LINE_TYPE_NULL, NULL }
+     * };
+     * \endcode
+     */
+    PMIX_EXPORT int pmix_cmd_line_create(pmix_cmd_line_t *cmd,
+                                           pmix_cmd_line_init_t *table);
+
+    /* Add a table of pmix_cmd_line_init_t instances
+     * to an existing PMIX command line handle.
+     *
+     * Multiple calls to pmix_cmd_line_add are permitted - each
+     * subsequent call will simply append new options to the existing
+     * handle. Note that any duplicates will return an error.
+     */
+     PMIX_EXPORT int pmix_cmd_line_add(pmix_cmd_line_t *cmd,
+                                         pmix_cmd_line_init_t *table);
+
+    /**
+     * Create a command line option.
+     *
+     * @param cmd PMIX command line handle.
+     * @param entry Command line entry to add to the command line.
+     *
+     * @retval PMIX_SUCCESS Upon success.
+     *
+     */
+    PMIX_EXPORT int pmix_cmd_line_make_opt_mca(pmix_cmd_line_t *cmd,
+                                                 pmix_cmd_line_init_t entry);
+
+    /**
+     * Create a command line option.
+     *
+     * @param cmd PMIX command line handle.
+     * @param short_name "Short" name of the command line option.
+     * @param sd_name "Single dash" name of the command line option.
+     * @param long_name "Long" name of the command line option.
+     * @param num_params How many parameters this option takes.
+     * @param dest Short string description of this option.
+     *
+     * @retval PMIX_ERR_OUT_OF_RESOURCE If out of memory.
+     * @retval PMIX_ERR_BAD_PARAM If bad parameters passed.
+     * @retval PMIX_SUCCESS Upon success.
+     *
+     * Adds a command line option to the list of options that an PMIX
+     * command line handle will accept.  The short_name may take the
+     * special value '\0' to not have a short name.  Likewise, the
+     * sd_name and long_name may take the special value NULL to not have
+     * a single dash or long name, respectively.  However, one of the
+     * three must have a name.
+     *
+     * num_params indicates how many parameters this option takes.  It
+     * must be greater than or equal to 0.
+     *
+     * Finally, desc is a short string description of this option.  It is
+     * used to generate the output from pmix_cmd_line_get_usage_msg().
+     *
+     */
+    PMIX_EXPORT int pmix_cmd_line_make_opt3(pmix_cmd_line_t *cmd,
+                                              char short_name,
+                                              const char *sd_name,
+                                              const char *long_name,
+                                              int num_params,
+                                              const char *desc);
+
+    /**
+     * Parse a command line according to a pre-built PMIX command line
+     * handle.
+     *
+     * @param cmd PMIX command line handle.
+     * @param ignore_unknown Whether to print an error message upon
+     * finding an unknown token or not
+     * @param ignore_unknown_option Whether to print an error message upon
+     * finding an unknown option or not
+     * @param argc Length of the argv array.
+     * @param argv Array of strings from the command line.
+     *
+     * @retval PMIX_SUCCESS Upon success.
+     * @retval PMIX_ERR_SILENT If an error message was printed.  This
+     * value will only be returned if the command line was not
+     * successfully parsed.
+     *
+     * Parse a series of command line tokens according to the option
+     * descriptions from a PMIX command line handle.  The PMIX command line
+     * handle can then be queried to see what options were used, what
+     * their parameters were, etc.
+     *
+     * If an unknown token is found in the command line (i.e., a token
+     * that is not a parameter or a registered option), the parsing will
+     * stop (see below).  If ignore_unknown is false, an error message
+     * is displayed.  If ignore_unknown is true, the error message is
+     * not displayed.
+     *
+     * Error messages are always displayed regardless of the value
+     * of ignore_unknown (to stderr, and PMIX_ERR_SILENT is
+     * returned) if:
+     *
+     * 1. A token was encountered that required N parameters, but <N
+     * parameters were found (e.g., "cmd --param foo", but --param was
+     * registered to require 2 option tokens).
+     *
+     * 2. An unknown token beginning with "-" is encountered.  For
+     * example, if "--fo" is specified, and no "fo" option is
+     * registered (e.g., perhaps the user meant to type "--foo"), an
+     * error message is always printed, UNLESS this unknown token
+     * happens after a "--" token (see below).
+     *
+     * The contents of argc and argv are not changed during parsing.
+     * argv[0] is assumed to be the executable name, and is ignored during
+     * parsing, except when printing error messages.
+     *
+     * Parsing will stop in the following conditions:
+     *
+     * - all argv tokens are processed
+     * - the token "--" is found
+     * - an unrecognized token is found
+     * - a parameter registered with an integer type option finds a
+     *   non-integer option token
+     * - a parameted registered N option tokens, but finds less then
+     *   <N tokens available
+     *
+     * Upon any of these conditions, any remaining tokens will be placed
+     * in the "tail" (and therefore not examined by the parser),
+     * regardless of the value of ignore_unknown.  The set of tail
+     * tokens is available from the pmix_cmd_line_get_tail() function.
+     *
+     * Note that "--" is ignored if it is found in the middle an expected
+     * number of arguments.  For example, if "--foo" is expected to have 3
+     * arguments, and the command line is:
+     *
+     * executable --foo a b -- other arguments
+     *
+     * This will result in an error, because "--" will be parsed as the
+     * third parameter to the first instance of "foo", and "other" will be
+     * an unrecognized option.
+     *
+     * Note that -- can be used to allow unknown tokens that begin
+     * with "-".  For example, if a user wants to mpirun an executable
+     * named "-my-mpi-program", the "usual" way:
+     *
+     *   mpirun -my-mpi-program
+     *
+     * will cause an error, because mpirun won't find single-letter
+     * options registered for some/all of those letters.  But two
+     * workarounds are possible:
+     *
+     *   mpirun -- -my-mpi-program
+     * or
+     *   mpirun ./-my-mpi-program
+     *
+     * Finally, note that invoking this function multiple times on
+     * different sets of argv tokens is safe, but will erase any
+     * previous parsing results.
+     */
+    PMIX_EXPORT int pmix_cmd_line_parse(pmix_cmd_line_t *cmd,
+                                          bool ignore_unknown,
+                                          bool ignore_unknown_option,
+                                          int argc, char **argv);
+
+    /**
+     * Return a consolidated "usage" message for a PMIX command line handle.
+     *
+     * @param cmd PMIX command line handle.
+     *
+     * @retval str Usage message.
+     *
+     * Returns a formatted string suitable for printing that lists the
+     * expected usage message and a short description of each option on
+     * the PMIX command line handle.  Options that passed a NULL
+     * description to pmix_cmd_line_make_opt3() will not be included in the
+     * display (to allow for undocumented options).
+     *
+     * This function is typically only invoked internally by the
+     * pmix_show_help() function.
+     *
+     * This function should probably be fixed up to produce prettier
+     * output.
+     *
+     * The returned string must be freed by the caller.
+     */
+    PMIX_EXPORT char *pmix_cmd_line_get_usage_msg(pmix_cmd_line_t *cmd) __pmix_attribute_malloc__ __pmix_attribute_warn_unused_result__;
+
+    /**
+     * Test if a given option was taken on the parsed command line.
+     *
+     * @param cmd PMIX command line handle.
+     * @param opt Short or long name of the option to check for.
+     *
+     * @retval true If the command line option was found during
+     * pmix_cmd_line_parse().
+     *
+     * @retval false If the command line option was not found during
+     * pmix_cmd_line_parse(), or pmix_cmd_line_parse() was not invoked on
+     * this handle.
+     *
+     * This function should only be called after pmix_cmd_line_parse().
+     *
+     * The function will return true if the option matching opt was found
+     * (either by its short or long name) during token parsing.
+     * Otherwise, it will return false.
+     */
+    PMIX_EXPORT bool pmix_cmd_line_is_taken(pmix_cmd_line_t *cmd,
+                                              const char *opt) __pmix_attribute_nonnull__(1) __pmix_attribute_nonnull__(2);
+
+    /**
+     * Return the number of arguments parsed on a PMIX command line handle.
+     *
+     * @param cmd A pointer to the PMIX command line handle.
+     *
+     * @retval PMIX_ERROR If cmd is NULL.
+     * @retval argc Number of arguments previously added to the handle.
+     *
+     * Arguments are added to the handle via the pmix_cmd_line_parse()
+     * function.
+     */
+    PMIX_EXPORT int pmix_cmd_line_get_argc(pmix_cmd_line_t *cmd) __pmix_attribute_unused__;
+
+    /**
+     * Return a string argument parsed on a PMIX command line handle.
+     *
+     * @param cmd A pointer to the PMIX command line handle.
+     * @param index The nth argument from the command line (0 is
+     * argv[0], etc.).
+     *
+     * @retval NULL If cmd is NULL or index is invalid
+     * @retval argument String of original argv[index]
+     *
+     * This function returns a single token from the arguments parsed
+     * on this handle.  Arguments are added bia the
+     * pmix_cmd_line_parse() function.
+     *
+     * What is returned is a pointer to the actual string that is on
+     * the handle; it should not be modified or freed.
+     */
+    PMIX_EXPORT char *pmix_cmd_line_get_argv(pmix_cmd_line_t *cmd,
+                                               int index);
+
+    /**
+     * Return the number of instances of an option found during parsing.
+     *
+     * @param cmd PMIX command line handle.
+     * @param opt Short or long name of the option to check for.
+     *
+     * @retval num Number of instances (to include 0) of a given potion
+     * found during pmix_cmd_line_parse().
+     *
+     * @retval PMIX_ERR If the command line option was not found during
+     * pmix_cmd_line_parse(), or pmix_cmd_line_parse() was not invoked on
+     * this handle.
+     *
+     * This function should only be called after pmix_cmd_line_parse().
+     *
+     * The function will return the number of instances of a given option
+     * (either by its short or long name) -- to include 0 -- or PMIX_ERR if
+     * either the option was not specified as part of the PMIX command line
+     * handle, or pmix_cmd_line_parse() was not invoked on this handle.
+     */
+    PMIX_EXPORT int pmix_cmd_line_get_ninsts(pmix_cmd_line_t *cmd,
+                                               const char *opt) __pmix_attribute_nonnull__(1) __pmix_attribute_nonnull__(2);
+
+    /**
+     * Return a specific parameter for a specific instance of a option
+     * from the parsed command line.
+     *
+     * @param cmd PMIX command line handle.
+     * @param opt Short or long name of the option to check for.
+     * @param instance_num Instance number of the option to query.
+     * @param param_num Which parameter to return.
+     *
+     * @retval param String of the parameter.
+     * @retval NULL If any of the input values are invalid.
+     *
+     * This function should only be called after pmix_cmd_line_parse().
+     *
+     * This function returns the Nth parameter for the Ith instance of a
+     * given option on the parsed command line (both N and I are
+     * zero-indexed).  For example, on the command line:
+     *
+     * executable --foo bar1 bar2 --foo bar3 bar4
+     *
+     * The call to pmix_cmd_line_get_param(cmd, "foo", 1, 1) would return
+     * "bar4".  pmix_cmd_line_get_param(cmd, "bar", 0, 0) would return
+     * NULL, as would pmix_cmd_line_get_param(cmd, "foo", 2, 2);
+     *
+     * The returned string should \em not be modified or freed by the
+     * caller.
+     */
+    PMIX_EXPORT char *pmix_cmd_line_get_param(pmix_cmd_line_t *cmd,
+                                                const char *opt,
+                                                int instance_num,
+                                                int param_num);
+
+    /**
+     * Return the entire "tail" of unprocessed argv from a PMIX
+     * command line handle.
+     *
+     * @param cmd A pointer to the PMIX command line handle.
+     * @param tailc Pointer to the output length of the null-terminated
+     * tail argv array.
+     * @param tailv Pointer to the output null-terminated argv of all
+     * unprocessed arguments from the command line.
+     *
+     * @retval PMIX_ERROR If cmd is NULL or otherwise invalid.
+     * @retval PMIX_SUCCESS Upon success.
+     *
+     * The "tail" is all the arguments on the command line that were
+     * not processed for some reason.  Reasons for not processing
+     * arguments include:
+     *
+     * \sa The argument was not recognized
+     * \sa The argument "--" was seen, and therefore all arguments
+     * following it were not processed
+     *
+     * The output tailc parameter will be filled in with the integer
+     * length of the null-terminated tailv array (length including the
+     * final NULL entry).  The output tailv parameter will be a copy
+     * of the tail parameters, and must be freed (likely with a call
+     * to pmix_argv_free()) by the caller.
+     */
+    PMIX_EXPORT int pmix_cmd_line_get_tail(pmix_cmd_line_t *cmd, int *tailc,
+                                             char ***tailv);
+
+END_C_DECLS
+
+
+#endif /* PMIX_CMD_LINE_H */

--- a/src/util/keyval_parse.h
+++ b/src/util/keyval_parse.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -26,7 +26,7 @@
 
 BEGIN_C_DECLS
 
-extern int pmix_util_keyval_parse_lineno;
+PMIX_EXPORT extern int pmix_util_keyval_parse_lineno;
 
 /**
  * Callback triggered for each key = value pair
@@ -46,14 +46,14 @@ typedef void (*pmix_keyval_parse_fn_t)(const char *key, const char *value);
  * called exactly once.  In a multithreaded context, calls to
  * pmix_util_keyval_parse() will serialize multiple calls.
  */
-int pmix_util_keyval_parse(const char *filename,
-                                         pmix_keyval_parse_fn_t callback);
+PMIX_EXPORT int pmix_util_keyval_parse(const char *filename,
+                                       pmix_keyval_parse_fn_t callback);
 
-int pmix_util_keyval_parse_init(void);
+PMIX_EXPORT int pmix_util_keyval_parse_init(void);
 
-int pmix_util_keyval_parse_finalize(void);
+PMIX_EXPORT int pmix_util_keyval_parse_finalize(void);
 
-int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback);
+PMIX_EXPORT int pmix_util_keyval_save_internal_envars(pmix_keyval_parse_fn_t callback);
 
 END_C_DECLS
 


### PR DESCRIPTION
Introduce PMIx-based tools that are only installed in standalone installations for use with PMIx-based RMs and language-based starters (e.g., mpirun).

* pinfo - show MCA params, build info, etc.

* pps - get list of active nspaces, retrieve status of jobs/nodes/procs

* pevent - inject an event into the system

* plookup - lookup published info

Not fully implemented yet, except for pinfo. Need to complete all the cmd line options and pretty-print output.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>