### PR TITLE
psec/native: fix usage of the socket descriptor

### DIFF
--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -1,7 +1,8 @@
 /*
  * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- *
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -187,8 +188,8 @@ static pmix_status_t validate_cred(struct pmix_peer_t *peer,
 
 #elif defined(HAVE_GETPEEREID)
         pmix_output_verbose(2, pmix_globals.debug_output,
-                            "psec:native checking getpeereid on socket %d for peer credentials", sd);
-        if (0 != getpeereid(sd, &euid, &egid)) {
+                            "psec:native checking getpeereid on socket %d for peer credentials", pr->sd);
+        if (0 != getpeereid(pr->sd, &euid, &egid)) {
             pmix_output_verbose(2, pmix_globals.debug_output,
                                 "psec: getsockopt getpeereid failed: %s",
                                 strerror (pmix_socket_errno));


### PR DESCRIPTION
add missing bits from pmix/pmix@89b6251a7666d14ae60955a89ad96ddbd9b6e6d6
and fix build os OS (such as OS X) that have HAVE_GETPEEREID

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>