### PR TITLE
Fix errors uncovered by cross-version testing

### DIFF
--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -421,7 +421,11 @@ int pmix12_v2_to_v1_datatype(pmix_data_type_t v2type)
             v1type = 6;
             break;
 
-        case 22:
+        case 39:
+            /* data arrays must be converted to info arrays */
+            v1type = 22;
+            break;
+
         case 23:
         case 24:
         case 25:
@@ -494,6 +498,10 @@ pmix_status_t pmix12_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t
     pmix_status_t rc;
 
     rc = pmix12_bfrop_unpack_datatype(buffer, &v1type, &n, PMIX_INT);
+    if (UINT16_MAX < v1type) {
+        *type = 0;
+        return PMIX_ERR_UNKNOWN_DATA_TYPE;
+    }
     if (PMIX_SUCCESS == rc) {
         *type = pmix12_v1_to_v2_datatype(v1type);
     }

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -188,7 +188,8 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
         }
         /* if the data types don't match, then return an error */
         if (v1type != local_type) {
-            pmix_output(0, "PMIX bfrop:unpack: got type %d when expecting type %d", local_type, v1type);
+            pmix_output_verbose(1, pmix_bfrops_base_framework.framework_output,
+                                "PMIX bfrop:unpack: got type %d when expecting type %d", local_type, v1type);
             return PMIX_ERR_PACK_MISMATCH;
         }
     }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1157,7 +1157,6 @@ static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
     pmix_buffer_t pbkt;
     pmix_proc_t proc;
     pmix_kval_t *kv;
-    pmix_peer_t *peer;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_modex for nspace %s",
@@ -1184,26 +1183,15 @@ static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
      * REMOTE/GLOBAL data. The byte object contains
      * the rank followed by pmix_kval_t's. The list of callbacks
      * contains all local participants. */
-    peer = NULL;
-    PMIX_LIST_FOREACH(scd, cbs, pmix_server_caddy_t) {
-        if (scd->peer->nptr == ns) {
-            peer = scd->peer;
-            break;
-        }
-    }
-    if (NULL == peer) {
-        /* we can ignore this one */
-        return PMIX_SUCCESS;
-    }
 
     /* setup the byte object for unpacking */
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
     /* the next step unfortunately NULLs the byte object's
      * entries, so we need to ensure we restore them! */
-    PMIX_LOAD_BUFFER(peer, &pbkt, bo->bytes, bo->size);
+    PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, bo->bytes, bo->size);
     /* unload the proc that provided this data */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, &pbkt, &proc, &cnt, PMIX_PROC);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, &proc, &cnt, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         bo->bytes = pbkt.base_ptr;
@@ -1215,7 +1203,7 @@ static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
-    PMIX_BFROPS_UNPACK(rc, peer, &pbkt, kv, &cnt, PMIX_KVAL);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
         if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc.rank, kv))) {
@@ -1230,7 +1218,7 @@ static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
         /* continue along */
         kv = PMIX_NEW(pmix_kval_t);
         cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, peer, &pbkt, kv, &cnt, PMIX_KVAL);
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
     }
     PMIX_RELEASE(kv);  // maintain accounting
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {


### PR DESCRIPTION
Fix errors uncovered when trying to execute OMPI v2.x apps (using PMIx v1.2) using a server from OMPI master (using PMIx v2.1). Get the packing/unpacking of pmix_info_array_t's and pmix_proc correct. Modex blobs are always provided based on the local peer since they were "fetched" locally. Avoid a segfault when a remote daemon fails to start its procs, thereby causing a collective to execute locally without any local callbacks.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 98ecfa22a3d867a2d80438bab1f917ae889fe9b5)