### PR TITLE
Add registration for cleanup support (RFC0027)

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -462,6 +462,16 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_JOB_CTRL_PROVISION_IMAGE       "pmix.jctrl.pvnimg"     // (char*) name of the image that is to be provisioned
 #define PMIX_JOB_CTRL_PREEMPTIBLE           "pmix.jctrl.preempt"    // (bool) job can be pre-empted
 #define PMIX_JOB_CTRL_TERMINATE             "pmix.jctrl.term"       // (bool) politely terminate the specified procs
+#define PMIX_REGISTER_CLEANUP               "pmix.reg.cleanup"      // (char*) comma-delimited list of files/directories to
+                                                                    //         be removed upon process termination
+#define PMIX_CLEANUP_RECURSIVE              "pmix.clnup.recurse"    // (bool) recursively cleanup all subdirectories under the
+                                                                    //        specified one(s)
+#define PMIX_CLEANUP_EMPTY                  "pmix.clnup.empty"      // (bool) only remove empty subdirectories
+#define PMIX_CLEANUP_IGNORE                 "pmix.clnup.ignore"     // (char*) comma-delimited list of filenames that are not
+                                                                    //         to be removed
+#define PMIX_CLEANUP_LEAVE_TOPDIR           "pmix.clnup.lvtop"      // (bool) when recursively cleaning subdirs, do not remove
+                                                                    //        the top-level directory (the one given in the
+                                                                    //        cleanup request)
 
 /* monitoring attributes */
 #define PMIX_MONITOR_ID                     "pmix.monitor.id"       // (char*) provide a string identifier for this request
@@ -592,6 +602,7 @@ typedef int pmix_status_t;
 #define PMIX_ERR_NOT_IMPLEMENTED                    -48
 #define PMIX_ERR_COMM_FAILURE                       -49
 #define PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER     -50         // internal-only
+#define PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES     -51
 
 /* define a starting point for v2.x error values */
 #define PMIX_ERR_V2X_BASE                   -100

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -462,7 +462,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_JOB_CTRL_PROVISION_IMAGE       "pmix.jctrl.pvnimg"     // (char*) name of the image that is to be provisioned
 #define PMIX_JOB_CTRL_PREEMPTIBLE           "pmix.jctrl.preempt"    // (bool) job can be pre-empted
 #define PMIX_JOB_CTRL_TERMINATE             "pmix.jctrl.term"       // (bool) politely terminate the specified procs
-#define PMIX_REGISTER_CLEANUP               "pmix.reg.cleanup"      // (char*) comma-delimited list of files/directories to
+#define PMIX_REGISTER_CLEANUP               "pmix.reg.cleanup"      // (char*) comma-delimited list of files to
+                                                                    //         be removed upon process termination
+#define PMIX_REGISTER_CLEANUP_DIR           "pmix.reg.cleanupdir"   // (char*) comma-delimited list of directories to
                                                                     //         be removed upon process termination
 #define PMIX_CLEANUP_RECURSIVE              "pmix.clnup.recurse"    // (bool) recursively cleanup all subdirectories under the
                                                                     //        specified one(s)

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -36,11 +36,26 @@
 #endif
 #include <ctype.h>
 #include PMIX_EVENT_HEADER
+#if HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif /* HAVE_SYS_STAT_H */
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif  /* HAVE_DIRENT_H */
+
+#include <pmix_common.h>
 
 #include "src/mca/bfrops/bfrops_types.h"
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"
 #include "src/threads/threads.h"
+#include "src/util/argv.h"
+#include "src/util/os_path.h"
+
+static void cleanup(pmix_epilog_t *epi);
+static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd,
+                            pmix_epilog_t *epi);
+static bool dirpath_is_empty(const char *path);
 
 PMIX_EXPORT pmix_lock_t pmix_global_lock = {
     .mutex = PMIX_MUTEX_STATIC_INIT,
@@ -52,6 +67,36 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namelist_t,
                                 pmix_list_item_t,
                                 NULL, NULL);
 
