### PR TITLE
Implementation of RFC0025 "IO Forwarding for Tools and Debuggers".

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ examples/dmodex
 examples/dynamic
 examples/fault
 examples/jctrl
+examples/pmix1client
 examples/pub
 examples/server
 examples/tool

--- a/VERSION
+++ b/VERSION
@@ -30,7 +30,7 @@ greek=
 # command, or with the date (if "git describe" fails) in the form of
 # "date<date>".
 
-repo_rev=git56e0795
+repo_rev=git1a2327c
 
 # If tarball_version is not empty, it is used as the version string in
 # the tarball filename, regardless of all other versions listed in
@@ -44,7 +44,7 @@ tarball_version=
 
 # The date when this release was created
 
-date="Jul 14, 2017"
+date="Jan 12, 2018"
 
 # The shared library version of each of PMIx's public libraries.
 # These versions are maintained in accordance with the "Library

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -17,7 +17,7 @@ dnl Copyright (c) 2009      Los Alamos National Security, LLC.  All rights
 dnl                         reserved.
 dnl Copyright (c) 2009-2011 Oak Ridge National Labs.  All rights reserved.
 dnl Copyright (c) 2011-2013 NVIDIA Corporation.  All rights reserved.
-dnl Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
 dnl Copyright (c) 2015-2017 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -626,7 +626,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/contrib/pmix-valgrind.supp
+++ b/contrib/pmix-valgrind.supp
@@ -1,6 +1,6 @@
 # -*- text -*-
 #
-# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -44,5 +44,3 @@
    fun:PMIx_init
    fun:main
 }
-
-

--- a/examples/debuggerd.c
+++ b/examples/debuggerd.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -41,6 +41,7 @@ typedef struct {
 } myquery_data_t;
 
 
+static volatile bool waiting_for_debugger = true;
 static pmix_proc_t myproc;
 
 /* this is a callback function for the PMIx_Query
@@ -133,6 +134,11 @@ int main(int argc, char **argv)
     size_t nq, n;
     myquery_data_t myquery_data;
 
+fprintf(stderr, "I AM HERE\n");
+fflush(stderr);
+    sleep(10);
+    exit(0);
+
     /* init us - since we were launched by the RM, our connection info
      * will have been provided at startup. */
     if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, NULL, 0))) {
@@ -210,7 +216,7 @@ int main(int argc, char **argv)
     n = 0;
     fprintf(stderr, "[%s:%u] Hanging around awhile, doing debugger magic\n", myproc.nspace, myproc.rank);
     while (n < 5) {
-        usleep(10);
+        usleep(1000);
         ++n;
     }
 

--- a/examples/pmi1client.c
+++ b/examples/pmi1client.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -567,7 +567,6 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
         PMIX_INFO_DESTRUCT(&_in);                                           \
     } while(0)
 
-
 /* Request a credential from the PMIx server/SMS.
  * Input values include:
  *
@@ -631,6 +630,118 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
 PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
                                                    const pmix_info_t info[], size_t ninfo,
                                                    pmix_validation_cbfunc_t cbfunc, void *cbdata);
+
+/* Define a callback function for delivering forwarded IO to a process
+ * This function will be called whenever data becomes available, or a
+ * specified buffering size and/or time has been met. The function
+ * will be passed the following values:
+ *
+ * iofhdlr - the returned registration number of the handler being invoked.
+ *           This is required when deregistering the handler.
+ *
+ * channel - a bitmask identifying the channel the data arrived on
+ *
+ * source - the nspace/rank of the process that generated the data
+ *
+ * payload - pointer to character array containing the data. Note that
+ *           multiple strings may be included, and that the array may
+ *           _not_ be NULL terminated
+ *
+ * info - an optional array of info provided by the source containing
+ *        metadata about the payload. This could include PMIX_IOF_COMPLETE
+ *
+ * ninfo - number of elements in the optional info array
+ */
+ typedef void (*pmix_iof_cbfunc_t)(size_t iofhdlr, pmix_iof_channel_t channel,
+                                   pmix_proc_t *source, char *payload,
+                                   pmix_info_t info[], size_t ninfo);
+
+
+/* Register to receive output forwarded from a remote process.
+ *
+ * procs - array of identifiers for sources whose IO is being
+ *         requested. Wildcard rank indicates that all procs
+ *         in the specified nspace are included in the request
+ *
+ * nprocs - number of identifiers in the procs array
+ *
+ * directives - optional array of attributes to control the
+ *              behavior of the request. For example, this
+ *              might include directives on buffering IO
+ *              before delivery, and/or directives to include
+ *              or exclude any backlogged data
+ *
+ * ndirs - number of elements in the directives array
+ *
+ * channel - bitmask of IO channels included in the request.
+ *           NOTE: STDIN is not supported as it will always
+ *           be delivered to the stdin file descriptor
+ *
+ * cbfunc - function to be called when relevant IO is received
+ *
+ * regcbfunc - since registration is async, this is the
+ *             function to be called when registration is
+ *             completed. The function itself will return
+ *             a non-success error if the registration cannot
+ *             be submitted - in this case, the regcbfunc
+ *             will _not_ be called.
+ *
+ * cbdata - pointer to object to be returned in regcbfunc
+ */
+PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
+                                        const pmix_info_t directives[], size_t ndirs,
+                                        pmix_iof_channel_t channel, pmix_iof_cbfunc_t cbfunc,
+                                        pmix_hdlr_reg_cbfunc_t regcbfunc, void *regcbdata);
+
+/* Deregister from output forwarded from a remote process.
+ *
+ * iofhdlr - the registration number returned from the
+ *           call to PMIx_IOF_pull
+ *
+ * directives - optional array of attributes to control the
+ *              behavior of the request. For example, this
+ *              might include directives regarding what to
+ *              do with any data currently in the IO buffer
+ *              for this process
+ *
+ * cbfunc - function to be called when deregistration has
+ *          been completed. Note that any IO to be flushed
+ *          may continue to be received after deregistration
+ *          has completed.
+ *
+ * cbdata - pointer to object to be returned in cbfunc
+ */
+PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Push data collected locally (typically from stdin) to
+ * target recipients.
+ *
+ * targets - array of process identifiers to which the data is to be delivered. Note
+ *           that a WILDCARD rank indicates that all procs in the given nspace are
+ *           to receive a copy of the data
+ *
+ * ntargets - number of procs in the targets array
+ *
+ * directives - optional array of attributes to control the
+ *              behavior of the request. For example, this
+ *              might include directives on buffering IO
+ *              before delivery, and/or directives to include
+ *              or exclude any backlogged data
+ *
+ * ndirs - number of elements in the directives array
+ *
+ * bo - pointer to a byte object containing the stdin data
+ *
+ * cbfunc - callback function when the data has been forwarded
+ *
+ * cbdata - object to be returned in cbfunc
+ */
+PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
+                                        pmix_byte_object_t *bo,
+                                        const pmix_info_t directives[], size_t ndirs,
+                                        pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
 #if defined(c_plusplus) || defined(__cplusplus)

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -147,6 +147,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_CONNECT_RETRY_DELAY            "pmix.tool.retry"       // (uint32_t) time in seconds between connection attempts
 #define PMIX_TOOL_DO_NOT_CONNECT            "pmix.tool.nocon"       // (bool) the tool wants to use internal PMIx support, but does
                                                                     //        not want to connect to a PMIx server
+                                                                    //        from the specified processes to this tool
 
 /* identification attributes */
 #define PMIX_USERID                         "pmix.euid"             // (uint32_t) effective user id
@@ -220,7 +221,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_LOCAL_CPUSETS                  "pmix.lcpus"            // (char*) colon-delimited cpusets of local peers within the specified nspace
 #define PMIX_PROC_URI                       "pmix.puri"             // (char*) URI containing contact info for proc
 #define PMIX_LOCALITY                       "pmix.loc"              // (uint16_t) relative locality of two procs
-#define PMIX_PARENT_ID                      "pmix.parent"           // (pmix_proc_t) process identifier of my parent process
+#define PMIX_PARENT_ID                      "pmix.parent"           // (pmix_proc_t*) identifier of the process that called PMIx_Spawn
+                                                                    //                to launch this proc's application
+
 
 /* size info */
 #define PMIX_UNIV_SIZE                      "pmix.univ.size"        // (uint32_t) #procs in this nspace
@@ -324,7 +327,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_WANT_TERMINATION         "pmix.evterm"           // (bool) indicates that the handler has determined that the application should be terminated
 
 
-/* attributes used to describe "spawn" attributes */
+/* attributes used to describe "spawn" directives */
 #define PMIX_PERSONALITY                    "pmix.pers"             // (char*) name of personality to use
 #define PMIX_HOST                           "pmix.host"             // (char*) comma-delimited list of hosts to use for spawned procs
 #define PMIX_HOSTFILE                       "pmix.hostfile"         // (char*) hostfile to use for spawned procs
@@ -341,10 +344,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PRELOAD_BIN                    "pmix.preloadbin"       // (bool) preload binaries
 #define PMIX_PRELOAD_FILES                  "pmix.preloadfiles"     // (char*) comma-delimited list of files to pre-position
 #define PMIX_NON_PMI                        "pmix.nonpmi"           // (bool) spawned procs will not call PMIx_Init
-#define PMIX_STDIN_TGT                      "pmix.stdin"            // (uint32_t) spawned proc rank that is to receive stdin
-#define PMIX_FWD_STDIN                      "pmix.fwd.stdin"        // (bool) forward my stdin to the designated proc
-#define PMIX_FWD_STDOUT                     "pmix.fwd.stdout"       // (bool) forward stdout from spawned procs to me
-#define PMIX_FWD_STDERR                     "pmix.fwd.stderr"       // (bool) forward stderr from spawned procs to me
+#define PMIX_STDIN_TGT                      "pmix.stdin"            // (pmix_proc_t) proc that is to receive stdin
+                                                                    //               (PMIX_RANK_WILDCARD = all in given nspace)
 #define PMIX_DEBUGGER_DAEMONS               "pmix.debugger"         // (bool) spawned app consists of debugger daemons
 #define PMIX_COSPAWN_APP                    "pmix.cospawn"          // (bool) designated app is to be spawned as a disconnected
                                                                     //        job - i.e., not part of the "comm_world" of the job
@@ -364,6 +365,11 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_JOB_CONTINUOUS                 "pmix.continuous"       // (bool) application is continuous, all failed procs should
                                                                         //        be immediately restarted
 #define PMIX_MAX_RESTARTS                   "pmix.maxrestarts"      // (uint32_t) max number of times to restart a job
+#define PMIX_FWD_STDIN                      "pmix.fwd.stdin"        // (bool) forward the stdin from this process to the spawned processes
+#define PMIX_FWD_STDOUT                     "pmix.fwd.stdout"       // (bool) forward stdout from the spawned processes to this process (typically used by a tool)
+#define PMIX_FWD_STDERR                     "pmix.fwd.stderr"       // (bool) forward stderr from the spawned processes to this process (typically used by a tool)
+#define PMIX_FWD_STDDIAG                    "pmix.fwd.stddiag"      // (bool) if a diagnostic channel exists, forward any output on it
+                                                                    //        from the spawned processes to this process (typically used by a tool)
 
 
 /* connect attributes */
@@ -416,6 +422,11 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_DEBUG_WAIT_FOR_NOTIFY          "pmix.dbg.notify"       // (bool) block at desired point until receiving debugger release notification
 #define PMIX_DEBUG_JOB                      "pmix.dbg.job"          // (char*) nspace of the job to be debugged - the RM/PMIx server are
 #define PMIX_DEBUG_WAITING_FOR_NOTIFY       "pmix.dbg.waiting"      // (bool) job to be debugged is waiting for a release
+#define PMIX_PREPEND_LD_PRELOAD             "pmix.prepend.preload"  // (char*) prepend the named library to any existing
+                                                                    //         LD_PRELOAD directive
+#define PMIX_APPEND_LD_PRELOAD              "pmix.append.preload"   // (char*) append the named library to any existing
+                                                                    //         LD_PRELOAD directive
+
 
 /* Resource Manager identification */
 #define PMIX_RM_NAME                        "pmix.rm.name"          // (char*) string name of the resource manager
@@ -501,6 +512,26 @@ typedef uint32_t pmix_rank_t;
                                                                     // may be available. When returned in a callback function, a
                                                                     // string identifier of the credential type
 
+/* IO Forwarding Attributes */
+#define PMIX_IOF_CACHE_SIZE        "pmix.iof.csize"       // (uint32_t) requested size of the server cache in bytes for each specified channel.
+                                                          //            By default, the server is allowed (but not required) to drop
+                                                          //            all bytes received beyond the max size
+#define PMIX_IOF_DROP_OLDEST       "pmix.iof.old"         // (bool) in an overflow situation, drop the oldest bytes to make room in the cache
+#define PMIX_IOF_DROP_NEWEST       "pmix.iof.new"         // (bool) in an overflow situation, drop any new bytes received until room becomes
+                                                          //        available in the cache (default)
+#define PMIX_IOF_BUFFERING_SIZE    "pmix.iof.bsize"       // (uint32_t) basically controls grouping of IO on the specified channel(s) to
+                                                          //            avoid being called every time a bit of IO arrives. The library
+                                                          //            will execute the callback whenever the specified number of bytes
+                                                          //            becomes available. Any remaining buffered data will be "flushed"
+                                                          //            upon call to deregister the respective channel
+#define PMIX_IOF_BUFFERING_TIME    "pmix.iof.btime"       // (uint32_t) max time in seconds to buffer IO before delivering it. Used in conjunction
+                                                          //            with buffering size, this prevents IO from being held indefinitely
+                                                          //            while waiting for another payload to arrive
+#define PMIX_IOF_COMPLETE          "pmix.iof.cmp"         // (bool) indicates whether or not the specified IO channel has been closed
+                                                          //        by the source
+#define PMIX_IOF_PUSH_STDIN        "pmix.iof.stdin"       // (bool) Used by a tool to request that the PMIx library collect
+                                                          //        the tool's stdin and forward it to the procs specified in
+                                                          //        the PMIx_IOF_push call
 
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;
@@ -720,6 +751,8 @@ typedef uint16_t pmix_data_type_t;
 #define PMIX_ALLOC_DIRECTIVE    43
 /**** DEPRECATED ****/
 #define PMIX_INFO_ARRAY         44
+/****            ****/
+#define PMIX_IOF_CHANNEL        45
 /********************/
 
 /* define a boundary for implementers so they can add their own data types */
@@ -786,11 +819,32 @@ typedef uint8_t pmix_alloc_directive_t;
 #define PMIX_ALLOC_EXTERNAL     128
 
 
