### PR TITLE
Make pmix_common.h be a generated header file so we actually take vis…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ examples/tool
 
 include/pmix_version.h
 include/pmix_rename.h
+include/pmix_common.h
 
 src/include/pmix_config.h
 src/include/pmix_config.h.in

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -819,6 +819,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     pmix_show_subtitle "Final output"
 
+    AC_CONFIG_HEADERS(pmix_config_prefix[include/pmix_common.h])
+
     AC_CONFIG_FILES(
         pmix_config_prefix[Makefile]
         pmix_config_prefix[config/Makefile]

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -13,7 +13,6 @@
 if WANT_PRIMARY_HEADERS
 include_HEADERS = \
         pmix.h \
-        pmix_common.h \
         pmix_server.h \
         pmix_tool.h
 
@@ -24,6 +23,7 @@ include_HEADERS += \
 endif
 
 nodist_include_HEADERS = \
+    pmix_common.h \
     pmix_version.h \
     pmix_rename.h
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -61,11 +61,15 @@
 #include <unistd.h> /* for uid_t and gid_t */
 #include <sys/types.h> /* for uid_t and gid_t */
 
-#ifdef PMIX_HAVE_VISIBILITY
+/* Whether C compiler supports -fvisibility */
+#undef PMIX_HAVE_VISIBILITY
+
+#if PMIX_HAVE_VISIBILITY == 1
 #define PMIX_EXPORT __attribute__((__visibility__("default")))
 #else
 #define PMIX_EXPORT
 #endif
+
 
 #include <pmix_rename.h>
 #include <pmix_version.h>


### PR DESCRIPTION
…ibility into account. As things were, we ignored that directive because PMIX_HAVE_VISIBILITY wasn't defined in pmix_common.h and we don't want to include pmix_config.h in a user-facing file.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>