+static void cfcon(pmix_cleanup_file_t *p)
+{
+    p->path = NULL;
+}
+static void cfdes(pmix_cleanup_file_t *p)
+{
+    if (NULL != p->path) {
+        free(p->path);
+    }
+}
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cleanup_file_t,
+                                pmix_list_item_t,
+                                cfcon, cfdes);
+
+static void cdcon(pmix_cleanup_dir_t *p)
+{
+    p->path = NULL;
+    p->recurse = false;
+    p->leave_topdir = false;
+}
+static void cddes(pmix_cleanup_dir_t *p)
+{
+    if (NULL != p->path) {
+        free(p->path);
+    }
+}
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cleanup_dir_t,
+                                pmix_list_item_t,
+                                cdcon, cddes);
+
 static void nscon(pmix_nspace_t *p)
 {
     p->nspace = NULL;
@@ -61,6 +106,9 @@ static void nscon(pmix_nspace_t *p)
     p->ndelivered = 0;
     PMIX_CONSTRUCT(&p->ranks, pmix_list_t);
     memset(&p->compat, 0, sizeof(p->compat));
+    PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
+    PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
+    PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
 }
 static void nsdes(pmix_nspace_t *p)
 {
@@ -71,6 +119,12 @@ static void nsdes(pmix_nspace_t *p)
         PMIX_RELEASE(p->jobbkt);
     }
     PMIX_LIST_DESTRUCT(&p->ranks);
+    /* perform any epilog */
+    cleanup(&p->epilog);
+    /* cleanup the epilog */
+    PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
+    PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
+    PMIX_LIST_DESTRUCT(&p->epilog.ignores);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_nspace_t,
                                 pmix_list_item_t,
@@ -126,7 +180,11 @@ static void pcon(pmix_peer_t *p)
     p->send_msg = NULL;
     p->recv_msg = NULL;
     p->commit_cnt = 0;
+    PMIX_CONSTRUCT(&p->epilog.cleanup_dirs, pmix_list_t);
+    PMIX_CONSTRUCT(&p->epilog.cleanup_files, pmix_list_t);
+    PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
 }