+/* define a set of bit-mask flags for specifying IO
+ * forwarding channels. These can be OR'd together
+ * to reference multiple channels */
+typedef uint16_t pmix_iof_channel_t;
+#define PMIX_FWD_NO_CHANNELS        0x0000
+#define PMIX_FWD_STDIN_CHANNEL      0x0001
+#define PMIX_FWD_STDOUT_CHANNEL     0x0002
+#define PMIX_FWD_STDERR_CHANNEL     0x0004
+#define PMIX_FWD_STDDIAG_CHANNEL    0x0008
+#define PMIX_FWD_ALL_CHANNELS       0x00ff
+
+
 /****    PMIX BYTE OBJECT    ****/
 typedef struct pmix_byte_object {
     char *bytes;
     size_t size;
 } pmix_byte_object_t;
+
+#define PMIX_BYTE_OBJECT_CREATE(m, n)   \
+    do {                                \
+        (m) = (pmix_byte_object_t*)malloc((n) * sizeof(pmix_byte_object_t));   \
+        if (NULL != (m)) {                                                     \
+            memset((m), 0, (n)*sizeof(pmix_byte_object_t));                    \
+        }                                                                      \
+    } while(0)
+
 #define PMIX_BYTE_OBJECT_CONSTRUCT(m)   \
     do {                                \
         (m)->bytes = NULL;              \
@@ -1629,14 +1683,19 @@ typedef void (*pmix_notification_fn_t)(size_t evhdlr_registration_id,
                                        pmix_event_notification_cbfunc_fn_t cbfunc,
                                        void *cbdata);
 
-/* define a callback function for calls to PMIx_Register_evhdlr. The
- * status indicates if the request was successful or not, evhdlr_ref is
- * an integer reference assigned to the event handler by PMIx, this reference
- * must be used to deregister the err handler. A ptr to the original
- * cbdata is returned. */
-typedef void (*pmix_evhdlr_reg_cbfunc_t)(pmix_status_t status,
-                                         size_t evhdlr_ref,
-                                         void *cbdata);
+/* define a callback function for calls to register handlers, e.g., event
+ * notification and IOF requests
+ *
+ * status - PMIX_SUCCESS or an appropriate error constant
+ *
+ * refid - reference identifier assigned to the handler by PMIx,
+ *         used to deregister the handler
+ *
+ * cbdata - object provided to the registration call
+ */
+typedef void (*pmix_hdlr_reg_cbfunc_t)(pmix_status_t status,
+                                       size_t refid,
+                                       void *cbdata);
 
 /* define a callback function for calls to PMIx_Get_nb. The status
  * indicates if the requested data was found or not - a pointer to the
@@ -1761,7 +1820,7 @@ typedef void (*pmix_validation_cbfunc_t)(pmix_status_t status,
 PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
                                              pmix_info_t info[], size_t ninfo,
                                              pmix_notification_fn_t evhdlr,
-                                             pmix_evhdlr_reg_cbfunc_t cbfunc,
+                                             pmix_hdlr_reg_cbfunc_t cbfunc,
                                              void *cbdata);
 
 /* Deregister an event handler
@@ -1819,6 +1878,7 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
  * - pmix_info_directives_t   (PMIX_INFO_DIRECTIVES)
  * - pmix_data_type_t   (PMIX_DATA_TYPE)
  * - pmix_alloc_directive_t  (PMIX_ALLOC_DIRECTIVE)
+ * - pmix_iof_channel_t  (PMIX_IOF_CHANNEL)
  */
 PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t status);
 PMIX_EXPORT const char* PMIx_Proc_state_string(pmix_proc_state_t state);
@@ -1828,6 +1888,7 @@ PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range);
 PMIX_EXPORT const char* PMIx_Info_directives_string(pmix_info_directives_t directives);
 PMIX_EXPORT const char* PMIx_Data_type_string(pmix_data_type_t type);
 PMIX_EXPORT const char* PMIx_Alloc_directive_string(pmix_alloc_directive_t directive);
+PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel);
 
 /* Get the PMIx version string. Note that the provided string is
  * statically defined and must NOT be free'd  */

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -414,6 +414,74 @@ typedef pmix_status_t (*pmix_server_validate_cred_fn_t)(const pmix_proc_t *proc,
                                                         const pmix_info_t directives[], size_t ndirs,
                                                         pmix_validation_cbfunc_t cbfunc, void *cbdata);
 
+/* Request the specified IO channels be forwarded from the given array of procs.
+ * The function shall return PMIX_SUCCESS once the host RM accepts the request for
+ * processing, or a PMIx error code if the request itself isn't correct or supported.
+ * The callback function shall be called when the request has been processed,
+ * returning either PMIX_SUCCESS to indicate that IO shall be forwarded as requested,
+ * or some appropriate error code if the request has been denied.
+ *
+ * NOTE: STDIN is not supported in this call! The forwarding of stdin is a "push"
+ * process - procs cannot request that it be "pulled" from some other source
+ *
+ * procs - array of process identifiers whose IO is being requested.
+ *
+ * nprocs - size of the procs array
+ *
+ * directives - array of key-value attributes further defining the request. This
+ *              might include directives on buffering and security credentials for
+ *              access to protected channels
+ *
+ * ndirs - size of the directives array
+ *
+ * channels - bitmask identifying the channels to be forwarded
+ *
+ * cbfunc - callback function when the IO forwarding has been setup
+ *
+ * cbdata - object to be returned in cbfunc
+ *
+ * This call serves as a registration with the host RM for the given IO channels from
+ * the specified procs - the host RM is expected to ensure that this local PMIx server
+ * is on the distribution list for the channel/proc combination
+ */
+typedef pmix_status_t (*pmix_server_iof_fn_t)(const pmix_proc_t procs[], size_t nprocs,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_iof_channel_t channels,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Passes stdin to the host RM for transmission to specified recipients. The host RM is
+ * responsible for forwarding the data to all PMIx servers that host the specified
+ * target.
+ *
+ * source - pointer to the identifier of the process whose stdin is being provided
+ *
+ * targets - array of process identifiers to which the data is to be delivered. Note
+ *           that a WILDCARD rank indicates that all procs in the given nspace are
+ *           to receive a copy of the data
+ *
+ * ntargets - number of procs in the targets array
+ *
+ * directives - array of key-value attributes further defining the request. This
+ *              might include directives on buffering and security credentials for
+ *              access to protected channels
+ *
+ * ndirs - size of the directives array
+ *
+ * bo - pointer to a byte object containing the stdin data
+ *
+ * cbfunc - callback function when the data has been forwarded
+ *
+ * cbdata - object to be returned in cbfunc
+ *
+ */
+
+typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
+                                                const pmix_proc_t targets[], size_t ntargets,
+                                                const pmix_info_t directives[], size_t ndirs,
+                                                const pmix_byte_object_t *bo,
+                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+
 typedef struct pmix_server_module_2_0_0_t {
     /* v1x interfaces */
     pmix_server_client_connected_fn_t   client_connected;
@@ -441,9 +509,11 @@ typedef struct pmix_server_module_2_0_0_t {
     /* v3x interfaces */
     pmix_server_get_cred_fn_t           get_credential;
     pmix_server_validate_cred_fn_t      validate_credential;
+    pmix_server_iof_fn_t                iof_pull;
+    pmix_server_stdin_fn_t              push_stdin;
 } pmix_server_module_t;
 
-/****    SERVER SUPPORT INIT/FINALIZE FUNCTIONS    ****/
+/****    HOST RM FUNCTIONS FOR INTERFACE TO PMIX SERVER    ****/
 
 /* Initialize the server support library, and provide a
  * pointer to a pmix_server_module_t structure
@@ -610,6 +680,38 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
 PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const char nspace[],
                                                           pmix_info_t info[], size_t ninfo,
                                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Provide a function by which the host RM can pass forwarded IO
+ * to the local PMIx server for distribution to its clients. The
+ * PMIx server is responsible for determining which of its clients
+ * have actually registered for the provided data
+ *
+ * Parameters include:
+ *
+ * source - the process that provided the data being forwarded
+ *
+ * channel - the IOF channel (stdin, stdout, etc.)
+ *
+ * bo - a byte object containing the data
+ *
+ * info - an optional array of metadata describing the data, including
+ *        attributes such as PMIX_IOF_COMPLETE to indicate that the
+ *        source channel has been closed
+ *
+ * ninfo - number of elements in the info array
+ *
+ * cbfunc - a callback function to be executed once the provided data
+ *          is no longer required. The host RM is required to retain
+ *          the byte object until the callback is executed, or a
+ *          non-success status is returned by the function
+ *
+ * cbdata - object pointer to be returned in the callback function
+ */
+PMIX_EXPORT pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
+                                                  pmix_iof_channel_t channel,
+                                                  const pmix_byte_object_t *bo,
+                                                  const pmix_info_t info[], size_t ninfo,
+                                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_tool.h
+++ b/include/pmix_tool.h
@@ -98,6 +98,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_init(pmix_proc_t *proc,
  * operation. */
 PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void);
 
+
 #if defined(c_plusplus) || defined(__cplusplus)
 }
 #endif

--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,11 +44,10 @@ static void local_eviction_callback(int fd, short flags, void *arg)
 }
 
 
-int pmix_hotel_init(pmix_hotel_t *h, int num_rooms,
-                    pmix_event_base_t *evbase,
-                    uint32_t eviction_timeout,
-                    int eviction_event_priority,
-                    pmix_hotel_eviction_callback_fn_t evict_callback_fn)
+pmix_status_t pmix_hotel_init(pmix_hotel_t *h, int num_rooms,
+                              pmix_event_base_t *evbase,
+                              uint32_t eviction_timeout,
+                              pmix_hotel_eviction_callback_fn_t evict_callback_fn)
 {
     int i;
 

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,7 +142,6 @@ PMIX_CLASS_DECLARATION(pmix_hotel_t);
  * @param evbase Pointer to event base used for eviction timeout
  * @param eviction_timeout Max length of a stay at the hotel before
  * the eviction callback is invoked (in microseconds)
- * @param eviction_event_priority Event lib priority for the eviction timeout
  * @param evict_callback_fn Callback function invoked if an occupant
  * does not check out before the eviction_timeout.
  *
@@ -158,11 +157,10 @@ PMIX_CLASS_DECLARATION(pmix_hotel_t);
  * @return PMIX_SUCCESS if all initializations were succesful. Otherwise,
  *  the error indicate what went wrong in the function.
  */
-PMIX_EXPORT int pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
-                                  pmix_event_base_t *evbase,
-                                  uint32_t eviction_timeout,
-                                  int eviction_event_priority,
-                                  pmix_hotel_eviction_callback_fn_t evict_callback_fn);
+PMIX_EXPORT pmix_status_t pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
+                                          pmix_event_base_t *evbase,
+                                          uint32_t eviction_timeout,
+                                          pmix_hotel_eviction_callback_fn_t evict_callback_fn);
 
 /**
  * Check in an occupant to the hotel.
@@ -184,9 +182,9 @@ PMIX_EXPORT int pmix_hotel_init(pmix_hotel_t *hotel, int num_rooms,
  * @return PMIX_ERR_TEMP_OUT_OF_RESOURCE is the hotel is full.  Try
  * again later.
  */
-static inline int pmix_hotel_checkin(pmix_hotel_t *hotel,
-                                     void *occupant,
-                                     int *room_num)
+static inline pmix_status_t pmix_hotel_checkin(pmix_hotel_t *hotel,
+                                               void *occupant,
+                                               int *room_num)
 {
     pmix_hotel_room_t *room;
 
@@ -214,8 +212,8 @@ static inline int pmix_hotel_checkin(pmix_hotel_t *hotel,
  * caller *knows* that there is a room available.
  */
 static inline void pmix_hotel_checkin_with_res(pmix_hotel_t *hotel,
-                                     void *occupant,
-                                     int *room_num)
+                                               void *occupant,
+                                               int *room_num)
 {
     pmix_hotel_room_t *room;
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -75,6 +75,7 @@ static const char pmix_version_string[] = PMIX_VERSION;
 #include "src/mca/preg/preg.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/include/pmix_globals.h"
+#include "src/common/pmix_iof.h"
 
 #include "pmix_client_ops.h"
 
@@ -342,6 +343,53 @@ static void _check_for_notify(pmix_info_t info[], size_t ninfo)
     }
 }
 
+static void client_iof_handler(struct pmix_peer_t *pr,
+                               pmix_ptl_hdr_t *hdr,
+                               pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_peer_t *peer = (pmix_peer_t*)pr;
+    pmix_proc_t source;
+    pmix_iof_channel_t channel;
+    pmix_byte_object_t bo;
+    int32_t cnt;
+    pmix_status_t rc;
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "recvd IOF");
+
+    /* if the buffer is empty, they are simply closing the channel */
+    if (0 == buf->bytes_used) {
+        return;
+    }
+
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &source, &cnt, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &channel, &cnt, PMIX_IOF_CHANNEL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &bo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return;
+    }
+    if (NULL != bo.bytes && 0 < bo.size) {
+        if (channel & PMIX_FWD_STDOUT_CHANNEL) {
+            pmix_iof_write_output(&source, channel, &bo, &pmix_client_globals.iof_stdout.wev);
+        } else {
+            pmix_iof_write_output(&source, channel, &bo, &pmix_client_globals.iof_stderr.wev);
+        }
+    }
+    PMIX_BYTE_OBJECT_DESTRUCT(&bo);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
                                     pmix_info_t info[], size_t ninfo)
 {
@@ -358,6 +406,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     pmix_lock_t reglock;
     size_t n;
     bool found;
+    pmix_ptl_posted_recv_t *rcv;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -394,6 +443,13 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return rc;
     }
+    /* setup the IO Forwarding recv */
+    rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
+    rcv->tag = PMIX_PTL_TAG_IOF;
+    rcv->cbfunc = client_iof_handler;
+    /* add it to the end of the list of recvs */
+    pmix_list_append(&pmix_ptl_globals.posted_recvs, &rcv->super);
+
 
     /* setup the globals */
     PMIX_CONSTRUCT(&pmix_client_globals.pending_requests, pmix_list_t);
