### PR TITLE
Cleanup separation of PMI-1/2 and PMIx symbols

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,10 @@ nodist_headers =
 EXTRA_DIST =
 dist_pmixdata_DATA =
 
+# place to capture sources for backward compatibility libs
+pmi1_sources =
+pmi2_sources =
+
 libpmix_la_LIBADD = \
 	mca/base/libpmix_mca_base.la \
 	$(MCA_pmix_FRAMEWORK_LIBS) \
@@ -73,10 +77,15 @@ libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
 
 if WANT_PMI_BACKWARD
 lib_LTLIBRARIES += libpmi.la libpmi2.la
-libpmi_la_SOURCES = $(headers) $(sources)
+libpmi_la_SOURCES = $(headers) $(sources) $(pmi1_sources)
 libpmi_la_LDFLAGS = -version-info $(libpmi_so_version)
-libpmi2_la_SOURCES = $(headers) $(sources)
+libpmi_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi_la_DEPENDENCIES = $(libpmi_la_LIBADD)
+
+libpmi2_la_SOURCES = $(headers) $(sources) $(pmi2_sources)
 libpmi2_la_LDFLAGS = -version-info $(libpmi2_so_version)
+libpmi2_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi2_la_DEPENDENCIES = $(libpmi2_la_LIBADD)
 endif
 
 endif !PMIX_EMBEDDED_MODE

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -23,7 +23,8 @@ sources += \
         client/pmix_client_connect.c
 
 if WANT_PMI_BACKWARD
-sources += \
-        client/pmi1.c \
+pmi1_sources += \
+        client/pmi1.c
+pmi2_sources += \
         client/pmi2.c
 endif

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved.
-# Copyright (c) 2014-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -29,7 +29,7 @@ headers += \
         runtime/pmix_rte.h \
         runtime/pmix_progress_threads.h
 
-libpmix_la_SOURCES += \
+sources += \
         runtime/pmix_finalize.c \
         runtime/pmix_init.c \
         runtime/pmix_params.c \

--- a/src/threads/Makefile.include
+++ b/src/threads/Makefile.include
@@ -32,7 +32,7 @@ headers += \
         threads/wait_sync.h \
 	threads/thread_usage.h
 
-libpmix_la_SOURCES += \
+sources += \
         threads/mutex.c \
         threads/thread.c \
         threads/wait_sync.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -51,13 +51,13 @@ pmi_client_SOURCES = $(headers) \
         pmi_client.c
 pmi_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi_client_LDADD = \
-    $(top_builddir)/src/libpmix.la
+    $(top_builddir)/src/libpmi.la
 
 pmi2_client_SOURCES = $(headers) \
         pmi2_client.c
 pmi2_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi2_client_LDADD = \
-    $(top_builddir)/src/libpmix.la
+    $(top_builddir)/src/libpmi2.la
 endif
 
 pmix_client_SOURCES = $(headers) \


### PR DESCRIPTION
Port the proposed patch in #617 from @pkovacs to master. It is not quite complete, however, as we shouldn't have PMI-1 or PMI-2 symbols in libpmix, nor should we have PMI-1 symbols in libpmi2 and vice versa. So fix all that and adjust the test linkages to match

Signed-off-by: Ralph Castain <rhc@open-mpi.org>