+
 static void pdes(pmix_peer_t *p)
 {
     if (0 <= p->sd) {
@@ -150,6 +208,12 @@ static void pdes(pmix_peer_t *p)
     if (NULL != p->recv_msg) {
         PMIX_RELEASE(p->recv_msg);
     }
+    /* perform any epilog */
+    cleanup(&p->epilog);
+    /* cleanup the epilog */
+    PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
+    PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
+    PMIX_LIST_DESTRUCT(&p->epilog.ignores);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
                                 pmix_object_t,
@@ -258,3 +322,198 @@ static void qdes(pmix_query_caddy_t *p)
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_query_caddy_t,
                                 pmix_object_t,
                                 qcon, qdes);
+
+static void cleanup(pmix_epilog_t *epi)
+{
+    pmix_cleanup_file_t *cf;
+    pmix_cleanup_dir_t *cd;
+    struct stat statbuf;
+    int rc;
+
+    /* start with any specified files */
+    PMIX_LIST_FOREACH(cf, &epi->cleanup_files, pmix_cleanup_file_t) {
+        /* check the effective uid/gid of the file and ensure it
+         * matches that of the peer - we do this to provide at least
+         * some minimum level of protection */
+        rc = stat(cf->path, &statbuf);
+        if (0 != rc) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "File %s failed to stat: %s", cf->path, strerror(rc));
+            continue;
+        }
+        if (statbuf.st_uid != epi->uid ||
+            statbuf.st_gid != epi->gid) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "File %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
+                                cf->path,
+                                (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
+                                (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
+            continue;
+        }
+        rc = unlink(cf->path);
+        if (0 != rc) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "File %s failed to unlink: %s", cf->path, strerror(rc));
+        }
+    }
+
+    /* now cleanup the directories */
+    PMIX_LIST_FOREACH(cd, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
+        /* check the effective uid/gid of the file and ensure it
+         * matches that of the peer - we do this to provide at least
+         * some minimum level of protection */
+        rc = stat(cd->path, &statbuf);
+        if (0 != rc) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "Directory %s failed to stat: %s", cd->path, strerror(rc));
+            continue;
+        }
+        if (statbuf.st_uid != epi->uid ||
+            statbuf.st_gid != epi->gid) {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "Directory %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
+                                cd->path,
+                                (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
+                                (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
+            continue;
+        }
+        if ((statbuf.st_mode & S_IRWXU) == S_IRWXU) {
+            dirpath_destroy(cd->path, cd, epi);
+        } else {
+            pmix_output_verbose(10, pmix_globals.debug_output,
+                                "Directory %s lacks permissions", cd->path);
+        }
+    }
+}
+
+static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd, pmix_epilog_t *epi)
+{
+    int rc;
+    bool is_dir = false;
+    DIR *dp;
+    struct dirent *ep;
+    char *filenm;
+    struct stat buf;
+    pmix_cleanup_file_t *cf;
+
+    if (NULL == path) {  /* protect against error */
+        return;
+    }
+
+    /* if this path is it to be ignored, then do so */
+    PMIX_LIST_FOREACH(cf, &epi->ignores, pmix_cleanup_file_t) {
+        if (0 == strcmp(cf->path, path)) {
+            return;
+        }
+    }
+
+    /* Open up the directory */
+    dp = opendir(path);
+    if (NULL == dp) {
+        return;
+    }
+
+    while (NULL != (ep = readdir(dp))) {
+        /* skip:
+         *  - . and ..
+         */
+        if ((0 == strcmp(ep->d_name, ".")) ||
+            (0 == strcmp(ep->d_name, ".."))) {
+            continue;
+        }
+
+        /* Create a pathname.  This is not always needed, but it makes
+         * for cleaner code just to create it here.  Note that we are
+         * allocating memory here, so we need to free it later on.
+         */
+        filenm = pmix_os_path(false, path, ep->d_name, NULL);
+
+        /* if this path is it to be ignored, then do so */
+        PMIX_LIST_FOREACH(cf, &epi->ignores, pmix_cleanup_file_t) {
+            if (0 == strcmp(cf->path, filenm)) {
+                free(filenm);
+                continue;
+            }
+        }
+
+        /* Check to see if it is a directory */
+        is_dir = false;
+
+        rc = stat(filenm, &buf);
+        if (0 > rc) {
+            /* Handle a race condition. filenm might have been deleted by an
+             * other process running on the same node. That typically occurs
+             * when one task is removing the job_session_dir and an other task
+             * is still removing its proc_session_dir.
+             */
+            free(filenm);
+            continue;
+        }
+        /* if the uid/gid don't match, then leave it alone */
+        if (buf.st_uid != epi->uid ||
+            buf.st_gid != epi->gid) {
+            free(filenm);
+            continue;
+        }
+
+        if (S_ISDIR(buf.st_mode)) {
+            is_dir = true;
+        }
+
+        /*
+         * If not recursively decending, then if we find a directory then fail
+         * since we were not told to remove it.
+         */
+        if (is_dir && !cd->recurse) {
+            /* continue removing files */
+            free(filenm);
+            continue;
+        }
+
+        /* Directories are recursively destroyed */
+        if (is_dir && cd->recurse && ((buf.st_mode & S_IRWXU) == S_IRWXU)) {
+            dirpath_destroy(filenm, cd, epi);
+            free(filenm);
+        } else {
+            /* Files are removed right here */
+            unlink(filenm);
+            free(filenm);
+        }
+    }
+
+    /* Done with this directory */
+    closedir(dp);
+
+    /* If the directory is empty, then remove it unless we
+     * were told to leave it */
+    if (0 == strcmp(path, cd->path) && cd->leave_topdir) {
+        return;
+    }
+    if (dirpath_is_empty(path)) {
+        rmdir(path);
+    }
+}
+
+static bool dirpath_is_empty(const char *path )
+{
+    DIR *dp;
+    struct dirent *ep;
+
+    if (NULL != path) {  /* protect against error */
+        dp = opendir(path);
+        if (NULL != dp) {
+            while ((ep = readdir(dp))) {
+                        if ((0 != strcmp(ep->d_name, ".")) &&
+                            (0 != strcmp(ep->d_name, ".."))) {
+                            closedir(dp);
+                            return false;
+                        }
+            }
+            closedir(dp);
+            return true;
+        }
+        return false;
+    }
+
+    return true;
+}

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  *                         and Technology (RIST). All rights reserved.
@@ -52,7 +52,6 @@
 #include "src/util/argv.h"
 #include "src/util/os_path.h"
 
-static void cleanup(pmix_epilog_t *epi);
 static void dirpath_destroy(char *path, pmix_cleanup_dir_t *cd,
                             pmix_epilog_t *epi);
 static bool dirpath_is_empty(const char *path);
@@ -120,7 +119,7 @@ static void nsdes(pmix_nspace_t *p)
     }
     PMIX_LIST_DESTRUCT(&p->ranks);
     /* perform any epilog */
