### PR TITLE
Fix event registration so OpenMP/MPI coordination sides can both get notification of model declarations

### DIFF
--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -749,13 +749,17 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
 
   ack:
     /* acknowledge the registration so the caller can release
-     * their data */
+     * their data AND record the event handler index */
     if (NULL != cd->evregcbfn) {
         cd->evregcbfn(rc, index, cd->cbdata);
     }
 
     /* check if any matching notifications have been cached */
     check_cached_events(cd);
+    if (NULL != cd->codes) {
+        free(cd->codes);
+        cd->codes = NULL;
+    }
 
     /* all done */
     PMIX_RELEASE(cd);
@@ -768,6 +772,7 @@ PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncode
                                              void *cbdata)
 {
     pmix_rshift_caddy_t *cd;
+    size_t n;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -783,7 +788,23 @@ PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncode
     /* need to thread shift this request so we can access
      * our global data to register this *local* event handler */
     cd = PMIX_NEW(pmix_rshift_caddy_t);
-    cd->codes = codes;
+    /* we have to save the codes as we will check them against existing
+     * registrations AFTER we have executed the callback which allows
+     * the caller to release their storage */
+    if (0 < ncodes) {
+        cd->codes = (pmix_status_t*)malloc(ncodes * sizeof(pmix_status_t));
+        if (NULL == cd->codes) {
+            /* immediately return error */
+            PMIX_RELEASE(cd);
+            if (NULL != cbfunc) {
+                cbfunc(PMIX_ERR_NOMEM, SIZE_MAX, cbdata);
+            }
+            return;
+        }
+        for (n=0; n < ncodes; n++) {
+            cd->codes[n] = codes[n];
+        }
+    }
     cd->ncodes = ncodes;
     cd->info = info;
     cd->ninfo = ninfo;


### PR DESCRIPTION

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit ac15fb23baf282718ce634cb170d0abbef7cfe7d)