### PR TITLE
configury: do not include src/include/pmix_config.h into the dist tar…

### DIFF
--- a/src/include/Makefile.include
+++ b/src/include/Makefile.include
@@ -12,6 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,6 +46,6 @@ headers += \
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
-headers += \
+nodist_headers += \
     include/pmix_config.h
 endif


### PR DESCRIPTION
…ball

This is an automatically generated file, so it should not be included
in the dist tarball

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>