-    cleanup(&p->epilog);
+    pmix_execute_epilog(&p->epilog);
     /* cleanup the epilog */
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
@@ -209,7 +208,7 @@ static void pdes(pmix_peer_t *p)
         PMIX_RELEASE(p->recv_msg);
     }
     /* perform any epilog */
-    cleanup(&p->epilog);
+    pmix_execute_epilog(&p->epilog);
     /* cleanup the epilog */
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_dirs);
     PMIX_LIST_DESTRUCT(&p->epilog.cleanup_files);
@@ -323,15 +322,15 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_query_caddy_t,
                                 pmix_object_t,
                                 qcon, qdes);
 
-static void cleanup(pmix_epilog_t *epi)
+void pmix_execute_epilog(pmix_epilog_t *epi)
 {
-    pmix_cleanup_file_t *cf;
-    pmix_cleanup_dir_t *cd;
+    pmix_cleanup_file_t *cf, *cfnext;
+    pmix_cleanup_dir_t *cd, *cdnext;
     struct stat statbuf;
     int rc;
 
     /* start with any specified files */
-    PMIX_LIST_FOREACH(cf, &epi->cleanup_files, pmix_cleanup_file_t) {
+    PMIX_LIST_FOREACH_SAFE(cf, cfnext, &epi->cleanup_files, pmix_cleanup_file_t) {
         /* check the effective uid/gid of the file and ensure it
          * matches that of the peer - we do this to provide at least
          * some minimum level of protection */
@@ -355,10 +354,12 @@ static void cleanup(pmix_epilog_t *epi)
             pmix_output_verbose(10, pmix_globals.debug_output,
                                 "File %s failed to unlink: %s", cf->path, strerror(rc));
         }
+        pmix_list_remove_item(&epi->cleanup_files, &cf->super);
+        PMIX_RELEASE(cf);
     }
 
     /* now cleanup the directories */
-    PMIX_LIST_FOREACH(cd, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
+    PMIX_LIST_FOREACH_SAFE(cd, cdnext, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
         /* check the effective uid/gid of the file and ensure it
          * matches that of the peer - we do this to provide at least
          * some minimum level of protection */
@@ -383,6 +384,8 @@ static void cleanup(pmix_epilog_t *epi)
             pmix_output_verbose(10, pmix_globals.debug_output,
                                 "Directory %s lacks permissions", cd->path);
         }
+        pmix_list_remove_item(&epi->cleanup_dirs, &cd->super);
+        PMIX_RELEASE(cd);
     }
 }
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -121,6 +121,29 @@ typedef struct pmix_personality_t {
     pmix_gds_base_module_t *gds;
 } pmix_personality_t;
 
+/* define a set of structs for tracking post-termination cleanup */
+typedef struct pmix_epilog_t {
+    uid_t uid;
+    gid_t gid;
+    pmix_list_t cleanup_dirs;
+    pmix_list_t cleanup_files;
+    pmix_list_t ignores;
+} pmix_epilog_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    char *path;
+} pmix_cleanup_file_t;
+PMIX_CLASS_DECLARATION(pmix_cleanup_file_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    char *path;
+    bool recurse;
+    bool leave_topdir;
+} pmix_cleanup_dir_t;
+PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);
+
 /* objects used by servers for tracking active nspaces */
 typedef struct {
     pmix_list_item_t super;
@@ -135,6 +158,8 @@ typedef struct {
      * Since servers may support clients from multiple nspaces,
      * track their respective compatibility modules here */
     pmix_personality_t compat;
+    pmix_epilog_t epilog;       // things to do upon termination of all local clients
+                                // from this nspace
 } pmix_nspace_t;
 PMIX_CLASS_DECLARATION(pmix_nspace_t);
 
@@ -157,6 +182,17 @@ typedef struct pmix_rank_info_t {
     void *server_object;       // pointer to rank-specific object provided by server
 } pmix_rank_info_t;
 PMIX_CLASS_DECLARATION(pmix_rank_info_t);
+
+
+/* define a very simple caddy for dealing with pmix_info_t
+ * objects when transferring portions of arrays */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_info_t *info;
+    size_t ninfo;
+} pmix_info_caddy_t;
+PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
+
 
 /* object for tracking peers - each peer can have multiple
  * connections. This can occur if the initial app executes
@@ -181,6 +217,8 @@ typedef struct pmix_peer_t {
     pmix_ptl_send_t *send_msg;      /**< current send in progress */
     pmix_ptl_recv_t *recv_msg;      /**< current recv in progress */
     int commit_cnt;