@@ -578,7 +634,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-    /* lood for a debugger attach key */
+    /* look for a debugger attach key */
     (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
     PMIX_INFO_LOAD(&ginfo, PMIX_OPTIONAL, NULL, PMIX_BOOL);
@@ -587,6 +643,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         /* if the value was found, then we need to wait for debugger attach here */
         /* register for the debugger release notification */
         PMIX_CONSTRUCT_LOCK(&reglock);
+        PMIX_POST_OBJECT(&reglock);
         PMIx_Register_event_handler(&code, 1, NULL, 0,
                                     notification_fn, NULL, (void*)&reglock);
         /* wait for it to arrive */

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,6 +17,7 @@
 #include "src/class/pmix_list.h"
 #include "src/class/pmix_pointer_array.h"
 #include "src/include/pmix_globals.h"
+#include "src/common/pmix_iof.h"
 
 BEGIN_C_DECLS
 
@@ -42,9 +43,15 @@ typedef struct {
     // verbosity for client event operations
     int event_output;
     int event_verbose;
+    // verbosity for client iof operations
+    int iof_output;
+    int iof_verbose;
     // verbosity for basic client functions
     int base_output;
     int base_verbose;
+    /* IOF output sinks */
+    pmix_iof_sink_t iof_stdout;
+    pmix_iof_sink_t iof_stderr;
 } pmix_client_globals_t;
 
 PMIX_EXPORT extern pmix_client_globals_t pmix_client_globals;

--- a/src/common/Makefile.include
+++ b/src/common/Makefile.include
@@ -1,6 +1,6 @@
 # -*- makefile -*-
 #
-# Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
 # Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -15,4 +15,8 @@ sources += \
         common/pmix_log.c \
         common/pmix_control.c \
         common/pmix_data.c \
-        common/pmix_security.c
+        common/pmix_security.c \
+        common/pmix_iof.c
+
+headers += \
+        common/pmix_iof.h

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -1,0 +1,863 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include <src/include/pmix_config.h>
+
+#include <src/include/types.h>
+#include <src/include/pmix_stdint.h>
+#include <src/include/pmix_socket_errno.h>
+
+#include <pmix.h>
+#include <pmix_common.h>
+#include <pmix_server.h>
+#include <pmix_rename.h>
+
+#include "src/threads/threads.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/name_fns.h"
+#include "src/util/output.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/mca/ptl/ptl.h"
+
+#include "src/client/pmix_client_ops.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/include/pmix_globals.h"
+
+static void msgcbfunc(struct pmix_peer_t *peer,
+                       pmix_ptl_hdr_t *hdr,
+                       pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
+    int32_t m;
+    pmix_status_t rc, status;
+
+    /* unpack the return status */
+    m=1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &m, PMIX_STATUS);
+    if (PMIX_SUCCESS == rc && PMIX_SUCCESS == status) {
+        /* store the request on our list - we are in an event, and
+         * so this is safe */
+        pmix_list_append(&pmix_globals.iof_requests, &cd->iofreq->super);
+    } else if (PMIX_SUCCESS != rc) {
+        status = rc;
+        PMIX_RELEASE(cd->iofreq);
+    }
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_register returned status %s", PMIx_Error_string(status));
+
+    if (NULL != cd->cbfunc.opcbfn) {
+        cd->cbfunc.opcbfn(status, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+}
+
+PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs,
+                                        const pmix_info_t directives[], size_t ndirs,
+                                        pmix_iof_channel_t channel, pmix_iof_cbfunc_t cbfunc,
+                                        pmix_hdlr_reg_cbfunc_t regcbfunc, void *regcbdata)
+{
+    pmix_shift_caddy_t *cd;
+    pmix_cmd_t cmd = PMIX_IOF_PULL_CMD;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_register");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we are a server, we cannot do this */
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* we don't allow stdin to flow thru this path */
+    if (PMIX_FWD_STDIN_CHANNEL & channel) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* send this request to the server */
+    cd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->cbfunc.hdlrregcbfn = regcbfunc;
+    cd->cbdata = regcbdata;
+    /* setup the request item */
+    cd->iofreq = PMIX_NEW(pmix_iof_req_t);
+    if (NULL == cd->iofreq) {
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    /* retain the channels and cbfunc */
+    cd->iofreq->channels = channel;
+    cd->iofreq->cbfunc = cbfunc;
+    /* we don't need the source specifications - only the
+    * server cares as it will filter against them */
+
+    /* setup the registration cmd */
+    msg = PMIX_NEW(pmix_buffer_t);
+    if (NULL == msg) {
+        PMIX_RELEASE(cd->iofreq);
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &nprocs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, procs, nprocs, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ndirs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+    if (0 < ndirs) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, directives, ndirs, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto cleanup;
+        }
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &channel, 1, PMIX_IOF_CHANNEL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto cleanup;
+    }
+
+    pmix_output_verbose(2, pmix_client_globals.iof_output,
+                        "pmix:iof_request sending to server");
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, msgcbfunc, (void*)cd);
+
+  cleanup:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cd->iofreq);
+        PMIX_RELEASE(cd);
+    }
+    return rc;
+}
+
+typedef struct {
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_ltcaddy_t;
+
+static void stdincbfunc(struct pmix_peer_t *peer,
+                        pmix_ptl_hdr_t *hdr,
+                        pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_ltcaddy_t *cd = (pmix_ltcaddy_t*)cbdata;
+    int cnt;
+    pmix_status_t rc, status;
+
+    /* a zero-byte buffer indicates that this recv is being
+     * completed due to a lost connection */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        /* release the caller */
+        if (NULL != cd->cbfunc) {
+            cd->cbfunc(PMIX_ERR_COMM_FAILURE, cd->cbdata);
+        }
+        free(cd);
+        return;
+    }
+
+    /* unpack the status */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &status, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        status = rc;
+    }
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(status, cd->cbdata);
+    }
+    free(cd);
+}
+
+pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
+                            pmix_byte_object_t *bo,
+                            const pmix_info_t directives[], size_t ndirs,
+                            pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_IOF_PUSH_CMD;
+    pmix_status_t rc;
+    pmix_ltcaddy_t *cd;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* if we are not a server, then we send the provided
+     * data to our server for processing */
+    if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        msg = PMIX_NEW(pmix_buffer_t);
+        if (NULL == msg) {
+            return PMIX_ERR_NOMEM;
+        }
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, &cmd, 1, PMIX_COMMAND);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, &ntargets, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        if (0 < ntargets) {
+            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                             msg, targets, ntargets, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                return rc;
+            }
+        }
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, &ndirs, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+        if (0 < ndirs) {
+            PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                             msg, directives, ndirs, PMIX_INFO);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                return rc;
+            }
+        }
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, bo, 1, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+
+        cd = (pmix_ltcaddy_t*)malloc(sizeof(pmix_ltcaddy_t));
+        if (NULL == cd) {
+            PMIX_RELEASE(msg);
+            rc = PMIX_ERR_NOMEM;
+            return rc;
+        }
+        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                           msg, stdincbfunc, cd);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            free(cd);
+        }
+        return rc;
+    }
+
+    /* if we are a server, just pass the data up to our host */
+    if (NULL == pmix_host_server.push_stdin) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+    rc = pmix_host_server.push_stdin(&pmix_globals.myid,
+                                     targets, ntargets,
+                                     directives, ndirs,
+                                     bo, cbfunc, cbdata);
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
+                                    pmix_iof_channel_t stream,
+                                    const pmix_byte_object_t *bo,
+                                    pmix_iof_write_event_t *channel)
+{
+    char starttag[PMIX_IOF_BASE_TAG_MAX], endtag[PMIX_IOF_BASE_TAG_MAX], *suffix;
+    pmix_iof_write_output_t *output;
+    size_t i;
+    int j, k, starttaglen, endtaglen, num_buffered;
+    bool endtagged;
+    char qprint[10];
+
+    PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+                         "%s write:output setting up to write %lu bytes to %s for %s on fd %d",
+                         PMIX_NAME_PRINT(&pmix_globals.myid),
+                         (unsigned long)bo->size,
+                         PMIx_IOF_channel_string(stream),
+                         PMIX_NAME_PRINT(name),
+                         (NULL == channel) ? -1 : channel->fd));
+
+    /* setup output object */
+    output = PMIX_NEW(pmix_iof_write_output_t);
+
+    /* write output data to the corresponding tag */
+    if (PMIX_FWD_STDIN_CHANNEL & stream) {
+        /* copy over the data to be written */
+        if (0 < bo->size) {
+            /* don't copy 0 bytes - we just need to pass
+             * the zero bytes so the fd can be closed
+             * after it writes everything out
+             */
+            memcpy(output->data, bo->bytes, bo->size);
+        }
+        output->numbytes = bo->size;
+        goto process;
+    } else if (PMIX_FWD_STDOUT_CHANNEL & stream) {
+        /* write the bytes to stdout */
+        suffix = "stdout";
+    } else if (PMIX_FWD_STDERR_CHANNEL & stream) {
+        /* write the bytes to stderr */
+        suffix = "stderr";
+    } else if (PMIX_FWD_STDDIAG_CHANNEL & stream) {
+        /* write the bytes to stderr */
+        suffix = "stddiag";
+    } else {
+        /* error - this should never happen */
+        PMIX_ERROR_LOG(PMIX_ERR_VALUE_OUT_OF_BOUNDS);
+        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+                             "%s stream %0x", PMIX_NAME_PRINT(&pmix_globals.myid), stream));
+        return PMIX_ERR_VALUE_OUT_OF_BOUNDS;
+    }
+
+    /* if this is to be xml tagged, create a tag with the correct syntax - we do not allow
+     * timestamping of xml output
+     */
+    if (pmix_globals.xml_output) {
+        snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "<%s rank=\"%s\">", suffix, PMIX_RANK_PRINT(name->rank));
+        snprintf(endtag, PMIX_IOF_BASE_TAG_MAX, "</%s>", suffix);
+        goto construct;
+    }
+
+    /* if we are to timestamp output, start the tag with that */
+    if (pmix_globals.timestamp_output) {
+        time_t mytime;
+        char *cptr;
+        /* get the timestamp */
+        time(&mytime);
+        cptr = ctime(&mytime);
+        cptr[strlen(cptr)-1] = '\0';  /* remove trailing newline */
+
+        if (pmix_globals.tag_output) {
+            /* if we want it tagged as well, use both */
+            snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "%s[%s]<%s>:",
+                     cptr, PMIX_NAME_PRINT(name), suffix);
+        } else {
+            /* only use timestamp */
+            snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "%s<%s>:", cptr, suffix);
+        }
+        /* no endtag for this option */
+        memset(endtag, '\0', PMIX_IOF_BASE_TAG_MAX);
+        goto construct;
+    }
+
+    if (pmix_globals.tag_output) {
+        snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "[%s]<%s>:",
+                 PMIX_NAME_PRINT(name), suffix);
+        /* no endtag for this option */
+        memset(endtag, '\0', PMIX_IOF_BASE_TAG_MAX);
+        goto construct;
+    }
+
+    /* if we get here, then the data is not to be tagged - just copy it
+     * and move on to processing
+     */
+    if (0 < bo->size) {
+        /* don't copy 0 bytes - we just need to pass
+         * the zero bytes so the fd can be closed
+         * after it writes everything out
+         */
+        memcpy(output->data, bo->bytes, bo->size);
+    }
+    output->numbytes = bo->size;
+    goto process;
+
+  construct:
+    starttaglen = strlen(starttag);
+    endtaglen = strlen(endtag);
+    endtagged = false;
+    /* start with the tag */
+    for (j=0, k=0; j < starttaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+        output->data[k++] = starttag[j];
+    }
+    /* cycle through the data looking for <cr>
+     * and replace those with the tag
+     */
+    for (i=0; i < bo->size && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; i++) {
+        if (pmix_globals.xml_output) {
+            if ('&' == bo->bytes[i]) {
+                if (k+5 >= PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    goto process;
+                }
+                snprintf(qprint, 10, "&amp;");
+                for (j=0; j < (int)strlen(qprint) && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                    output->data[k++] = qprint[j];
+                }
+            } else if ('<' == bo->bytes[i]) {
+                if (k+4 >= PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    goto process;
+                }
+                snprintf(qprint, 10, "&lt;");
+                for (j=0; j < (int)strlen(qprint) && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                    output->data[k++] = qprint[j];
+                }
+            } else if ('>' == bo->bytes[i]) {
+                if (k+4 >= PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    goto process;
+                }
+                snprintf(qprint, 10, "&gt;");
+                for (j=0; j < (int)strlen(qprint) && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                    output->data[k++] = qprint[j];
+                }
+            } else if (bo->bytes[i] < 32 || bo->bytes[i] > 127) {
+                /* this is a non-printable character, so escape it too */
+                if (k+7 >= PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    goto process;
+                }
+                snprintf(qprint, 10, "&#%03d;", (int)bo->bytes[i]);
+                for (j=0; j < (int)strlen(qprint) && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                    output->data[k++] = qprint[j];
+                }
+                /* if this was a \n, then we also need to break the line with the end tag */
+                if ('\n' == bo->bytes[i] && (k+endtaglen+1) < PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                    /* we need to break the line with the end tag */
+                    for (j=0; j < endtaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX-1; j++) {
+                        output->data[k++] = endtag[j];
+                    }
+                    /* move the <cr> over */
+                    output->data[k++] = '\n';
+                    /* if this isn't the end of the data buffer, add a new start tag */
+                    if (i < bo->size-1 && (k+starttaglen) < PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+                        for (j=0; j < starttaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                            output->data[k++] = starttag[j];
+                            endtagged = false;
+                        }
+                    } else {
+                        endtagged = true;
+                    }
+                }
+            } else {
+                output->data[k++] = bo->bytes[i];
+            }
+        } else {
+            if ('\n' == bo->bytes[i]) {
+                /* we need to break the line with the end tag */
+                for (j=0; j < endtaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX-1; j++) {
+                    output->data[k++] = endtag[j];
+                }
+                /* move the <cr> over */
+                output->data[k++] = '\n';
+                /* if this isn't the end of the data buffer, add a new start tag */
+                if (i < bo->size-1) {
+                    for (j=0; j < starttaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; j++) {
+                        output->data[k++] = starttag[j];
+                        endtagged = false;
+                    }
+                } else {
+                    endtagged = true;
+                }
+            } else {
+                output->data[k++] = bo->bytes[i];
+            }
+        }
+    }
+    if (!endtagged && k < PMIX_IOF_BASE_TAGGED_OUT_MAX) {
+        /* need to add an endtag */
+        for (j=0; j < endtaglen && k < PMIX_IOF_BASE_TAGGED_OUT_MAX-1; j++) {
+            output->data[k++] = endtag[j];
+        }
+        output->data[k] = '\n';
+    }
+    output->numbytes = k;
+
+  process:
+    /* add this data to the write list for this fd */
+    pmix_list_append(&channel->outputs, &output->super);
+
+    /* record how big the buffer is */
+    num_buffered = pmix_list_get_size(&channel->outputs);
+
+    /* is the write event issued? */
+    if (!channel->pending) {
+        /* issue it */
+        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+                             "%s write:output adding write event",
+                             PMIX_NAME_PRINT(&pmix_globals.myid)));
+        PMIX_IOF_SINK_ACTIVATE(channel);
+    }
+
+    return num_buffered;
+}
+
+void pmix_iof_static_dump_output(pmix_iof_sink_t *sink)
+{
+    bool dump;
+    int num_written;
+    pmix_iof_write_event_t *wev = &sink->wev;
+    pmix_iof_write_output_t *output;
+
+    if (!pmix_list_is_empty(&wev->outputs)) {
+        dump = false;
+        /* make one last attempt to write this out */
+        while (NULL != (output = (pmix_iof_write_output_t*)pmix_list_remove_first(&wev->outputs))) {
+            if (!dump) {
+                num_written = write(wev->fd, output->data, output->numbytes);
+                if (num_written < output->numbytes) {
+                    /* don't retry - just cleanout the list and dump it */
+                    dump = true;
+                }
+            }
+            PMIX_RELEASE(output);
+        }
+    }
+}
+
+void pmix_iof_write_handler(int _fd, short event, void *cbdata)
+{
+    pmix_iof_sink_t *sink = (pmix_iof_sink_t*)cbdata;
+    pmix_iof_write_event_t *wev = &sink->wev;
+    pmix_list_item_t *item;
+    pmix_iof_write_output_t *output;
+    int num_written, total_written = 0;
+
+    PMIX_ACQUIRE_OBJECT(sink);
+
+    PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+                         "%s write:handler writing data to %d",
+                         PMIX_NAME_PRINT(&pmix_globals.myid),
+                         wev->fd));
+
+    while (NULL != (item = pmix_list_remove_first(&wev->outputs))) {
+        output = (pmix_iof_write_output_t*)item;
+        if (0 == output->numbytes) {
+            /* indicates we are to close this stream */
+            PMIX_RELEASE(sink);
+            return;
+        }
+        num_written = write(wev->fd, output->data, output->numbytes);
+        if (num_written < 0) {
+            if (EAGAIN == errno || EINTR == errno) {
+                /* push this item back on the front of the list */
+                pmix_list_prepend(&wev->outputs, item);
+                /* if the list is getting too large, abort */
+                if (pmix_globals.output_limit < pmix_list_get_size(&wev->outputs)) {
+                    pmix_output(0, "IO Forwarding is running too far behind - something is blocking us from writing");
+                    goto ABORT;
+                }
+                /* leave the write event running so it will call us again
+                 * when the fd is ready.
+                 */
+                goto NEXT_CALL;
+            }
+            /* otherwise, something bad happened so all we can do is abort
+             * this attempt
+             */
+            PMIX_RELEASE(output);
+            goto ABORT;
+        } else if (num_written < output->numbytes) {
+            /* incomplete write - adjust data to avoid duplicate output */
+            memmove(output->data, &output->data[num_written], output->numbytes - num_written);
+            /* adjust the number of bytes remaining to be written */
+            output->numbytes -= num_written;
+            /* push this item back on the front of the list */
+            pmix_list_prepend(&wev->outputs, item);
+            /* if the list is getting too large, abort */
+            if (pmix_globals.output_limit < pmix_list_get_size(&wev->outputs)) {
+                pmix_output(0, "IO Forwarding is running too far behind - something is blocking us from writing");
+                goto ABORT;
+            }
+            /* leave the write event running so it will call us again
+             * when the fd is ready
+             */
+            goto NEXT_CALL;
+        }
+        PMIX_RELEASE(output);
+
+        total_written += num_written;
+        if(wev->always_writable && (PMIX_IOF_SINK_BLOCKSIZE <= total_written)){
+            /* If this is a regular file it will never tell us it will block
+             * Write no more than PMIX_IOF_REGULARF_BLOCK at a time allowing
+             * other fds to progress
+             */
+            goto NEXT_CALL;
+        }
+    }
+  ABORT:
+    wev->pending = false;
+    PMIX_POST_OBJECT(wev);
+    return;
+NEXT_CALL:
+    PMIX_IOF_SINK_ACTIVATE(wev);
+}
+
+/* return true if we should read stdin from fd, false otherwise */
+bool pmix_iof_stdin_check(int fd)
+{
+#if defined(HAVE_TCGETPGRP)
+    if( isatty(fd) && (getpgrp() != tcgetpgrp(fd)) ) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+void pmix_iof_stdin_cb(int fd, short event, void *cbdata)
+{
+    bool should_process;
+    pmix_iof_read_event_t *stdinev = (pmix_iof_read_event_t*)cbdata;
+
+    PMIX_ACQUIRE_OBJECT(stdinev);
+
+    should_process = pmix_iof_stdin_check(0);
+
+    if (should_process) {
+        PMIX_IOF_READ_ACTIVATE(stdinev);
+    } else {
+        pmix_event_del(&stdinev->ev);
+        stdinev->active = false;
+        PMIX_POST_OBJECT(stdinev);
+    }
+}
+
+static void restart_stdin(int fd, short event, void *cbdata)
+{
+    pmix_iof_read_event_t *tm = (pmix_iof_read_event_t*)cbdata;
+
+    PMIX_ACQUIRE_OBJECT(tm);
+
+    if (!tm->active) {
+        PMIX_IOF_READ_ACTIVATE(tm);
+    }
+}
+
+/* this is the read handler for stdin */
+void pmix_iof_read_local_handler(int unusedfd, short event, void *cbdata)
+{
+    pmix_iof_read_event_t *rev = (pmix_iof_read_event_t*)cbdata;
+    unsigned char data[PMIX_IOF_BASE_MSG_MAX];
+    int32_t numbytes;
+    int fd;
+    pmix_status_t rc;
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_IOF_PUSH_CMD;
+
+    PMIX_ACQUIRE_OBJECT(rev);
+
+    /* As we may use timer events, fd can be bogus (-1)
+     * use the right one here
+     */
+    fd = fileno(stdin);
+
+    /* read up to the fragment size */
+    memset(data, 0, PMIX_IOF_BASE_MSG_MAX);
+    numbytes = read(fd, data, sizeof(data));
+
+    if (numbytes < 0) {
+        /* either we have a connection error or it was a non-blocking read */
+
+        /* non-blocking, retry */
+        if (EAGAIN == errno || EINTR == errno) {
+            PMIX_IOF_READ_ACTIVATE(rev);
+            return;
+        }
+
+        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,
+                             "%s iof:read handler Error on stdin",
+                             PMIX_NAME_PRINT(&pmix_globals.myid)));
+        /* Un-recoverable error. Allow the code to flow as usual in order to
+         * to send the zero bytes message up the stream, and then close the
+         * file descriptor and delete the event.
+         */
+        numbytes = 0;
+    }
+
+    /* The event has fired, so it's no longer active until we
+       re-add it */
+    rev->active = false;
+
+    /* pass the data to our PMIx server so it can relay it
+     * to the host RM for distribution */
+    msg = PMIX_NEW(pmix_buffer_t);
+    if (NULL == msg) {
+        /* don't restart the event - just return */
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        goto restart;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &numbytes, 1, PMIX_INT32);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        goto restart;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, data, numbytes, PMIX_BYTE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        goto restart;
+    }
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, stdincbfunc, NULL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+    }
+
+  restart:
+    /* if num_bytes was zero, or we read the last piece of the file, then we need to terminate the event */
+    if (0 == numbytes) {
+       /* this will also close our stdin file descriptor */
+        PMIX_RELEASE(rev);
+    } else {
+        /* if we are looking at a tty, then we just go ahead and restart the
+         * read event assuming we are not backgrounded
+         */
+        if (pmix_iof_stdin_check(fd)) {
+            restart_stdin(fd, 0, rev);
+        } else {
+            /* delay for awhile and then restart */
+            pmix_event_evtimer_set(pmix_globals.evbase,
+                                   &rev->ev, restart_stdin, rev);
+            rev->tv.tv_sec = 0;
+            rev->tv.tv_usec = 10000;
+            PMIX_POST_OBJECT(rev);
+            pmix_event_evtimer_add(&rev->ev, &rev->tv);
+        }
+    }
+    /* nothing more to do */
+    return;
+}
+
+/* class instances */
+static void iof_sink_construct(pmix_iof_sink_t* ptr)
+{
+    PMIX_CONSTRUCT(&ptr->wev, pmix_iof_write_event_t);
+    ptr->xoff = false;
+    ptr->exclusive = false;
+    ptr->closed = false;
+}
+static void iof_sink_destruct(pmix_iof_sink_t* ptr)
+{
+    if (0 <= ptr->wev.fd) {
+        PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
+                             "%s iof: closing sink for process %s on fd %d",
+                             PMIX_NAME_PRINT(&pmix_globals.myid),
+                             PMIX_NAME_PRINT(&ptr->name), ptr->wev.fd));
+        PMIX_DESTRUCT(&ptr->wev);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_iof_sink_t,
+                    pmix_list_item_t,
+                    iof_sink_construct,
+                    iof_sink_destruct);
+
+
+static void iof_read_event_construct(pmix_iof_read_event_t* rev)
+{
+    rev->fd = -1;
+    rev->active = false;
+    rev->tv.tv_sec = 0;
+    rev->tv.tv_usec = 0;
+}
+static void iof_read_event_destruct(pmix_iof_read_event_t* rev)
+{
+    pmix_event_del(&rev->ev);
+    if (0 <= rev->fd) {
+        PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
+                             "%s iof: closing fd %d",
+                             PMIX_NAME_PRINT(&pmix_globals.myid), rev->fd));
+        close(rev->fd);
+        rev->fd = -1;
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_iof_read_event_t,
+                    pmix_object_t,
+                    iof_read_event_construct,
+                    iof_read_event_destruct);
+
+static void iof_write_event_construct(pmix_iof_write_event_t* wev)
+{
+    wev->pending = false;
+    wev->always_writable = false;
+    wev->fd = -1;
+    PMIX_CONSTRUCT(&wev->outputs, pmix_list_t);
+    wev->tv.tv_sec = 0;
+    wev->tv.tv_usec = 0;
+}
+static void iof_write_event_destruct(pmix_iof_write_event_t* wev)
+{
+    pmix_event_del(&wev->ev);
+    if (2 < wev->fd) {
+        PMIX_OUTPUT_VERBOSE((20, pmix_client_globals.iof_output,
+                             "%s iof: closing fd %d for write event",
+                             PMIX_NAME_PRINT(&pmix_globals.myid), wev->fd));
+        close(wev->fd);
+    }
+    PMIX_DESTRUCT(&wev->outputs);
+}
+PMIX_CLASS_INSTANCE(pmix_iof_write_event_t,
+                    pmix_list_item_t,
+                    iof_write_event_construct,
+                    iof_write_event_destruct);
+
+PMIX_CLASS_INSTANCE(pmix_iof_write_output_t,
+                    pmix_list_item_t,
+                    NULL, NULL);

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ *
+ * I/O Forwarding Service
+ */
+
+#ifndef PMIX_IOF_H
+#define PMIX_IOF_H
+
+#include <src/include/pmix_config.h>
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_UIO_H
+#include <sys/uio.h>
+#endif
+#ifdef HAVE_NET_UIO_H
+#include <net/uio.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <signal.h>
+
+#include "src/class/pmix_list.h"
+#include "src/include/pmix_globals.h"
+#include "src/util/fd.h"
+
+#include "src/common/pmix_iof.h"
+
+BEGIN_C_DECLS
+
+/*
+ * Maximum size of single msg
+ */
+#define PMIX_IOF_BASE_MSG_MAX           4096
+#define PMIX_IOF_BASE_TAG_MAX             50
+#define PMIX_IOF_BASE_TAGGED_OUT_MAX    8192
+#define PMIX_IOF_MAX_INPUT_BUFFERS        50
+
+typedef struct {
+    pmix_list_item_t super;
+    bool pending;
+    bool always_writable;
+    pmix_event_t ev;
+    struct timeval tv;
+    int fd;
+    pmix_list_t outputs;
+} pmix_iof_write_event_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_write_event_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_proc_t name;
+    pmix_iof_channel_t tag;
+    pmix_iof_write_event_t wev;
+    bool xoff;
+    bool exclusive;
+    bool closed;
+} pmix_iof_sink_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_sink_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    char data[PMIX_IOF_BASE_TAGGED_OUT_MAX];
+    int numbytes;
+} pmix_iof_write_output_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_write_output_t);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    struct timeval tv;
+    int fd;
+    bool active;
+    bool always_readable;
+} pmix_iof_read_event_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_read_event_t);
+
+
+/* Write event macro's */
+
+static inline bool
+pmix_iof_fd_always_ready(int fd)
+{
+    return pmix_fd_is_regular(fd) ||
+           (pmix_fd_is_chardev(fd) && !isatty(fd)) ||
+           pmix_fd_is_blkdev(fd);
+}
+
+#define PMIX_IOF_SINK_BLOCKSIZE (1024)
+
+#define PMIX_IOF_SINK_ACTIVATE(wev)                                     \
+    do {                                                                \
+        struct timeval *tv = NULL;                                      \
+        wev->pending = true;                                            \
+        PMIX_POST_OBJECT(wev);                                          \
+        if (wev->always_writable) {                                     \
+            /* Regular is always write ready. Use timer to activate */  \
+            tv = &wev->tv;                                        \
+        }                                                               \
+        if (pmix_event_add(&wev->ev, tv)) {                             \
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);                         \
+        }                                                               \
+    } while(0);
+
+
+/* define an output "sink", adding it to the provided
+ * endpoint list for this proc */
+#define PMIX_IOF_SINK_DEFINE(snk, nm, fid, tg, wrthndlr)                    \
+    do {                                                                    \
+        PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,             \
+                            "defining endpt: file %s line %d fd %d",        \
+                            __FILE__, __LINE__, (fid)));                    \
+        PMIX_CONSTRUCT((snk), pmix_iof_sink_t);                             \
+        (void)strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);    \
+        (snk)->name.rank = (nm)->rank;                                      \
+        (snk)->tag = (tg);                                                  \
+        if (0 <= (fid)) {                                                   \
+            (snk)->wev.fd = (fid);                                          \
+            (snk)->wev.always_writable =                                    \
+                    pmix_iof_fd_always_ready(fid);                          \
+            if ((snk)->wev.always_writable) {                               \
+                pmix_event_evtimer_set(pmix_globals.evbase,                 \
+                                       &(snk)->wev.ev,  wrthndlr, (snk));   \
+            } else {                                                        \
+                pmix_event_set(pmix_globals.evbase,                         \
+                               &(snk)->wev.ev, (snk)->wev.fd,               \
+                               PMIX_EV_WRITE,                               \
+                               wrthndlr, (snk));                            \
+            }                                                               \
+        }                                                                   \
+        PMIX_POST_OBJECT(snk);                                              \
+    } while(0);
+
+/* Read event macro's */
+#define PMIX_IOF_READ_ADDEV(rev)                                \
+    do {                                                        \
+        struct timeval *tv = NULL;                              \
+        if ((rev)->always_readable) {                           \
+            tv = &(rev)->tv;                                    \
+        }                                                       \
+        if (pmix_event_add(&(rev)->ev, tv)) {                   \
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);                 \
+        }                                                       \
+    } while(0);
+
+#define PMIX_IOF_READ_ACTIVATE(rev)                             \
+    do {                                                        \
+        (rev)->active = true;                                   \
+        PMIX_POST_OBJECT(rev);                                  \
+        PMIX_IOF_READ_ADDEV(rev);                               \
+    } while(0);
+
+
+PMIX_EXPORT pmix_status_t pmix_iof_flush(void);
+
+PMIX_EXPORT pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
+                                                pmix_iof_channel_t stream,
+                                                const pmix_byte_object_t *bo,
+                                                pmix_iof_write_event_t *channel);
+PMIX_EXPORT void pmix_iof_static_dump_output(pmix_iof_sink_t *sink);
+PMIX_EXPORT void pmix_iof_write_handler(int fd, short event, void *cbdata);
+PMIX_EXPORT void pmix_iof_stdin_write_handler(int fd, short event, void *cbdata);
+PMIX_EXPORT bool pmix_iof_stdin_check(int fd);
+PMIX_EXPORT void pmix_iof_stdin_cb(int fd, short event, void *cbdata);
+PMIX_EXPORT void pmix_iof_read_local_handler(int fd, short event, void *cbdata);
+
+END_C_DECLS
+
+#endif /* PMIX_IOF_H */

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -216,7 +216,42 @@ PMIX_EXPORT const char* pmix_command_string(pmix_cmd_t cmd)
             return "JOB CONTROL";
         case PMIX_MONITOR_CMD:
             return "MONITOR";
