### PR TITLE
 Fixed server-side get logic when there is no key in GDS

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -125,6 +125,7 @@ static void pcon(pmix_peer_t *p)
     PMIX_CONSTRUCT(&p->send_queue, pmix_list_t);
     p->send_msg = NULL;
     p->recv_msg = NULL;
+    p->commit_cnt = 0;
 }
 static void pdes(pmix_peer_t *p)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -180,6 +180,7 @@ typedef struct pmix_peer_t {
     pmix_list_t send_queue;         /**< list of messages to send */
     pmix_ptl_send_t *send_msg;      /**< current send in progress */
     pmix_ptl_recv_t *recv_msg;      /**< current recv in progress */
+    int commit_cnt;
 } pmix_peer_t;
 PMIX_CLASS_DECLARATION(pmix_peer_t);
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -550,35 +550,22 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
             *local = true;
         }
         if (PMIX_RANK_WILDCARD != rank) {
+            peer = NULL;
             /* see if the requested rank is local */
             PMIX_LIST_FOREACH(iptr, &nptr->ranks, pmix_rank_info_t) {
                 if (rank == iptr->pname.rank) {
                     scope = PMIX_LOCAL;
+                    if (0 <= iptr->peerid) {
+                        peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid);
+                    }
+                    if (NULL == peer) {
+                        /* this rank has not connected yet, so this request needs to be held */
+                        return PMIX_ERR_NOT_FOUND;
+                    }
                     break;
                 }
             }
-            if (PMIX_LOCAL == scope) {
-                /* must have found a local rank
-                 * we need the personality module for a client from this
-                 * nspace, but it doesn't matter which one as they all
-                 * must use the same GDS module. We don't know the GDS
-                 * module, however, until _after_ the first local client
-                 * connects to us. Since the nspace of the requestor may
-                 * not match the nspace of the proc whose info is being
-                 * requested, we cannot be sure this will have occurred.
-                 * So we have to loop again to see if someone has connected */
-                peer = NULL;
-                PMIX_LIST_FOREACH(iptr, &nptr->ranks, pmix_rank_info_t) {
-                    if (0 <= iptr->peerid) {
-                        peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, iptr->peerid);
-                        break;
-                    }
-                }
-                if (NULL == peer) {
-                    /* nobody has connected yet, so this request needs to be held */
-                    return PMIX_ERR_NOT_FOUND;
-                }
-            } else {
+            if (PMIX_LOCAL != scope)  {
                 /* this must be a remote rank */
                 if (local) {
                     *local = false;
@@ -658,6 +645,9 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 
     /* retrieve the data for the specific rank they are asking about */
     if (PMIX_RANK_WILDCARD != rank) {
+        if (!peer->commit_cnt) {
+            return PMIX_ERR_NOT_FOUND;
+        }
         proc.rank = rank;
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         /* this is a local request, so give the gds the option

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -226,6 +226,9 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
     /* mark us as having successfully received a blob from this proc */
     info->modex_recvd = true;
 
+    /* update the commit counter */
+    peer->commit_cnt++;
+
     /* see if anyone remote is waiting on this data - could be more than one */
     PMIX_LIST_FOREACH_SAFE(dcd, dcdnext, &pmix_server_globals.remote_pnd, pmix_dmdx_remote_t) {
         if (0 != strncmp(dcd->cd->proc.nspace, nptr->nspace, PMIX_MAX_NSLEN)) {


### PR DESCRIPTION
- added the flag indicating the rank has invoked `commit`
- the request is moved to pending till the requested rank does not invoke `commit`

Signed-off-by: Boris Karasev <karasev.b@gmail.com>