+    pmix_epilog_t epilog;           /**< things to be performed upon
+                                         termination of this peer */
 } pmix_peer_t;
 PMIX_CLASS_DECLARATION(pmix_peer_t);
 
@@ -315,14 +353,6 @@ typedef struct {
     bool timer_running;
 } pmix_cb_t;
 PMIX_CLASS_DECLARATION(pmix_cb_t);
-
-/* define a very simple caddy for dealing with pmix_info_t
- * objects when transferring portions of arrays */
-typedef struct {
-    pmix_list_item_t super;
-    pmix_info_t *info;
-} pmix_info_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
 
 #define PMIX_THREADSHIFT(r, c)                              \
  do {                                                       \

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -419,6 +419,8 @@ typedef struct {
     pmix_gds_base_module_t *mygds;
 } pmix_globals_t;
 
+/* provide access to a function to cleanup epilogs */
+PMIX_EXPORT void pmix_execute_epilog(pmix_epilog_t *ep);
 
 PMIX_EXPORT extern pmix_globals_t pmix_globals;
 PMIX_EXPORT extern pmix_lock_t pmix_global_lock;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1164,6 +1164,12 @@ static void connection_handler(int sd, short args, void *cbdata)
     peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
+    /* update the epilog fields */
+    peer->epilog.uid = info->uid;
+    peer->epilog.gid = info->gid;
+    /* ensure the nspace epilog is updated too */
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     peer->sd = pnd->sd;
     if (0 > (peer->index = pmix_pointer_array_add(&pmix_server_globals.clients, peer))) {
@@ -1405,6 +1411,11 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
+    /* save the uid/gid */
+    peer->epilog.uid = info->uid;
+    peer->epilog.gid = info->gid;
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     peer->proc_cnt = 1;
     peer->sd = pnd->sd;
 

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -606,6 +606,11 @@ static void connection_handler(int sd, short args, void *cbdata)
     psave->nptr = nptr;
     PMIX_RETAIN(info);
     psave->info = info;
+    /* save the epilog info */
+    psave->epilog.uid = info->uid;
+    psave->epilog.gid = info->gid;
+    nptr->epilog.uid = info->uid;
+    nptr->epilog.gid = info->gid;
     info->proc_cnt++; /* increase number of processes on this rank */
     psave->sd = pnd->sd;
     if (0 > (psave->index = pmix_pointer_array_add(&pmix_server_globals.clients, psave))) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2084,6 +2084,13 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
     pmix_status_t rc;
     pmix_query_caddy_t *cd;
     pmix_proc_t proc;
+    size_t n;
+    bool recurse, leave_topdir, duplicate;
+    pmix_list_t cachedirs, cachefiles;
+    pmix_epilog_t *epi;
+    pmix_cleanup_file_t *cf, *cf2;
+    pmix_cleanup_dir_t *cdir, *cdir2;
+    struct stat statbuf;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd job control request from client");
@@ -2114,6 +2121,22 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
             goto exit;
         }
     }
+
+    /* check targets to find proper place to put any epilog requests */
+    if (NULL == cd->targets) {
+        epi = &peer->nptr->epilog;
+    } else if (1 == cd->ntargets) {
+        if (0 == strncmp(cd->targets[0].nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN)) {
+            if (PMIX_RANK_WILDCARD == cd->targets[0].rank) {
+                epi = &peer->nptr->epilog;
+            } else {
+                epi = &peer->epilog;
+            }
+        }
+    } else {
+        epi = NULL;  // do not allow epilog requests
+    }
+
     /* unpack the number of info objects */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