+        case PMIX_IOF_PUSH_CMD:
+            return "IOF PUSH";
+        case PMIX_IOF_PULL_CMD:
+            return "IOF PULL";
         default:
             return "UNKNOWN";
     }
+}
+
+/* this is not a thread-safe implementation. To correctly implement this,
+ * we need to port the thread-safe data code from OPAL and use it here */
+static char answer[300];
+
+PMIX_EXPORT const char* PMIx_IOF_channel_string(pmix_iof_channel_t channel)
+{
+    size_t cnt=0;
+
+    memset(answer, 0, sizeof(answer));
+    if (PMIX_FWD_STDIN_CHANNEL & channel) {
+        strncpy(&answer[cnt], "STDIN ", strlen("STDIN "));
+        cnt += strlen("STDIN ");
+    }
+    if (PMIX_FWD_STDOUT_CHANNEL & channel) {
+        strncpy(&answer[cnt], "STDOUT ", strlen("STDOUT "));
+        cnt += strlen("STDOUT ");
+    }
+    if (PMIX_FWD_STDERR_CHANNEL & channel) {
+        strncpy(&answer[cnt], "STDERR ", strlen("STDERR "));
+        cnt += strlen("STDERR ");
+    }
+    if (PMIX_FWD_STDDIAG_CHANNEL & channel) {
+        strncpy(&answer[cnt], "STDDIAG ", strlen("STDDIAG "));
+        cnt += strlen("STDDIAG ");
+    }
+    if (0 == cnt) {
+        strncpy(&answer[cnt], "NONE", strlen("NONE"));
+    }
+    return answer;
 }

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -41,7 +41,7 @@
     pmix_info_t *info;
     size_t ninfo;
     pmix_notification_fn_t evhdlr;
