### PR TITLE
dstor: addresses a dstor compatibility issues

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -382,6 +382,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     }
     if (PMIX_ERR_NOT_FOUND != rc || NULL == lcd) {
         /* we have a problem - e.g., out of memory */
+        cbfunc(PMIX_ERR_NOT_FOUND, NULL, 0, cbdata, NULL, NULL);
         PMIX_INFO_FREE(info, ninfo);
         return rc;
     }


### PR DESCRIPTION
Fixed dstor compatibility issues between v1.2 and v2.x.

Fixes #563

Note: the `dstor` cannot support multi-clients case for nspace when clients in the same one nspace will be has different versions, i.e. in one nspace should be use clients v1.2 only, or v2.x only.