### PR TITLE
psec/munge: use munge configure.m4 vars; use C99 designated initializers

### DIFF
--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+AM_CPPFLAGS = $(psec_munge_CPPFLAGS)
+
 headers = psec_munge.h
 sources = \
         psec_munge_component.c \
@@ -43,8 +45,10 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_munge_la_SOURCES = $(component_sources)
-mca_psec_munge_la_LDFLAGS = -module -avoid-version
+mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_munge_la_SOURCES = $(lib_sources)
-libmca_psec_munge_la_LDFLAGS = -module -avoid-version
+libmca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+libmca_psec_munge_la_LIBADD = $(psec_munge_LIBS)

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -40,13 +40,11 @@ static pmix_status_t validate_cred(struct pmix_peer_t *peer,
                                    const pmix_byte_object_t *cred);
 
 pmix_psec_module_t pmix_munge_module = {
-    "munge",
-    munge_init,
-    munge_finalize,
-    create_cred,
-    NULL,
-    validate_cred,
-    NULL
+    .name = "munge",
+    .init = munge_init,
+    .finalize = munge_finalize,
+    .create_cred = create_cred,
+    .validate_cred = validate_cred
 };
 
 static char *mycred = NULL;


### PR DESCRIPTION
Signed-off-by: Philip Kovacs <pkdevel@yahoo.com>

- Link psec/munge to munge library for `munge_decode` and `munge_encode`.
- Use C99 designated initializers for `pmix_psec_module_t`, just like the other modules.