@@ -2129,6 +2152,173 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto exit;
+        }
+    }
+
+    /* if this includes a request for post-termination cleanup, we handle
+     * that request ourselves */
+    PMIX_CONSTRUCT(&cachedirs, pmix_list_t);
+    PMIX_CONSTRUCT(&cachefiles, pmix_list_t);
+    cnt = 0;  // track how many infos are cleanup related
+    for (n=0; n < cd->ninfo; n++) {
+        if (0 == strncmp(cd->info[n].key, PMIX_REGISTER_CLEANUP, PMIX_MAX_KEYLEN)) {
+            ++cnt;
+            /* see if we allow epilog requests */
+            if (NULL == epi) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            if (PMIX_STRING != cd->info[n].value.type ||
+                NULL == cd->info[n].value.data.string) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            if (0 != stat(cd->info[n].value.data.string, &statbuf)) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            if (S_ISDIR(statbuf.st_mode)) {
+                cdir = PMIX_NEW(pmix_cleanup_dir_t);
+                if (NULL == cdir) {
+                    /* return an error */
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
+                }
+                cdir->path = strdup(cd->info[n].value.data.string);
+                pmix_list_append(&cachedirs, &cdir->super);
+            } else {
+                cf = PMIX_NEW(pmix_cleanup_file_t);
+                if (NULL == cf) {
+                    /* return an error */
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
+                }
+                cf->path = strdup(cd->info[n].value.data.string);
+                pmix_list_append(&cachefiles, &cf->super);
+            }
+        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_RECURSIVE, PMIX_MAX_KEYLEN)) {
+            /* see if we allow epilog requests */
+            if (NULL == epi) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            recurse = PMIX_INFO_TRUE(&cd->info[n]);
+            ++cnt;
+        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_IGNORE, PMIX_MAX_KEYLEN)) {
+            if (PMIX_STRING != cd->info[n].value.type ||
+                NULL == cd->info[n].value.data.string) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            /* see if we allow epilog requests */
+            if (NULL == epi) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            /* scan the list of ignores for any duplicate */
+            duplicate = false;
+            PMIX_LIST_FOREACH(cf, &epi->ignores, pmix_cleanup_file_t) {
+                if (0 == strcmp(cf->path, cd->info[n].value.data.string)) {
+                    /* we can drop this request */
+                    duplicate = true;
+                    break;
+                }
+            }
+            if (!duplicate) {
+                cf = PMIX_NEW(pmix_cleanup_file_t);
+                if (NULL == cf) {
+                    /* return an error */
+                    rc = PMIX_ERR_NOMEM;
+                    goto exit;
+                }
+                cf->path = strdup(cd->info[n].value.data.string);
+                pmix_list_append(&epi->ignores, &cf->super);
+            }
+            ++cnt;
+        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_LEAVE_TOPDIR, PMIX_MAX_KEYLEN)) {
+            /* see if we allow epilog requests */
+            if (NULL == epi) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
+            }
+            leave_topdir = PMIX_INFO_TRUE(&cd->info[n]);
+            ++cnt;
+        }
+    }
+    if (0 < cnt) {
+        while (NULL != (cdir = (pmix_cleanup_dir_t*)pmix_list_remove_first(&cachedirs))) {
+            /* scan the existing list of directories for any duplicate */
+            PMIX_LIST_FOREACH(cdir2, &epi->cleanup_dirs, pmix_cleanup_dir_t) {
+                if (0 == strcmp(cdir2->path, cdir->path)) {
+                    /* duplicate - check for difference in flags per RFC
+                     * precedence rules */
+                    if (!cdir->recurse && recurse) {
+                        cdir->recurse = recurse;
+                    }
+                    if (!cdir->leave_topdir && leave_topdir) {
+                        cdir->leave_topdir = leave_topdir;
+                    }
+                    PMIX_RELEASE(cdir);
+                    cdir = NULL;
+                    break;
+                }
+            }
+            if (NULL != cdir) {
+                /* check for conflict with ignore */
+                PMIX_LIST_FOREACH(cf, &epi->ignores, pmix_cleanup_file_t) {
+                    if (0 == strcmp(cf->path, cdir->path)) {
+                        /* return an error */
+                        rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+                        PMIX_LIST_DESTRUCT(&cachedirs);
+                        PMIX_LIST_DESTRUCT(&cachefiles);
+                        goto exit;
+                    }
+                }
+                cdir->recurse = recurse;
+                cdir->leave_topdir = leave_topdir;
+                /* just append it to the end of the list */
+                pmix_list_append(&epi->cleanup_dirs, &cdir->super);
+            }
+        }
+        PMIX_DESTRUCT(&cachedirs);
+        while (NULL != (cf = (pmix_cleanup_file_t*)pmix_list_remove_first(&cachefiles))) {
+            /* scan the existing list of files for any duplicate */
+            PMIX_LIST_FOREACH(cf2, &epi->cleanup_files, pmix_cleanup_file_t) {
+                if (0 == strcmp(cf2->path, cf->path)) {
+                    PMIX_RELEASE(cf);
+                    cf = NULL;
+                    break;
+                }
+            }
+            if (NULL != cf) {
+                /* check for conflict with ignore */
+                PMIX_LIST_FOREACH(cf2, &epi->ignores, pmix_cleanup_file_t) {
+                    if (0 == strcmp(cf->path, cf2->path)) {
+                        /* return an error */
+                        rc = PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES;
+                        PMIX_LIST_DESTRUCT(&cachedirs);
+                        PMIX_LIST_DESTRUCT(&cachefiles);
+                        goto exit;
+                    }
+                }
+                /* just append it to the end of the list */
+                pmix_list_append(&epi->cleanup_files, &cf->super);
+            }
+        }
+        PMIX_DESTRUCT(&cachefiles);
+        if (cnt == (int)cd->ninfo) {
+            /* nothing more to do */
+            if (NULL != cbfunc) {
+                cbfunc(PMIX_SUCCESS, NULL, 0, cd, NULL, NULL);
+            }
+            return PMIX_SUCCESS;
         }
     }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2090,7 +2090,6 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
     pmix_epilog_t *epi;
     pmix_cleanup_file_t *cf, *cf2;
     pmix_cleanup_dir_t *cdir, *cdir2;
