### PR TITLE
Unify definition of PMIX_EXPORT

### DIFF
--- a/include/pmi.h
+++ b/include/pmi.h
@@ -48,11 +48,8 @@
 #ifndef PMI_H
 #define PMI_H
 
-#ifdef PMIX_HAVE_VISIBILITY
-#define PMIX_EXPORT __attribute__((__visibility__("default")))
-#else
-#define PMIX_EXPORT
-#endif
+/* Structure and constant definitions */
+#include <pmix_common.h>
 
 /* prototypes for the PMI interface in MPICH2 */
 

--- a/include/pmi2.h
+++ b/include/pmi2.h
@@ -7,11 +7,8 @@
 #ifndef PMI2_H_INCLUDED
 #define PMI2_H_INCLUDED
 
-#ifdef PMIX_HAVE_VISIBILITY
-#define PMIX_EXPORT __attribute__((__visibility__("default")))
-#else
-#define PMIX_EXPORT
-#endif
+/* Structure and constant definitions */
+#include <pmix_common.h>
 
 #define PMI2_MAX_KEYLEN 64
 #define PMI2_MAX_VALLEN 1024


### PR DESCRIPTION
It is possible for the test in the legacy PMI include files to get a different answer for PMIX_EXPORT when built in an embedded environment, leading to "redefined" warnings. So use the definition generated for pmix_common.h, even though we don't really need any of the rest of the definitions in there.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 5cfc43d84cd2e22244cd05a744397b564c25d484)