### PR TITLE
Some cleanup for the psec framework

### DIFF
--- a/src/mca/psec/base/psec_base_select.c
+++ b/src/mca/psec/base/psec_base_select.c
@@ -74,12 +74,21 @@ int pmix_psec_base_select(void)
         if (PMIX_SUCCESS != rc || NULL == module) {
             pmix_output_verbose(5, pmix_psec_base_framework.framework_output,
                                 "mca:psec:select: Skipping component [%s]. Query failed to return a module",
-                                component->pmix_mca_component_name );
+                                component->pmix_mca_component_name);
+            continue;
+        }
+        nmodule = (pmix_psec_module_t*) module;
+
+        /* give the module a chance to init */
+        if (NULL != nmodule->init && PMIX_SUCCESS != nmodule->init()) {
+            /* failed to init, so skip it */
+            pmix_output_verbose(5, pmix_psec_base_framework.framework_output,
+                                "mca:psec:select: Skipping component [%s]. Failed to init",
+                                component->pmix_mca_component_name);
             continue;
         }
 
         /* If we got a module, keep it */
-        nmodule = (pmix_psec_module_t*) module;
         /* add to the list of selected modules */
         newmodule = PMIX_NEW(pmix_psec_base_active_module_t);
         newmodule->pri = priority;

--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -73,6 +73,9 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer,
     gid_t egid;
     char *tmp, *ptr;
 
+    /* ensure initialization */
+    PMIX_BYTE_OBJECT_CONSTRUCT(cred);
+
     /* we may be responding to a local request for a credential, so
      * see if they specified a mechanism */
     if (NULL != directives && 0 < ndirs) {

--- a/src/mca/psec/none/psec_none.c
+++ b/src/mca/psec/none/psec_none.c
@@ -66,6 +66,9 @@ static pmix_status_t create_cred(struct pmix_peer_t *peer,
                                  pmix_info_t **info, size_t *ninfo,
                                  pmix_byte_object_t *cred)
 {
+    /* ensure initialization */
+    PMIX_BYTE_OBJECT_CONSTRUCT(cred);
+
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
Provide a chance for psec modules to init. Ensure that the credential byte object is always initialized, even when we return an error. Add thread protection to psec/munge module.

Fixes #620 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>