-    struct stat statbuf;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd job control request from client");
@@ -2175,30 +2174,36 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            if (0 != stat(cd->info[n].value.data.string, &statbuf)) {
+            cf = PMIX_NEW(pmix_cleanup_file_t);
+            if (NULL == cf) {
+                /* return an error */
+                rc = PMIX_ERR_NOMEM;
+                goto exit;
+            }
+            cf->path = strdup(cd->info[n].value.data.string);
+            pmix_list_append(&cachefiles, &cf->super);
+        } else if (0 == strncmp(cd->info[n].key, PMIX_REGISTER_CLEANUP_DIR, PMIX_MAX_KEYLEN)) {
+            ++cnt;
+            /* see if we allow epilog requests */
+            if (NULL == epi) {
                 /* return an error */
                 rc = PMIX_ERR_BAD_PARAM;
                 goto exit;
             }
-            if (S_ISDIR(statbuf.st_mode)) {
-                cdir = PMIX_NEW(pmix_cleanup_dir_t);
-                if (NULL == cdir) {
-                    /* return an error */
-                    rc = PMIX_ERR_NOMEM;
-                    goto exit;
-                }
-                cdir->path = strdup(cd->info[n].value.data.string);
-                pmix_list_append(&cachedirs, &cdir->super);
-            } else {
-                cf = PMIX_NEW(pmix_cleanup_file_t);
-                if (NULL == cf) {
-                    /* return an error */
-                    rc = PMIX_ERR_NOMEM;
-                    goto exit;
-                }
-                cf->path = strdup(cd->info[n].value.data.string);
-                pmix_list_append(&cachefiles, &cf->super);
+            if (PMIX_STRING != cd->info[n].value.type ||
+                NULL == cd->info[n].value.data.string) {
+                /* return an error */
+                rc = PMIX_ERR_BAD_PARAM;
+                goto exit;
             }
+            cdir = PMIX_NEW(pmix_cleanup_dir_t);
+            if (NULL == cdir) {
+                /* return an error */
+                rc = PMIX_ERR_NOMEM;
+                goto exit;
+            }
+            cdir->path = strdup(cd->info[n].value.data.string);
+            pmix_list_append(&cachedirs, &cdir->super);
         } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_RECURSIVE, PMIX_MAX_KEYLEN)) {
             /* see if we allow epilog requests */
             if (NULL == epi) {

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -171,6 +171,8 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
         return "PMIX MODEL DECLARED";
     case PMIX_ERR_TEMP_UNAVAILABLE:
         return "PMIX TEMPORARILY UNAVAILABLE";
+    case PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES:
+        return "PMIX CONFLICTING CLEANUP DIRECTIVES";
     case PMIX_SUCCESS:
         return "SUCCESS";
     default:


### PR DESCRIPTION
Application processes frequently need to create temporary files and directories (e.g., for shared memory backing) that need to be cleaned up upon termination. This RFC provides a mechanism by which the process can register a file or directory for post-termination cleanup by the PMIx server.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>