-    pmix_evhdlr_reg_cbfunc_t evregcbfn;
+    pmix_hdlr_reg_cbfunc_t evregcbfn;
     void *cbdata;
 } pmix_rshift_caddy_t;
 static void rscon(pmix_rshift_caddy_t *p)
@@ -766,7 +766,7 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
 PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
                                              pmix_info_t info[], size_t ninfo,
                                              pmix_notification_fn_t event_hdlr,
-                                             pmix_evhdlr_reg_cbfunc_t cbfunc,
+                                             pmix_hdlr_reg_cbfunc_t cbfunc,
                                              void *cbdata)
 {
     pmix_rshift_caddy_t *cd;

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -219,6 +219,24 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_peer_t,
                                 pmix_object_t,
                                 pcon, pdes);
 
+static void iofreqcon(pmix_iof_req_t *p)
+{
+    p->peer = NULL;
+    memset(&p->pname, 0, sizeof(pmix_name_t));
+    p->channels = PMIX_FWD_NO_CHANNELS;
+    p->cbfunc = NULL;
+}
+static void iofreqdes(pmix_iof_req_t *p)
+{
+    if (NULL != p->peer) {
+        PMIX_RELEASE(p->peer);
+    }
+}
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_iof_req_t,
+                                pmix_list_item_t,
+                                iofreqcon, iofreqdes);
+
+
 static void scon(pmix_shift_caddy_t *p)
 {
     PMIX_CONSTRUCT_LOCK(&p->lock);
@@ -234,6 +252,7 @@ static void scon(pmix_shift_caddy_t *p)
     p->directives = NULL;
     p->ndirs = 0;
     p->evhdlr = NULL;
+    p->iofreq = NULL;
     p->kv = NULL;
     p->vptr = NULL;
     p->cd = NULL;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -31,6 +31,7 @@
 #endif
 #include PMIX_EVENT_HEADER
 
+#include <pmix.h>
 #include <pmix_common.h>
 
 #include "src/class/pmix_hash_table.h"
@@ -97,6 +98,8 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_MONITOR_CMD            19
 #define PMIX_GET_CREDENTIAL_CMD     20
 #define PMIX_VALIDATE_CRED_CMD      21
+#define PMIX_IOF_PULL_CMD           22
+#define PMIX_IOF_PUSH_CMD           23
 
 /* provide a "pretty-print" function for cmds */
 const char* pmix_command_string(pmix_cmd_t cmd);
@@ -228,6 +231,17 @@ typedef struct pmix_peer_t {
 PMIX_CLASS_DECLARATION(pmix_peer_t);
 
 
+/* tracker for IOF requests */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_peer_t *peer;
+    pmix_name_t pname;
+    pmix_iof_channel_t channels;
+    pmix_iof_cbfunc_t cbfunc;
+} pmix_iof_req_t;
+PMIX_CLASS_DECLARATION(pmix_iof_req_t);
+
+
 /* caddy for query requests */
 typedef struct {
     pmix_object_t super;
@@ -307,6 +321,7 @@ PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
     pmix_info_t *directives;
     size_t ndirs;
     pmix_notification_fn_t evhdlr;
+    pmix_iof_req_t *iofreq;
     pmix_kval_t *kv;
     pmix_value_t *vptr;
     pmix_server_caddy_t *cd;
@@ -314,9 +329,8 @@ PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
     bool enviro;
     union {
        pmix_release_cbfunc_t relfn;
-       pmix_evhdlr_reg_cbfunc_t evregcbfn;
+       pmix_hdlr_reg_cbfunc_t hdlrregcbfn;
        pmix_op_cbfunc_t opcbfn;
-       pmix_evhdlr_reg_cbfunc_t errregcbfn;
     } cbfunc;
     void *cbdata;
     size_t ref;
@@ -340,7 +354,7 @@ typedef struct {
         pmix_lookup_cbfunc_t lookupfn;
         pmix_spawn_cbfunc_t spawnfn;
         pmix_connect_cbfunc_t cnctfn;
-        pmix_evhdlr_reg_cbfunc_t errregfn;
+        pmix_hdlr_reg_cbfunc_t hdlrregfn;
     } cbfunc;
     size_t errhandler_ref;
     void *cbdata;
@@ -414,6 +428,7 @@ typedef struct {
     bool commits_pending;
     struct timeval event_window;
     pmix_list_t cached_events;          // events waiting in the window prior to processing
+    pmix_list_t iof_requests;           // list of pmix_iof_req_t IOF requests
     pmix_ring_buffer_t notifications;   // ring buffer of pending notifications
     /* processes also need a place where they can store
      * their own internal data - e.g., data provided by
@@ -422,6 +437,11 @@ typedef struct {
      * interface so that other parts of the process can
      * look them up */
     pmix_gds_base_module_t *mygds;
+    /* IOF controls */
+    bool tag_output;
+    bool xml_output;
+    bool timestamp_output;
+    size_t output_limit;
 } pmix_globals_t;
 
 /* provide access to a function to cleanup epilogs */

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -244,6 +244,8 @@ typedef struct event pmix_event_t;
 
 #define pmix_event_assign(x, b, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
 
+#define pmix_event_set(b, x, fd, fg, cb, arg) event_assign((x), (b), (fd), (fg), (event_callback_fn) (cb), (arg))
+
 #define pmix_event_add(ev, tv) event_add((ev), (tv))
 
 #define pmix_event_del(ev) event_del((ev))
@@ -264,5 +266,6 @@ typedef struct event pmix_event_t;
 
 #define pmix_event_evtimer_del(x) pmix_event_del((x))
 
+#define pmix_event_signal_set(b, x, fd, cb, arg) event_assign((x), (b), (fd), EV_SIGNAL|EV_PERSIST, (event_callback_fn) (cb), (arg))
 
 #endif /* PMIX_TYPES_H */

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -379,6 +379,8 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_val(pmix_buffer_t *buffer,
                                                     pmix_value_t *p);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
                                                                 int32_t num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_buffer_t *buffer, const void *src,
+                                                            int32_t num_vals, pmix_data_type_t type);
 
 /*
 * "Standard" unpack functions
@@ -466,6 +468,8 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, v
                                                         int32_t *num_vals, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
                                                                   int32_t *num_vals, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_buffer_t *buffer, void *dest,
+                                                              int32_t *num_vals, pmix_data_type_t type);
 /**** DEPRECATED ****/
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
@@ -637,6 +641,9 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_rank(char **output, char *prefi
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix,
                                                                  pmix_alloc_directive_t *src,
                                                                  pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
+                                                            pmix_iof_channel_t *src,
+                                                            pmix_data_type_t type);
 
 /*
  * Common helper functions

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -113,6 +113,7 @@ pmix_status_t pmix_bfrops_base_std_copy(void **dest, void *src,
 
     case PMIX_INT16:
     case PMIX_UINT16:
+    case PMIX_IOF_CHANNEL:
         datasize = 2;
         break;
 

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1269,4 +1269,10 @@ pmix_status_t pmix_bfrops_base_pack_array(pmix_buffer_t *buffer, const void *src
     }
 
     return PMIX_SUCCESS;
+}
+
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_buffer_t *buffer, const void *src,
+                                                            int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix_bfrops_base_pack_int16(buffer, src, num_vals, PMIX_UINT16);
 }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1636,6 +1636,35 @@ pmix_status_t pmix_bfrops_base_print_alloc_directive(char **output, char *prefix
     }
 }
 
+pmix_status_t pmix_bfrops_base_print_iof_channel(char **output, char *prefix,
+                                                 pmix_iof_channel_t *src,
+                                                 pmix_data_type_t type)
+{
+    char *prefx;
+    int ret;
+
+    /* deal with NULL prefix */
+    if (NULL == prefix) {
+        if (0 > asprintf(&prefx, " ")) {
+            return PMIX_ERR_NOMEM;
+        }
+    } else {
+        prefx = prefix;
+    }
+
+    ret = asprintf(output, "%sData type: PMIX_IOF_CHANNEL\tValue: %s",
+                   prefx, PMIx_IOF_channel_string(*src));
+    if (prefx != prefix) {
+        free(prefx);
+    }
+
+    if (0 > ret) {
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    } else {
+        return PMIX_SUCCESS;
+    }
+}
+
 
 /**** DEPRECATED ****/
 pmix_status_t pmix_bfrops_base_print_array(char **output, char *prefix,

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1603,6 +1603,11 @@ pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_buffer_t *buffer, voi
     return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
 }
 
+pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_buffer_t *buffer, void *dest,
+                                                  int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix_bfrops_base_unpack_int16(buffer, dest, num_vals, PMIX_UINT16);
+}
 
 /**** DEPRECATED ****/
 pmix_status_t pmix_bfrops_base_unpack_array(pmix_buffer_t *buffer, void *dest,

--- a/src/mca/bfrops/v3/Makefile.am
+++ b/src/mca/bfrops/v3/Makefile.am
@@ -1,0 +1,50 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = bfrop_pmix3.h
+sources = \
+        bfrop_pmix3_component.c \
+        bfrop_pmix3.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_bfrops_v3_DSO
+lib =
+lib_sources =
+component = mca_bfrops_v3.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_bfrops_v3.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_bfrops_v3_la_SOURCES = $(component_sources)
+mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
+
+noinst_LTLIBRARIES = $(lib)
+libmca_bfrops_v3_la_SOURCES = $(lib_sources)
+libmca_bfrops_v3_la_LDFLAGS = -module -avoid-version

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -1,0 +1,456 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2011 Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix3.h"
+
+static pmix_status_t init(void);
+static void finalize(void);
+static pmix_status_t pmix3_pack(pmix_buffer_t *buffer,
+                                const void *src, int num_vals,
+                                pmix_data_type_t type);
+static pmix_status_t pmix3_unpack(pmix_buffer_t *buffer, void *dest,
+                                  int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t pmix3_copy(void **dest, void *src,
+                                pmix_data_type_t type);
+static pmix_status_t pmix3_print(char **output, char *prefix,
+                                 void *src, pmix_data_type_t type);
+static pmix_status_t register_type(const char *name,
+                                   pmix_data_type_t type,
+                                   pmix_bfrop_pack_fn_t pack,
+                                   pmix_bfrop_unpack_fn_t unpack,
+                                   pmix_bfrop_copy_fn_t copy,
+                                   pmix_bfrop_print_fn_t print);
+static const char* data_type_string(pmix_data_type_t type);
+
+pmix_bfrops_module_t pmix_bfrops_pmix3_module = {
+    .version = "v3",
+    .init = init,
+    .finalize = finalize,
+    .pack = pmix3_pack,
+    .unpack = pmix3_unpack,
+    .copy = pmix3_copy,
+    .print = pmix3_print,
+    .copy_payload = pmix_bfrops_base_copy_payload,
+    .value_xfer = pmix_bfrops_base_value_xfer,
+    .value_load = pmix_bfrops_base_value_load,
+    .value_unload = pmix_bfrops_base_value_unload,
+    .value_cmp = pmix_bfrops_base_value_cmp,
+    .register_type = register_type,
+    .data_type_string = data_type_string
+};
+
+static pmix_status_t init(void)
+{
+    /* some standard types don't require anything special */
+    PMIX_REGISTER_TYPE("PMIX_BOOL", PMIX_BOOL,
+                       pmix_bfrops_base_pack_bool,
+                       pmix_bfrops_base_unpack_bool,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_bool,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_BYTE", PMIX_BYTE,
+                       pmix_bfrops_base_pack_byte,
+                       pmix_bfrops_base_unpack_byte,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_byte,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_STRING", PMIX_STRING,
+                       pmix_bfrops_base_pack_string,
+                       pmix_bfrops_base_unpack_string,
+                       pmix_bfrops_base_copy_string,
+                       pmix_bfrops_base_print_string,
+                       &mca_bfrops_v3_component.types);
+
+    /* Register the rest of the standard generic types to point to internal functions */
+    PMIX_REGISTER_TYPE("PMIX_SIZE", PMIX_SIZE,
+                       pmix_bfrops_base_pack_sizet,
+                       pmix_bfrops_base_unpack_sizet,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_size,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PID", PMIX_PID,
+                       pmix_bfrops_base_pack_pid,
+                       pmix_bfrops_base_unpack_pid,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_pid,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INT", PMIX_INT,
+                       pmix_bfrops_base_pack_int,
+                       pmix_bfrops_base_unpack_int,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_int,
+                       &mca_bfrops_v3_component.types);
+
+    /* Register all the standard fixed types to point to base functions */
+    PMIX_REGISTER_TYPE("PMIX_INT8", PMIX_INT8,
+                       pmix_bfrops_base_pack_byte,
+                       pmix_bfrops_base_unpack_byte,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_int8,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INT16", PMIX_INT16,
+                       pmix_bfrops_base_pack_int16,
+                       pmix_bfrops_base_unpack_int16,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_int16,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INT32", PMIX_INT32,
+                       pmix_bfrops_base_pack_int32,
+                       pmix_bfrops_base_unpack_int32,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_int32,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INT64", PMIX_INT64,
+                       pmix_bfrops_base_pack_int64,
+                       pmix_bfrops_base_unpack_int64,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_int64,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_UINT", PMIX_UINT,
+                       pmix_bfrops_base_pack_int,
+                       pmix_bfrops_base_unpack_int,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_uint,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_UINT8", PMIX_UINT8,
+                       pmix_bfrops_base_pack_byte,
+                       pmix_bfrops_base_unpack_byte,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_uint8,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_UINT16", PMIX_UINT16,
+                       pmix_bfrops_base_pack_int16,
+                       pmix_bfrops_base_unpack_int16,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_uint16,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_UINT32", PMIX_UINT32,
+                       pmix_bfrops_base_pack_int32,
+                       pmix_bfrops_base_unpack_int32,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_uint32,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_UINT64", PMIX_UINT64,
+                       pmix_bfrops_base_pack_int64,
+                       pmix_bfrops_base_unpack_int64,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_uint64,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_FLOAT", PMIX_FLOAT,
+                       pmix_bfrops_base_pack_float,
+                       pmix_bfrops_base_unpack_float,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_float,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DOUBLE", PMIX_DOUBLE,
+                       pmix_bfrops_base_pack_double,
+                       pmix_bfrops_base_unpack_double,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_double,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_TIMEVAL", PMIX_TIMEVAL,
+                       pmix_bfrops_base_pack_timeval,
+                       pmix_bfrops_base_unpack_timeval,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_timeval,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_TIME", PMIX_TIME,
+                       pmix_bfrops_base_pack_time,
+                       pmix_bfrops_base_unpack_time,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_time,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_STATUS", PMIX_STATUS,
+                       pmix_bfrops_base_pack_status,
+                       pmix_bfrops_base_unpack_status,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_status,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_VALUE", PMIX_VALUE,
+                       pmix_bfrops_base_pack_value,
+                       pmix_bfrops_base_unpack_value,
+                       pmix_bfrops_base_copy_value,
+                       pmix_bfrops_base_print_value,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC", PMIX_PROC,
+                       pmix_bfrops_base_pack_proc,
+                       pmix_bfrops_base_unpack_proc,
+                       pmix_bfrops_base_copy_proc,
+                       pmix_bfrops_base_print_proc,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_APP", PMIX_APP,
+                       pmix_bfrops_base_pack_app,
+                       pmix_bfrops_base_unpack_app,
+                       pmix_bfrops_base_copy_app,
+                       pmix_bfrops_base_print_app,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INFO", PMIX_INFO,
+                       pmix_bfrops_base_pack_info,
+                       pmix_bfrops_base_unpack_info,
+                       pmix_bfrops_base_copy_info,
+                       pmix_bfrops_base_print_info,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PDATA", PMIX_PDATA,
+                       pmix_bfrops_base_pack_pdata,
+                       pmix_bfrops_base_unpack_pdata,
+                       pmix_bfrops_base_copy_pdata,
+                       pmix_bfrops_base_print_pdata,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_BUFFER", PMIX_BUFFER,
+                       pmix_bfrops_base_pack_buf,
+                       pmix_bfrops_base_unpack_buf,
+                       pmix_bfrops_base_copy_buf,
+                       pmix_bfrops_base_print_buf,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_BYTE_OBJECT", PMIX_BYTE_OBJECT,
+                       pmix_bfrops_base_pack_bo,
+                       pmix_bfrops_base_unpack_bo,
+                       pmix_bfrops_base_copy_bo,
+                       pmix_bfrops_base_print_bo,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_KVAL", PMIX_KVAL,
+                       pmix_bfrops_base_pack_kval,
+                       pmix_bfrops_base_unpack_kval,
+                       pmix_bfrops_base_copy_kval,
+                       pmix_bfrops_base_print_kval,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_MODEX", PMIX_MODEX,
+                       pmix_bfrops_base_pack_modex,
+                       pmix_bfrops_base_unpack_modex,
+                       pmix_bfrops_base_copy_modex,
+                       pmix_bfrops_base_print_modex,
+                       &mca_bfrops_v3_component.types);
+
+    /* these are fixed-sized values and can be done by base */
+    PMIX_REGISTER_TYPE("PMIX_PERSIST", PMIX_PERSIST,
+                       pmix_bfrops_base_pack_persist,
+                       pmix_bfrops_base_unpack_persist,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_persist,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_POINTER", PMIX_POINTER,
+                       pmix_bfrops_base_pack_ptr,
+                       pmix_bfrops_base_unpack_ptr,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_ptr,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_SCOPE", PMIX_SCOPE,
+                       pmix_bfrops_base_pack_scope,
+                       pmix_bfrops_base_unpack_scope,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_std_copy,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DATA_RANGE", PMIX_DATA_RANGE,
+                       pmix_bfrops_base_pack_range,
+                       pmix_bfrops_base_unpack_range,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_ptr,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_COMMAND", PMIX_COMMAND,
+                       pmix_bfrops_base_pack_cmd,
+                       pmix_bfrops_base_unpack_cmd,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_cmd,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_INFO_DIRECTIVES", PMIX_INFO_DIRECTIVES,
+                       pmix_bfrops_base_pack_info_directives,
+                       pmix_bfrops_base_unpack_info_directives,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_info_directives,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DATA_TYPE", PMIX_DATA_TYPE,
+                       pmix_bfrops_base_pack_datatype,
+                       pmix_bfrops_base_unpack_datatype,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_datatype,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC_STATE", PMIX_PROC_STATE,
+                       pmix_bfrops_base_pack_pstate,
+                       pmix_bfrops_base_unpack_pstate,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_pstate,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC_INFO", PMIX_PROC_INFO,
+                       pmix_bfrops_base_pack_pinfo,
+                       pmix_bfrops_base_unpack_pinfo,
+                       pmix_bfrops_base_copy_pinfo,
+                       pmix_bfrops_base_print_pinfo,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_DATA_ARRAY", PMIX_DATA_ARRAY,
+                       pmix_bfrops_base_pack_darray,
+                       pmix_bfrops_base_unpack_darray,
+                       pmix_bfrops_base_copy_darray,
+                       pmix_bfrops_base_print_darray,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_PROC_RANK", PMIX_PROC_RANK,
+                       pmix_bfrops_base_pack_rank,
+                       pmix_bfrops_base_unpack_rank,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_rank,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_QUERY", PMIX_QUERY,
+                       pmix_bfrops_base_pack_query,
+                       pmix_bfrops_base_unpack_query,
+                       pmix_bfrops_base_copy_query,
+                       pmix_bfrops_base_print_query,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_COMPRESSED_STRING",
+                       PMIX_COMPRESSED_STRING,
+                       pmix_bfrops_base_pack_bo,
+                       pmix_bfrops_base_unpack_bo,
+                       pmix_bfrops_base_copy_bo,
+                       pmix_bfrops_base_print_bo,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_ALLOC_DIRECTIVE",
+                       PMIX_ALLOC_DIRECTIVE,
+                       pmix_bfrops_base_pack_alloc_directive,
+                       pmix_bfrops_base_unpack_alloc_directive,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_alloc_directive,
+                       &mca_bfrops_v3_component.types);
+
+    PMIX_REGISTER_TYPE("PMIX_IOF_CHANNEL",
+                       PMIX_IOF_CHANNEL,
+                       pmix_bfrops_base_pack_iof_channel,
+                       pmix_bfrops_base_unpack_iof_channel,
+                       pmix_bfrops_base_std_copy,
+                       pmix_bfrops_base_print_iof_channel,
+                       &mca_bfrops_v3_component.types);
+
+    /**** DEPRECATED ****/
+    PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY,
+                       pmix_bfrops_base_pack_array,
+                       pmix_bfrops_base_unpack_array,
+                       pmix_bfrops_base_copy_array,
+                       pmix_bfrops_base_print_array,
+                       &mca_bfrops_v3_component.types);
+    /********************/
+
+
+    return PMIX_SUCCESS;
+}
+
+static void finalize(void)
+{
+    int n;
+    pmix_bfrop_type_info_t *info;
+
+    for (n=0; n < mca_bfrops_v3_component.types.size; n++) {
+        if (NULL != (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v3_component.types, n))) {
+            PMIX_RELEASE(info);
+            pmix_pointer_array_set_item(&mca_bfrops_v3_component.types, n, NULL);
+        }
+    }
+}
+
+static pmix_status_t pmix3_pack(pmix_buffer_t *buffer,
+                                const void *src, int num_vals,
+                                pmix_data_type_t type)
+{
+    /* kick the process off by passing this in to the base */
+    return pmix_bfrops_base_pack(&mca_bfrops_v3_component.types,
+                                 buffer, src, num_vals, type);
+}
+
+static pmix_status_t pmix3_unpack(pmix_buffer_t *buffer, void *dest,
+                                  int32_t *num_vals, pmix_data_type_t type)
+{
+     /* kick the process off by passing this in to the base */
+    return pmix_bfrops_base_unpack(&mca_bfrops_v3_component.types,
+                                   buffer, dest, num_vals, type);
+}
+
+static pmix_status_t pmix3_copy(void **dest, void *src,
+                                pmix_data_type_t type)
+{
+    return pmix_bfrops_base_copy(&mca_bfrops_v3_component.types,
+                                 dest, src, type);
+}
+
+static pmix_status_t pmix3_print(char **output, char *prefix,
+                                 void *src, pmix_data_type_t type)
+{
+    return pmix_bfrops_base_print(&mca_bfrops_v3_component.types,
+                                  output, prefix, src, type);
+}
+
+static pmix_status_t register_type(const char *name, pmix_data_type_t type,
+                                   pmix_bfrop_pack_fn_t pack,
+                                   pmix_bfrop_unpack_fn_t unpack,
+                                   pmix_bfrop_copy_fn_t copy,
+                                   pmix_bfrop_print_fn_t print)
+{
+    PMIX_REGISTER_TYPE(name, type,
+                       pack, unpack,
+                       copy, print,
+                       &mca_bfrops_v3_component.types);
+    return PMIX_SUCCESS;
+}
+
+static const char* data_type_string(pmix_data_type_t type)
+{
+    return pmix_bfrops_base_data_type_string(&mca_bfrops_v3_component.types, type);
+}

--- a/src/mca/bfrops/v3/bfrop_pmix3.h
+++ b/src/mca/bfrops/v3/bfrop_pmix3.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_BFROPS_PMIX3_H
+#define PMIX_BFROPS_PMIX3_H
+
+#include "src/mca/bfrops/bfrops.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+ PMIX_EXPORT extern pmix_bfrops_base_component_t mca_bfrops_v3_component;
+
+extern pmix_bfrops_module_t pmix_bfrops_pmix3_module;
+
+END_C_DECLS
+
+#endif /* PMIX_BFROPS_PMIX3_H */

--- a/src/mca/bfrops/v3/bfrop_pmix3_component.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3_component.c
@@ -1,0 +1,99 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennbfropsee and The University
+ *                         of Tennbfropsee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+#include "src/include/types.h"
+#include "src/include/pmix_globals.h"
+
+#include "src/util/error.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/mca/bfrops/base/base.h"
+#include "bfrop_pmix3.h"
+
+extern pmix_bfrops_module_t pmix_bfrops_pmix3_module;
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_status_t component_close(void);
+static pmix_bfrops_module_t* assign_module(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_bfrops_base_component_t mca_bfrops_v3_component = {
+    .base = {
+        PMIX_BFROPS_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "v3",
+        PMIX_MCA_BASE_MAKE_VERSION(component, PMIX_MAJOR_VERSION, PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_query_component = component_query,
+    },
+    .priority = 40,
+    .assign_module = assign_module
+};
+
+
+pmix_status_t component_open(void)
+{
+    /* setup the types array */
+    PMIX_CONSTRUCT(&mca_bfrops_v3_component.types, pmix_pointer_array_t);
+    pmix_pointer_array_init(&mca_bfrops_v3_component.types, 32, INT_MAX, 16);
+
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+
+    *priority = mca_bfrops_v3_component.priority;
+    *module = (pmix_mca_base_module_t *)&pmix_bfrops_pmix3_module;
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t component_close(void)
+{
+    PMIX_DESTRUCT(&mca_bfrops_v3_component.types);
+    return PMIX_SUCCESS;
+}
+
+static pmix_bfrops_module_t* assign_module(void)
+{
+    pmix_output_verbose(10, pmix_bfrops_base_framework.framework_output,
+                        "bfrops:pmix3x assigning module");
+    return &pmix_bfrops_pmix3_module;
+}

--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -100,6 +100,7 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer,
             }
         }
         if (!takeus) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
             return PMIX_ERR_NOT_SUPPORTED;
         }
     }
