### PR TITLE
Ensure pmi/pmi2 compat libs have all symbols

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -74,8 +74,12 @@ if WANT_PMI_BACKWARD
 lib_LTLIBRARIES += libpmi.la libpmi2.la
 libpmi_la_SOURCES = $(headers) $(sources)
 libpmi_la_LDFLAGS = -version-info $(libpmi_so_version)
+libpmi_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi_la_DEPENDENCIES = $(libpmi_la_LIBADD)
 libpmi2_la_SOURCES = $(headers) $(sources)
 libpmi2_la_LDFLAGS = -version-info $(libpmi2_so_version)
+libpmi2_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi2_la_DEPENDENCIES = $(libpmi2_la_LIBADD)
 endif
 
 endif !PMIX_EMBEDDED_MODE

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -29,7 +29,7 @@ headers += \
         runtime/pmix_rte.h \
         runtime/pmix_progress_threads.h
 
-libpmix_la_SOURCES += \
+sources += \
         runtime/pmix_finalize.c \
         runtime/pmix_init.c \
         runtime/pmix_params.c \

--- a/src/threads/Makefile.include
+++ b/src/threads/Makefile.include
@@ -32,7 +32,7 @@ headers += \
         threads/wait_sync.h \
 	threads/thread_usage.h
 
-libpmix_la_SOURCES += \
+sources += \
         threads/mutex.c \
         threads/thread.c \
         threads/wait_sync.c


### PR DESCRIPTION
This patch allows you to `dlopen` the libpmi/libpmi2 compat libraries using `RTLD_NOW` which is desirable for hardened environments.   There were a plethora of undefined `pmix_` symbols in those libraries which I've eliminated by building the same code for all 3 libraries.   There are no doubt more surgically precise ways to ensure libpmi and libpmi2 contain no extraneous code, but this method is simple and seems like a good first step.  Test program below.

```
#include <stdio.h>
#include <stdlib.h>
#include <dlfcn.h>

#define PMI "/usr/lib64/libpmi.so"
#define PMI2 "/usr/lib64/libpmi2.so"

int main()
{
        void *handle = dlopen(PMI, RTLD_NOW);
        if (!handle) {
                fprintf(stderr, "%s\n", dlerror());
                exit(EXIT_FAILURE);
        }
        dlerror();
        dlclose(handle);
        handle = dlopen(PMI2, RTLD_NOW);
        if (!handle) {
                fprintf(stderr, "%s\n", dlerror());
                exit(EXIT_FAILURE);
        }
        dlerror();
        dlclose(handle);
        return 0;
}

```