@@ -124,6 +125,7 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer,
         goto complete;
     } else {
         /* unrecognized protocol */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -89,6 +89,7 @@ typedef uint32_t pmix_ptl_tag_t;
  * within the system */
 #define PMIX_PTL_TAG_NOTIFY           0
 #define PMIX_PTL_TAG_HEARTBEAT        1
+#define PMIX_PTL_TAG_IOF              2
 
 /* define the start of dynamic tags that are
  * assigned for send/recv operations */

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008-2015 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -115,6 +115,7 @@ void pmix_rte_finalize(void)
     PMIX_DESTRUCT(&pmix_globals.events);
     PMIX_LIST_DESTRUCT(&pmix_globals.cached_events);
     PMIX_DESTRUCT(&pmix_globals.notifications);
+    PMIX_LIST_DESTRUCT(&pmix_globals.iof_requests);
 
     /* now safe to release the event base */
     if (!pmix_globals.external_evbase) {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2009      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2010-2015 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -159,6 +159,8 @@ int pmix_rte_init(pmix_proc_type_t type,
     /* construct the global notification ring buffer */
     PMIX_CONSTRUCT(&pmix_globals.notifications, pmix_ring_buffer_t);
     pmix_ring_buffer_init(&pmix_globals.notifications, 256);
+    /* and setup the iof request tracking list */
+    PMIX_CONSTRUCT(&pmix_globals.iof_requests, pmix_list_t);
 
     /* Setup client verbosities as all procs are allowed to
      * access client APIs */
@@ -197,6 +199,12 @@ int pmix_rte_init(pmix_proc_type_t type,
         pmix_client_globals.event_output = pmix_output_open(NULL);
         pmix_output_set_verbosity(pmix_client_globals.event_output,
                                   pmix_client_globals.event_verbose);
+    }
+    if (0 < pmix_client_globals.iof_verbose) {
+        /* set default output */
+        pmix_client_globals.iof_output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(pmix_client_globals.iof_output,
+                                  pmix_client_globals.iof_verbose);
     }
 
     /* get our effective id's */

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -21,7 +21,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -95,105 +95,152 @@ pmix_status_t pmix_register_params(void)
     }
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", NULL, "event_caching_window",
-                                  "Time (in seconds) to aggregate events before reporting them - this "
-                                  "suppresses event cascades when processes abnormally terminate",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_event_caching_window);
+                                       "Time (in seconds) to aggregate events before reporting them - this "
+                                       "suppresses event cascades when processes abnormally terminate",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_event_caching_window);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", NULL, "suppress_missing_data_warning",
-                                  "Suppress warning that PMIx is missing job-level data that "
-                                  "is supposed to be provided by the host RM.",
-                                  PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_suppress_missing_data_warning);
+                                       "Suppress warning that PMIx is missing job-level data that "
+                                       "is supposed to be provided by the host RM.",
+                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_suppress_missing_data_warning);
 
     /****   CLIENT: VERBOSE OUTPUT PARAMS   ****/
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "get_verbose",
-                                  "Verbosity for client get operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.get_verbose);
+                                       "Verbosity for client get operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.get_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "connect_verbose",
-                                  "Verbosity for client connect operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.connect_verbose);
+                                       "Verbosity for client connect operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.connect_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "fence_verbose",
-                                  "Verbosity for client fence operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.fence_verbose);
+                                       "Verbosity for client fence operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.fence_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "pub_verbose",
-                                  "Verbosity for client publish, lookup, and unpublish operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.pub_verbose);
+                                       "Verbosity for client publish, lookup, and unpublish operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.pub_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "spawn_verbose",
-                                  "Verbosity for client spawn operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.spawn_verbose);
+                                       "Verbosity for client spawn operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.spawn_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "event_verbose",
-                                  "Verbosity for eventt spawn operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.event_verbose);
+                                       "Verbosity for client event notifications",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.event_verbose);
+
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "iof_verbose",
+                                       "Verbosity for client iof operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.iof_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "client", "base_verbose",
-                                  "Verbosity for basic client operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_client_globals.base_verbose);
+                                       "Verbosity for basic client operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_client_globals.base_verbose);
 
     /****   SERVER: VERBOSE OUTPUT PARAMS   ****/
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "get_verbose",
-                                  "Verbosity for server get operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.get_verbose);
+                                       "Verbosity for server get operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.get_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "connect_verbose",
-                                  "Verbosity for server connect operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.connect_verbose);
+                                       "Verbosity for server connect operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.connect_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "fence_verbose",
-                                  "Verbosity for server fence operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.fence_verbose);
+                                       "Verbosity for server fence operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.fence_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "pub_verbose",
-                                  "Verbosity for server publish, lookup, and unpublish operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.pub_verbose);
+                                       "Verbosity for server publish, lookup, and unpublish operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.pub_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "spawn_verbose",
-                                  "Verbosity for server spawn operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.spawn_verbose);
+                                       "Verbosity for server spawn operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.spawn_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "event_verbose",
-                                  "Verbosity for server event operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.event_verbose);
+                                       "Verbosity for server event operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.event_verbose);
+
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "iof_verbose",
+                                       "Verbosity for server iof operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.iof_verbose);
 
     (void) pmix_mca_base_var_register ("pmix", "pmix", "server", "base_verbose",
-                                  "Verbosity for basic server operations",
-                                  PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
-                                  PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
-                                  &pmix_server_globals.base_verbose);
+                                       "Verbosity for basic server operations",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.base_verbose);
 
+    /* check for maximum number of pending output messages */
+    pmix_globals.output_limit = (size_t) INT_MAX;
+    (void) pmix_mca_base_var_register("pmix", "iof", NULL, "output_limit",
+                                      "Maximum backlog of output messages [default: unlimited]",
+                                      PMIX_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,
+                                      PMIX_INFO_LVL_9,
+                                      PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                      &pmix_globals.output_limit);
+
+    pmix_globals.xml_output = false;
+    (void) pmix_mca_base_var_register ("pmix", "iof", NULL, "xml_output",
+                                       "Display all output in XML format (default: false)",
+                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                       PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                       &pmix_globals.xml_output);
+
+    /* whether to tag output */
+    /* if we requested xml output, be sure to tag the output as well */
+    pmix_globals.tag_output = pmix_globals.xml_output;
+    (void) pmix_mca_base_var_register ("pmix", "iof", NULL, "tag_output",
+                                       "Tag all output with [job,rank] (default: false)",
+                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                       PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                       &pmix_globals.tag_output);
+    if (pmix_globals.xml_output) {
+        pmix_globals.tag_output = true;
+    }
+
+    /* whether to timestamp output */
+    pmix_globals.timestamp_output = false;
+    (void) pmix_mca_base_var_register ("pmix", "iof", NULL, "timestamp_output",
+                                       "Timestamp all application process output (default: false)",
+                                       PMIX_MCA_BASE_VAR_TYPE_BOOL, NULL, 0, 0,
+                                       PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                       &pmix_globals.timestamp_output);
 
     return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -53,6 +53,7 @@
 
 #include "src/util/argv.h"
 #include "src/util/error.h"
+#include "src/util/name_fns.h"
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
 #include "src/util/show_help.h"
@@ -86,6 +87,14 @@ static pid_t mypid;
 static void server_message_handler(struct pmix_peer_t *pr,
                                    pmix_ptl_hdr_t *hdr,
                                    pmix_buffer_t *buf, void *cbdata);
+
+static void iof_eviction_cbfunc(struct pmix_hotel_t *hotel,
+                                int room_num,
+                                void *occupant)
+{
+    pmix_setup_caddy_t *cache = (pmix_setup_caddy_t*)occupant;
+    PMIX_RELEASE(cache);
+}
 
 PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                                            pmix_info_t info[], size_t ninfo)
@@ -129,6 +138,15 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     PMIX_CONSTRUCT(&pmix_server_globals.events, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.nspaces, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_hotel_t);
+    rc = pmix_hotel_init(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE,
+                         pmix_globals.evbase, PMIX_IOF_MAX_STAY,
+                         iof_eviction_cbfunc);
+    if (PMIX_SUCCESS != rc) {
+       PMIX_ERROR_LOG(rc);
+       PMIX_RELEASE_THREAD(&pmix_global_lock);
+       return rc;
+    }
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server init called");
@@ -169,6 +187,12 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         pmix_server_globals.event_output = pmix_output_open(NULL);
         pmix_output_set_verbosity(pmix_server_globals.event_output,
                                   pmix_server_globals.event_verbose);
+    }
+    if (0 < pmix_server_globals.iof_verbose) {
+        /* set default output */
+        pmix_server_globals.iof_output = pmix_output_open(NULL);
+        pmix_output_set_verbosity(pmix_server_globals.iof_output,
+                                  pmix_server_globals.iof_verbose);
     }
     /* setup the base verbosity */
     if (0 < pmix_server_globals.base_verbose) {
@@ -347,6 +371,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     int i;
     pmix_peer_t *peer;
     pmix_nspace_t *ns;
+    pmix_setup_caddy_t *cd;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -374,6 +399,14 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 
     pmix_ptl_base_stop_listening();
 
+    /* cleanout any IOF */
+    for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
+        pmix_hotel_checkout_and_return_occupant(&pmix_server_globals.iof, i, (void**)&cd);
+        if (NULL != cd) {
+            PMIX_RELEASE(cd);
+        }
+    }
+    PMIX_DESTRUCT(&pmix_server_globals.iof);
     for (i=0; i < pmix_server_globals.clients.size; i++) {
         if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {
             /* ensure that we do the specified cleanup - if this is an
@@ -1446,6 +1479,148 @@ pmix_status_t PMIx_server_setup_local_support(const char nspace[],
     return PMIX_SUCCESS;
 }
 
+static void _iofdeliver(int sd, short args, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+    pmix_iof_req_t *req;
+    pmix_status_t rc;
+    pmix_buffer_t *msg;
+    bool found = false;
+    bool cached = false;
+    int ignore;
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "PMIX:SERVER delivering IOF");
+
+    /* cycle across our list of IOF requestors and see who wants
+     * this channel from this source */
+    PMIX_LIST_FOREACH(req, &pmix_globals.iof_requests, pmix_iof_req_t) {
+        /* if the channel wasn't included, then ignore it */
+        if (!(cd->channels & req->channels)) {
+            continue;
+        }
+        /* if the source matches the request, then forward this along */
+        if (0 != strncmp(cd->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
+            (PMIX_RANK_WILDCARD != req->pname.rank && cd->procs->rank != req->pname.rank)) {
+            continue;
+        }
+        found = true;
+        /* setup the msg */
+        if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+            PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+            rc = PMIX_ERR_OUT_OF_RESOURCE;
+            break;
+        }
+        /* provide the source */
+        PMIX_BFROPS_PACK(rc, req->peer, msg, cd->procs, 1, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            break;
+        }
+        /* provide the channel */
+        PMIX_BFROPS_PACK(rc, req->peer, msg, &cd->channels, 1, PMIX_IOF_CHANNEL);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            break;
+        }
+        /* pack the data */
+        PMIX_BFROPS_PACK(rc, req->peer, msg, cd->bo, 1, PMIX_BYTE_OBJECT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            break;
+        }
+        /* send it to the requestor */
+        PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+        }
+    }
+
+    /* if nobody has registered for this yet, then cache it */
+    if (!found) {
+        /* add this output to our hotel so it is cached until someone
+         * registers to receive it */
+        if (PMIX_SUCCESS != (rc = pmix_hotel_checkin(&pmix_server_globals.iof, cd, &ignore))) {
+            /* we can't cache it for some reason */
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(cd);
+            return;
+        }
+        cached = true;
+    }
+
+
+    if (NULL != cd->opcbfunc) {
+        cd->opcbfunc(rc, cd->cbdata);
+    }
+    if (!cached) {
+        if (NULL != cd->info) {
+            PMIX_INFO_FREE(cd->info, cd->ninfo);
+        }
+        PMIX_PROC_FREE(cd->procs, 1);
+        PMIX_BYTE_OBJECT_FREE(cd->bo, 1);
+        PMIX_RELEASE(cd);
+    }
+}
+
+pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
+                                      pmix_iof_channel_t channel,
+                                      const pmix_byte_object_t *bo,
+                                      const pmix_info_t info[], size_t ninfo,
+                                      pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_setup_caddy_t *cd;
+    size_t n;
+
+    /* need to threadshift this request */
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    /* unfortunately, we need to copy the input because we
+     * might have to cache it for later delivery */
+    PMIX_PROC_CREATE(cd->procs, 1);
+    if (NULL == cd->procs) {
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    (void)strncpy(cd->procs[0].nspace, source->nspace, PMIX_MAX_NSLEN);
+    cd->procs[0].rank = source->rank;
+    cd->channels = channel;
+    PMIX_BYTE_OBJECT_CREATE(cd->bo, 1);
+    if (NULL == cd->bo) {
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    cd->bo[0].bytes = (char*)malloc(bo->size);
+    if (NULL == cd->bo[0].bytes) {
+        PMIX_BYTE_OBJECT_FREE(cd->bo, 1);
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOMEM;
+    }
+    memcpy(cd->bo[0].bytes, bo->bytes, bo->size);
+    cd->bo[0].size = bo->size;
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(cd->info, ninfo);
+        if (NULL == cd->info) {
+            PMIX_BYTE_OBJECT_FREE(cd->bo, 1);
+            PMIX_RELEASE(cd);
+            return PMIX_ERR_NOMEM;
+        }
+        cd->ninfo = ninfo;
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&cd->info[n], (pmix_info_t*)&info[n]);
+        }
+    }
+    cd->opcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+    PMIX_THREADSHIFT(cd, _iofdeliver);
+    return PMIX_SUCCESS;
+}
 
 /****    THE FOLLOWING CALLBACK FUNCTIONS ARE USED BY THE HOST SERVER    ****
  ****    THEY THEREFORE CAN OCCUR IN EITHER THE HOST SERVER'S THREAD     ****
@@ -2357,6 +2532,69 @@ static void validate_cbfunc(pmix_status_t status,
 }
 
 
+static void _iofreg(int sd, short args, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+    pmix_server_caddy_t *scd = (pmix_server_caddy_t*)cd->cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_OBJECT(cd);
+
+    /* setup the reply to the requestor */
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+        rc = PMIX_ERR_NOMEM;
+        goto cleanup;
+    }
+    /* start with the status */
+    PMIX_BFROPS_PACK(rc, scd->peer, reply, &cd->status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(reply);
+        goto cleanup;
+    }
+
+    /* was the request a success? */
+    if (PMIX_SUCCESS != cd->status) {
+        /* find and remove the tracker(s) */
+    }
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "server:_iofreg reply being sent to %s:%u",
+                        scd->peer->info->pname.nspace, scd->peer->info->pname.rank);
+    PMIX_SERVER_QUEUE_REPLY(scd->peer, scd->hdr.tag, reply);
+
+  cleanup:
+    /* release the cached info */
+    if (NULL != cd->procs) {
+        PMIX_PROC_FREE(cd->procs, cd->nprocs);
+    }
+    PMIX_INFO_FREE(cd->info, cd->ninfo);
+    /* we are done */
+    PMIX_RELEASE(cd);
+}
+
+static void iof_cbfunc(pmix_status_t status,
+                       void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "server:iof_cbfunc called with status %d",
+                        status);
+
+    if (NULL == cd) {
+        /* nothing to do */
+        return;
+    }
+    cd->status = status;
+
+    /* need to thread-shift this callback as it accesses global data */
+    PMIX_THREADSHIFT(cd, _iofreg);
+}
+
 /* the switchyard is the primary message handling function. It's purpose
  * is to take incoming commands (packed into a buffer), unpack them,
  * and then call the corresponding host server's function to execute
@@ -2605,6 +2843,18 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
     if (PMIX_VALIDATE_CRED_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         rc = pmix_server_validate_credential(peer, buf, validate_cbfunc, cd);
+        return rc;
+    }
+
+    if (PMIX_IOF_PULL_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        rc = pmix_server_iofreg(peer, buf, iof_cbfunc, cd);
+        return rc;
+    }
+
+    if (PMIX_IOF_PUSH_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        rc = pmix_server_iofstdin(peer, buf, op_cbfunc, cd);
         return rc;
     }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -48,6 +48,7 @@
 #endif
 #include PMIX_EVENT_HEADER
 
+#include "src/class/pmix_hotel.h"
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/util/argv.h"
@@ -1025,7 +1026,76 @@ static void spcbfunc(pmix_status_t status,
                      char nspace[], void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+    pmix_iof_req_t *req;
+    pmix_setup_caddy_t *occupant;
+    int i;
+    pmix_buffer_t *msg;
+    pmix_status_t rc;
 
+    /* if it was successful, and there are IOF requests, then
+     * register them now */
+    if (PMIX_SUCCESS == status && PMIX_FWD_NO_CHANNELS != cd->channels) {
+         /* record the request */
+        req = PMIX_NEW(pmix_iof_req_t);
+        if (NULL != req) {
+            PMIX_RETAIN(cd->peer);
+            req->peer = cd->peer;
+            req->pname.nspace = strdup(nspace);
+            req->pname.rank = PMIX_RANK_WILDCARD;
+            req->channels = cd->channels;
+            pmix_list_append(&pmix_globals.iof_requests, &req->super);
+        }
+        /* process any cached IO */
+        for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
+            pmix_hotel_knock(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1, (void**)&occupant);
+            if (NULL != occupant) {
+                if (!(occupant->channels & req->channels)) {
+                    continue;
+                }
+                /* if the source matches the request, then forward this along */
+                if (0 != strncmp(occupant->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
+                    (PMIX_RANK_WILDCARD != req->pname.rank && occupant->procs->rank != req->pname.rank)) {
+                    continue;
+                }
+                /* setup the msg */
+                if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    rc = PMIX_ERR_OUT_OF_RESOURCE;
+                    break;
+                }
+                /* provide the source */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->procs, 1, PMIX_PROC);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* provide the channel */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, &occupant->channels, 1, PMIX_IOF_CHANNEL);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* pack the data */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->bo, 1, PMIX_BYTE_OBJECT);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* send it to the requestor */
+                PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                }
+                /* remove it from the hotel since it has now been forwarded */
+                pmix_hotel_checkout(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1);
+                PMIX_RELEASE(occupant);
+            }
+        }
+    }
     /* cleanup the caddy */
     if (NULL != cd->info) {
         PMIX_INFO_FREE(cd->info, cd->ninfo);
@@ -1048,7 +1118,8 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
     int32_t cnt;
     pmix_status_t rc;
     pmix_proc_t proc;
-    size_t ninfo;
+    size_t ninfo, n;
+    bool stdout_found = false, stderr_found = false, stddiag_found = false;
 
     pmix_output_verbose(2, pmix_server_globals.spawn_output,
                         "recvd SPAWN");
@@ -1063,6 +1134,8 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
     if (NULL == cd) {
         return PMIX_ERR_NOMEM;
     }
+    PMIX_RETAIN(peer);
+    cd->peer = peer;
     cd->spcbfunc = cbfunc;
     cd->cbdata = cbdata;
 
@@ -1091,10 +1164,48 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
             PMIX_ERROR_LOG(rc);
             goto cleanup;
         }
+        /* run a quick check of the directives to see if any IOF
+         * requests were included so we can set that up now - helps
+         * to catch any early output */
+        cd->channels = PMIX_FWD_NO_CHANNELS;
+        for (n=0; n < cd->ninfo; n++) {
+            if (0 == strncmp(cd->info[n].key, PMIX_FWD_STDIN, PMIX_MAX_KEYLEN)) {
+                stdout_found = true;
+                if (PMIX_INFO_TRUE(&cd->info[n])) {
+                    cd->channels |= PMIX_FWD_STDIN_CHANNEL;
+                }
+            } else if (0 == strncmp(cd->info[n].key, PMIX_FWD_STDOUT, PMIX_MAX_KEYLEN)) {
+                if (PMIX_INFO_TRUE(&cd->info[n])) {
+                    cd->channels |= PMIX_FWD_STDOUT_CHANNEL;
+                }
+            } else if (0 == strncmp(cd->info[n].key, PMIX_FWD_STDERR, PMIX_MAX_KEYLEN)) {
+                stderr_found = true;
+                if (PMIX_INFO_TRUE(&cd->info[n])) {
+                    cd->channels |= PMIX_FWD_STDERR_CHANNEL;
+                }
+            } else if (0 == strncmp(cd->info[n].key, PMIX_FWD_STDDIAG, PMIX_MAX_KEYLEN)) {
+                stddiag_found = true;
+                if (PMIX_INFO_TRUE(&cd->info[n])) {
+                    cd->channels |= PMIX_FWD_STDDIAG_CHANNEL;
+                }
+            }
+        }
+        /* we will construct any required iof request tracker upon completion of the spawn */
     }
     /* add the directive to the end */
     if (PMIX_PROC_IS_TOOL(peer)) {
         PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_REQUESTOR_IS_TOOL, NULL, PMIX_BOOL);
+        /* if the requestor is a tool, we default to forwarding all
+         * output IO channels */
+        if (!stdout_found) {
+            cd->channels |= PMIX_FWD_STDOUT_CHANNEL;
+        }
+        if (!stderr_found) {
+            cd->channels |= PMIX_FWD_STDERR_CHANNEL;
+        }
+        if (!stddiag_found) {
+            cd->channels |= PMIX_FWD_STDDIAG_CHANNEL;
+        }
     } else {
         PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_REQUESTOR_IS_CLIENT, NULL, PMIX_BOOL);
     }
@@ -2542,6 +2653,296 @@ pmix_status_t pmix_server_validate_credential(pmix_peer_t *peer,
     return rc;
 }
 
+pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
+                                 pmix_buffer_t *buf,
+                                 pmix_op_cbfunc_t cbfunc,
+                                 void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc;
+    pmix_setup_caddy_t *cd;
+    pmix_iof_req_t *req;
+    bool notify, match;
+    size_t n;
+    int i;
+    pmix_setup_caddy_t *occupant;
+    pmix_buffer_t *msg;
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "recvd IOF PULL request from client");
+
+    if (NULL == pmix_host_server.iof_pull) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->cbdata = cbdata;  // this is the pmix_server_caddy_t
+
+    /* unpack the number of procs */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->nprocs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    /* unpack the procs */
+    if (0 < cd->nprocs) {
+        PMIX_PROC_CREATE(cd->procs, cd->nprocs);
+        cnt = cd->nprocs;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, cd->procs, &cnt, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+    }
+
+    /* unpack the number of directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+    /* unpack the directives */
+    if (0 < cd->ninfo) {
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        cnt = cd->ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+    }
+
+    /* unpack the channels */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->channels, &cnt, PMIX_IOF_CHANNEL);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto exit;
+    }
+
+    /* check to see if we have already registered this source/channel combination */
+    notify = false;
+    for (n=0; n < cd->nprocs; n++) {
+        match = false;
+        PMIX_LIST_FOREACH(req, &pmix_globals.iof_requests, pmix_iof_req_t) {
+            /* is this request from the same peer? */
+            if (peer != req->peer) {
+                continue;
+            }
+            /* do we already have this source for this peer? */
+            if (0 == strncmp(cd->procs[n].nspace, req->pname.nspace, PMIX_MAX_NSLEN) &&
+                (PMIX_RANK_WILDCARD == req->pname.rank || cd->procs[n].rank == req->pname.rank)) {
+                match = true;
+                if ((req->channels & cd->channels) != cd->channels) {
+                    /* this is a channel update */
+                    req->channels |= cd->channels;
+                    /* we need to notify the host */
+                    notify = true;
+                }
+                break;
+            }
+        }
+        /* if we didn't find the matching entry, then add it */
+        if (!match) {
+            /* record the request */
+            req = PMIX_NEW(pmix_iof_req_t);
+            if (NULL == req) {
+                rc = PMIX_ERR_NOMEM;
+                goto exit;
+            }
+            PMIX_RETAIN(peer);
+            req->peer = peer;
+            req->pname.nspace = strdup(cd->procs[n].nspace);
+            req->pname.rank = cd->procs[n].rank;
+            req->channels = cd->channels;
+            pmix_list_append(&pmix_globals.iof_requests, &req->super);
+        }
+        /* process any cached IO */
+        for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
+            pmix_hotel_knock(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1, (void**)&occupant);
+            if (NULL != occupant) {
+                if (!(occupant->channels & req->channels)) {
+                    continue;
+                }
+                /* if the source matches the request, then forward this along */
+                if (0 != strncmp(occupant->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
+                    (PMIX_RANK_WILDCARD != req->pname.rank && occupant->procs->rank != req->pname.rank)) {
+                    continue;
+                }
+                /* setup the msg */
+                if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                    rc = PMIX_ERR_OUT_OF_RESOURCE;
+                    break;
+                }
+                /* provide the source */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->procs, 1, PMIX_PROC);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* provide the channel */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, &occupant->channels, 1, PMIX_IOF_CHANNEL);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* pack the data */
+                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->bo, 1, PMIX_BYTE_OBJECT);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                    break;
+                }
+                /* send it to the requestor */
+                PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_RELEASE(msg);
+                }
+                /* remove it from the hotel since it has now been forwarded */
+                pmix_hotel_checkout(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1);
+                PMIX_RELEASE(occupant);
+            }
+        }
+    }
+    if (notify) {
+        /* ask the host to execute the request */
+        if (PMIX_SUCCESS != (rc = pmix_host_server.iof_pull(cd->procs, cd->nprocs,
+                                                            cd->info, cd->ninfo,
+                                                            cd->channels,
+                                                            cbfunc, cd))) {
+            goto exit;
+        }
+    }
+    return PMIX_SUCCESS;
+
+  exit:
+    PMIX_RELEASE(cd);
+    return rc;
+}
+
+static void stdcbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
+
+    if (NULL != cd->opcbfunc) {
+        cd->opcbfunc(status, cd->cbdata);
+    }
+    if (NULL != cd->procs) {
+        PMIX_PROC_FREE(cd->procs, cd->nprocs);
+    }
+    if (NULL != cd->info) {
+        PMIX_INFO_FREE(cd->info, cd->ninfo);
+    }
+    if (NULL != cd->bo) {
+        PMIX_BYTE_OBJECT_FREE(cd->bo, 1);
+    }
+    PMIX_RELEASE(cd);
+}
+
+pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
+                                   pmix_buffer_t *buf,
+                                   pmix_op_cbfunc_t cbfunc,
+                                   void *cbdata)
+{
+    int32_t cnt;
+    pmix_status_t rc;
+    pmix_proc_t source;
+    pmix_setup_caddy_t *cd;
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "recvd stdin IOF data from tool");
+
+    if (NULL == pmix_host_server.push_stdin) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    if (NULL == cd) {
+        return PMIX_ERR_NOMEM;
+    }
+    cd->opcbfunc = cbfunc;
+    cd->cbdata = cbdata;
+
+    /* unpack the number of targets */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->nprocs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    if (0 < cd->nprocs) {
+        PMIX_PROC_CREATE(cd->procs, cd->nprocs);
+        if (NULL == cd->procs) {
+            rc = PMIX_ERR_NOMEM;
+            goto error;
+        }
+        cnt = cd->nprocs;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, cd->procs, &cnt, PMIX_PROC);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto error;
+        }
+    }
+
+    /* unpack the number of directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    if (0 < cd->ninfo) {
+        PMIX_INFO_CREATE(cd->info, cd->ninfo);
+        if (NULL == cd->info) {
+            rc = PMIX_ERR_NOMEM;
+            goto error;
+        }
+        cnt = cd->ninfo;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto error;
+        }
+    }
+
+    /* unpack the data */
+    PMIX_BYTE_OBJECT_CREATE(cd->bo, 1);
+    if (NULL == cd->bo) {
+        rc = PMIX_ERR_NOMEM;
+        goto error;
+    }
+
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, cd->bo, &cnt, PMIX_BYTE_OBJECT);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+
+    /* pass the data to the host */
+    (void)strncpy(source.nspace, peer->nptr->nspace, PMIX_MAX_NSLEN);
+    source.rank = peer->info->pname.rank;
+    if (PMIX_SUCCESS != (rc = pmix_host_server.push_stdin(&source, cd->procs, cd->nprocs,
+                                                          cd->info, cd->ninfo, cd->bo,
+                                                          stdcbfunc, cd))) {
+        goto error;
+    }
+    return PMIX_SUCCESS;
+
+  error:
+    PMIX_RELEASE(cd);
+    return rc;
+}
+
 /*****    INSTANCE SERVER LIBRARY CLASSES    *****/
 static void tcon(pmix_server_trkr_t *t)
 {
@@ -2603,6 +3004,7 @@ PMIX_CLASS_INSTANCE(pmix_server_caddy_t,
 
 static void scadcon(pmix_setup_caddy_t *p)
 {
+    p->peer = NULL;
     memset(&p->proc, 0, sizeof(pmix_proc_t));
     PMIX_CONSTRUCT_LOCK(&p->lock);
     p->nspace = NULL;
@@ -2615,6 +3017,8 @@ static void scadcon(pmix_setup_caddy_t *p)
     p->info = NULL;
     p->ninfo = 0;
     p->keys = NULL;
+    p->channels = PMIX_FWD_NO_CHANNELS;
+    p->bo = NULL;
     p->cbfunc = NULL;
     p->opcbfunc = NULL;
     p->setupcbfunc = NULL;
@@ -2624,6 +3028,9 @@ static void scadcon(pmix_setup_caddy_t *p)
 }
 static void scaddes(pmix_setup_caddy_t *p)
 {
+    if (NULL != p->peer) {
+        PMIX_RELEASE(p->peer);
+    }
     PMIX_DESTRUCT_LOCK(&p->lock);
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,

--- a/src/util/fd.c
+++ b/src/util/fd.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -20,6 +20,12 @@
 #endif
 #include <errno.h>
 #include <fcntl.h>
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
 
 #include "src/util/error.h"
 #include "src/util/fd.h"
@@ -92,4 +98,32 @@ pmix_status_t pmix_fd_set_cloexec(int fd)
 #endif
 
     return PMIX_SUCCESS;
+}
+
+
+bool pmix_fd_is_regular(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISREG(buf.st_mode);
+}
+
+bool pmix_fd_is_chardev(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISCHR(buf.st_mode);
+}
+
+bool pmix_fd_is_blkdev(int fd)
+{
+    struct stat buf;
+    if (fstat(fd, &buf)) {
+        return false;
+    }
+    return S_ISBLK(buf.st_mode);
 }

--- a/src/util/fd.h
+++ b/src/util/fd.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2008-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2009      Sandia National Laboratories. All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -66,6 +66,37 @@ PMIX_EXPORT pmix_status_t pmix_fd_write(int fd, int len, const void *buffer);
  * to setting a file descriptor to be close-on-exec.
  */
 PMIX_EXPORT pmix_status_t pmix_fd_set_cloexec(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible regular file.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+PMIX_EXPORT bool pmix_fd_is_regular(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible character device.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+PMIX_EXPORT bool pmix_fd_is_chardev(int fd);
+
+/**
+ * Convenience function to check if fd point to an accessible block device.
+ *
+ * @param fd File descriptor
+ *
+ * @returns true if "fd" points to a regular file.
+ * @returns false otherwise.
+ */
+PMIX_EXPORT bool pmix_fd_is_blkdev(int fd);
+
 
 END_C_DECLS
 


### PR DESCRIPTION
Add several IOF-related attributes. Define a new pmix_iof_t bitmask
identifying what channels are to be forwarded. Provide support for
registering/deregistering IOF, and for the host RM to distribute
collected data.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>