### PR TITLE
    v2.1 bugfix rollup

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -43,6 +43,10 @@ nodist_headers =
 EXTRA_DIST =
 dist_pmixdata_DATA =
 
+# place to capture sources for backward compatibility libs
+pmi1_sources =
+pmi2_sources =
+
 libpmix_la_LIBADD = \
 	mca/base/libpmix_mca_base.la \
 	$(MCA_pmix_FRAMEWORK_LIBS) \
@@ -73,10 +77,15 @@ libpmix_la_LDFLAGS = -version-info $(libpmix_so_version)
 
 if WANT_PMI_BACKWARD
 lib_LTLIBRARIES += libpmi.la libpmi2.la
-libpmi_la_SOURCES = $(headers) $(sources)
+libpmi_la_SOURCES = $(headers) $(sources) $(pmi1_sources)
 libpmi_la_LDFLAGS = -version-info $(libpmi_so_version)
-libpmi2_la_SOURCES = $(headers) $(sources)
+libpmi_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi_la_DEPENDENCIES = $(libpmi_la_LIBADD)
+
+libpmi2_la_SOURCES = $(headers) $(sources) $(pmi2_sources)
 libpmi2_la_LDFLAGS = -version-info $(libpmi2_so_version)
+libpmi2_la_LIBADD = $(libpmix_la_LIBADD)
+libpmi2_la_DEPENDENCIES = $(libpmi2_la_LIBADD)
 endif
 
 endif !PMIX_EMBEDDED_MODE

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -23,7 +23,8 @@ sources += \
         client/pmix_client_connect.c
 
 if WANT_PMI_BACKWARD
-sources += \
-        client/pmi1.c \
+pmi1_sources += \
+        client/pmi1.c
+pmi2_sources += \
         client/pmi2.c
 endif

--- a/src/mca/base/pmix_mca_base_var.h
+++ b/src/mca/base/pmix_mca_base_var.h
@@ -95,7 +95,7 @@ typedef enum {
     PMIX_MCA_BASE_VAR_TYPE_MAX
 } pmix_mca_base_var_type_t;
 
-extern const char *pmix_var_type_names[];
+PMIX_EXPORT extern const char *pmix_var_type_names[];
 
 /**
  * Source of an MCA variable's value
@@ -298,7 +298,7 @@ BEGIN_C_DECLS
 /**
  * Object declarayion for pmix_mca_base_var_t
  */
-PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
 
 /**
  * Initialize the MCA variable system.
@@ -309,7 +309,7 @@ PMIX_CLASS_DECLARATION(pmix_mca_base_var_t);
  * invoked internally (by pmix_mca_base_open()) and is only documented
  * here for completeness.
  */
-int pmix_mca_base_var_init(void);
+PMIX_EXPORT int pmix_mca_base_var_init(void);
 
 /**
  * Register an MCA variable
@@ -489,7 +489,7 @@ PMIX_EXPORT int pmix_mca_base_var_register_synonym (int synonym_for, const char 
  *
  * If an enumerator is associated with this variable it will be dereferenced.
  */
-int pmix_mca_base_var_deregister(int vari);
+PMIX_EXPORT int pmix_mca_base_var_deregister(int vari);
 
 
 /**
@@ -512,9 +512,9 @@ int pmix_mca_base_var_deregister(int vari);
  * Note: The value can be changed by the registering code without using
  * the pmix_mca_base_var_* interface so the source may be incorrect.
  */
-int pmix_mca_base_var_get_value (int vari, void *value,
-                                 pmix_mca_base_var_source_t *source,
-                                 const char **source_file);
+PMIX_EXPORT int pmix_mca_base_var_get_value (int vari, void *value,
+                                             pmix_mca_base_var_source_t *source,
+                                             const char **source_file);
 
 /**
  * Sets an "override" value for an integer MCA variable.
@@ -537,9 +537,9 @@ int pmix_mca_base_var_get_value (int vari, void *value,
  * a synonym the variable the synonym represents) if the value is
  * settable.
  */
-int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
-                                 pmix_mca_base_var_source_t source,
-                                 const char *source_file);
+PMIX_EXPORT int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
+                                             pmix_mca_base_var_source_t source,
+                                             const char *source_file);
 
 /**
  * Get the string name corresponding to the MCA variable
@@ -554,8 +554,8 @@ int pmix_mca_base_var_set_value (int vari, const void *value, size_t size,
  * The string that is returned is owned by the caller; if
  * appropriate, it must be eventually freed by the caller.
  */
-int pmix_mca_base_var_env_name(const char *param_name,
-                               char **env_name);
+PMIX_EXPORT int pmix_mca_base_var_env_name(const char *param_name,
+                                           char **env_name);
 
 /**
  * Find the index for an MCA variable based on its names.
@@ -574,10 +574,10 @@ int pmix_mca_base_var_env_name(const char *param_name,
  * of any registered variable.  The returned index can be used with
  * pmix_mca_base_var_get() and pmix_mca_base_var_get_value().
  */
-int pmix_mca_base_var_find (const char *project_name,
-                            const char *type_name,
-                            const char *component_name,
-                            const char *param_name);
+PMIX_EXPORT int pmix_mca_base_var_find (const char *project_name,
+                                        const char *type_name,
+                                        const char *component_name,
+                                        const char *param_name);
 
 /**
  * Find the index for a variable based on its full name
@@ -587,7 +587,7 @@ int pmix_mca_base_var_find (const char *project_name,
  *
  * See pmix_mca_base_var_find().
  */
-int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
+PMIX_EXPORT int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
 
 /**
  * Check that two MCA variables were not both set to non-default
@@ -617,13 +617,13 @@ int pmix_mca_base_var_find_by_name (const char *full_name, int *vari);
  * are not MCA_BASE_VAR_SOURCE_DEFAULT.
  * @returns PMIX_SUCCESS otherwise.
  */
-int pmix_mca_base_var_check_exclusive (const char *project,
-                                       const char *type_a,
-                                       const char *component_a,
-                                       const char *param_a,
-                                       const char *type_b,
-                                       const char *component_b,
-                                       const char *param_b);
+PMIX_EXPORT int pmix_mca_base_var_check_exclusive (const char *project,
+                                                   const char *type_a,
+                                                   const char *component_a,
+                                                   const char *param_a,
+                                                   const char *type_b,
+                                                   const char *component_b,
+                                                   const char *param_b);
 
 /**
  * Set or unset a flag on a variable.
@@ -636,8 +636,8 @@ int pmix_mca_base_var_check_exclusive (const char *project,
  * @returns PMIX_ERR_BAD_PARAM If the variable is not registered.
  * @returns PMIX_ERROR Otherwise
  */
-int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
-                               bool set);
+PMIX_EXPORT int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
+                                           bool set);
 
 /**
  * Obtain basic info on a single variable (name, help message, etc)
@@ -651,7 +651,7 @@ int pmix_mca_base_var_set_flag(int vari, pmix_mca_base_var_flag_t flag,
  * The returned pointer belongs to the MCA variable system. Do not
  * modify/free/retain the pointer.
  */
-int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
+PMIX_EXPORT int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
 
 /**
  * Obtain the number of variables that have been registered.
@@ -664,7 +664,7 @@ int pmix_mca_base_var_get (int vari, const pmix_mca_base_var_t **var);
  * returned is equal to the number of calls to pmix_mca_base_var_register with
  * unique names. ie. two calls with the same name will not affect the count.
  */
-int pmix_mca_base_var_get_count (void);
+PMIX_EXPORT int pmix_mca_base_var_get_count (void);
 
 /**
  * Obtain a list of enironment variables describing the all
@@ -683,8 +683,8 @@ int pmix_mca_base_var_get_count (void);
  * its output is in terms of an argv-style array of key=value
  * strings, suitable for using in an environment.
  */
-int pmix_mca_base_var_build_env(char ***env, int *num_env,
-                                bool internal);
+PMIX_EXPORT int pmix_mca_base_var_build_env(char ***env, int *num_env,
+                                            bool internal);
 
 /**
  * Shut down the MCA variable system (normally only invoked by the
@@ -700,7 +700,7 @@ int pmix_mca_base_var_build_env(char ***env, int *num_env,
  * when the process is shutting down (e.g., during MPI_FINALIZE).  It
  * is only documented here for completeness.
  */
-int pmix_mca_base_var_finalize(void);
+PMIX_EXPORT int pmix_mca_base_var_finalize(void);
 
 typedef enum {
     /* Dump human-readable strings */
@@ -721,19 +721,19 @@ typedef enum {
  * This function returns an array of strings describing the variable. All strings
  * and the array must be freed by the caller.
  */
-int pmix_mca_base_var_dump(int vari, char ***out, pmix_mca_base_var_dump_type_t output_type);
+PMIX_EXPORT int pmix_mca_base_var_dump(int vari, char ***out, pmix_mca_base_var_dump_type_t output_type);
 
 #define MCA_COMPILETIME_VER "print_compiletime_version"
 #define MCA_RUNTIME_VER "print_runtime_version"
 
-int pmix_mca_base_var_cache_files (bool rel_path_search);
+PMIX_EXPORT int pmix_mca_base_var_cache_files (bool rel_path_search);
 
 /*
  * Parse a provided list of envars and add their local value, or
  * their assigned value, to the provided argv
  */
-int pmix_mca_base_var_process_env_list(char ***argv);
-int pmix_mca_base_var_process_env_list_from_file(char ***argv);
+PMIX_EXPORT int pmix_mca_base_var_process_env_list(char ***argv);
+PMIX_EXPORT int pmix_mca_base_var_process_env_list_from_file(char ***argv);
 
 END_C_DECLS
 

--- a/src/mca/psec/base/psec_base_select.c
+++ b/src/mca/psec/base/psec_base_select.c
@@ -74,12 +74,21 @@ int pmix_psec_base_select(void)
         if (PMIX_SUCCESS != rc || NULL == module) {
             pmix_output_verbose(5, pmix_psec_base_framework.framework_output,
                                 "mca:psec:select: Skipping component [%s]. Query failed to return a module",
-                                component->pmix_mca_component_name );
+                                component->pmix_mca_component_name);
+            continue;
+        }
+        nmodule = (pmix_psec_module_t*) module;
+
+        /* give the module a chance to init */
+        if (NULL != nmodule->init && PMIX_SUCCESS != nmodule->init()) {
+            /* failed to init, so skip it */
+            pmix_output_verbose(5, pmix_psec_base_framework.framework_output,
+                                "mca:psec:select: Skipping component [%s]. Failed to init",
+                                component->pmix_mca_component_name);
             continue;
         }
 
         /* If we got a module, keep it */
-        nmodule = (pmix_psec_module_t*) module;
         /* add to the list of selected modules */
         newmodule = PMIX_NEW(pmix_psec_base_active_module_t);
         newmodule->pri = priority;

--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -19,6 +19,8 @@
 # $HEADER$
 #
 
+AM_CPPFLAGS = $(psec_munge_CPPFLAGS)
+
 headers = psec_munge.h
 sources = \
         psec_munge_component.c \
@@ -43,8 +45,10 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_munge_la_SOURCES = $(component_sources)
-mca_psec_munge_la_LDFLAGS = -module -avoid-version
+mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_munge_la_SOURCES = $(lib_sources)
-libmca_psec_munge_la_LDFLAGS = -module -avoid-version
+libmca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
+libmca_psec_munge_la_LIBADD = $(psec_munge_LIBS)

--- a/src/mca/psec/munge/psec_munge.c
+++ b/src/mca/psec/munge/psec_munge.c
@@ -25,6 +25,7 @@
 #endif
 #include <munge.h>
 
+#include "src/threads/threads.h"
 #include "src/mca/psec/psec.h"
 #include "psec_munge.h"
 
@@ -37,15 +38,14 @@ static pmix_status_t validate_cred(int sd, uid_t uid, gid_t gid,
                                    char *cred, size_t len);
 
 pmix_psec_module_t pmix_munge_module = {
-    "munge",
-    munge_init,
-    munge_finalize,
-    create_cred,
-    NULL,
-    validate_cred,
-    NULL
+    .name = "munge",
+    .init = munge_init,
+    .finalize = munge_finalize,
+    .create_cred = create_cred,
+    .validate_cred = validate_cred
 };
 
+static pmix_lock_t lock;
 static char *mycred = NULL;
 static bool initialized = false;
 static bool refresh = false;
@@ -57,6 +57,9 @@ static pmix_status_t munge_init(void)
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "psec: munge init");
 
+    PMIX_CONSTRUCT_LOCK(&lock);
+    lock.active = false;
+
     /* attempt to get a credential as a way of checking that
      * the munge server is available - cache the credential
      * for later use */
@@ -67,6 +70,7 @@ static pmix_status_t munge_init(void)
                             munge_strerror(rc));
         return PMIX_ERR_SERVER_NOT_AVAIL;
     }
+
     initialized = true;
 
     return PMIX_SUCCESS;
@@ -74,6 +78,8 @@ static pmix_status_t munge_init(void)
 
 static void munge_finalize(void)
 {
+    PMIX_ACQUIRE_THREAD(&lock);
+
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "psec: munge finalize");
     if (initialized) {
@@ -82,12 +88,16 @@ static void munge_finalize(void)
             mycred = NULL;
         }
     }
+    PMIX_RELEASE_THREAD(&lock);
+    PMIX_DESTRUCT_LOCK(&lock);
 }
 
 static pmix_status_t create_cred(pmix_listener_protocol_t protocol,
                                  char **cred, size_t *len)
 {
     int rc;
+
+    PMIX_ACQUIRE_THREAD(&lock);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "psec: munge create_cred");
@@ -107,12 +117,14 @@ static pmix_status_t create_cred(pmix_listener_protocol_t protocol,
                 pmix_output_verbose(2, pmix_globals.debug_output,
                                     "psec: munge failed to create credential: %s",
                                     munge_strerror(rc));
-                return NULL;
+                PMIX_RELEASE_THREAD(&lock);
+                return PMIX_ERR_NOT_SUPPORTED;
             }
             *cred = strdup(mycred);
             *len = strlen(mycred) + 1;
         }
     }
+    PMIX_RELEASE_THREAD(&lock);
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/psec/none/psec_none.c
+++ b/src/mca/psec/none/psec_none.c
@@ -1,6 +1,8 @@
 /*
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -29,6 +31,8 @@
 
 static pmix_status_t none_init(void);
 static void none_finalize(void);
+static pmix_status_t create_cred(pmix_listener_protocol_t protocol,
+                                 char **cred, size_t *len);
 static pmix_status_t validate_cred(int sd, uid_t uid, gid_t gid,
                                    pmix_listener_protocol_t protocol,
                                    char *cred, size_t len);
@@ -37,6 +41,7 @@ pmix_psec_module_t pmix_none_module = {
     .name = "none",
     .init = none_init,
     .finalize = none_finalize,
+    .create_cred = create_cred,
     .validate_cred = validate_cred
 };
 
@@ -51,6 +56,15 @@ static void none_finalize(void)
 {
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "psec: none finalize");
+}
+
+static pmix_status_t create_cred(pmix_listener_protocol_t protocol,
+                                 char **cred, size_t *len)
+{
+    *cred = NULL;
+    *len = 0;
+
+    return PMIX_SUCCESS;
 }
 
 static pmix_status_t validate_cred(int sd, uid_t uid, gid_t gid,

--- a/src/runtime/Makefile.include
+++ b/src/runtime/Makefile.include
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, LLC.
 #                         All rights reserved.
-# Copyright (c) 2014-2016 Intel, Inc. All rights reserved
+# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
 # Copyright (c) 2014      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
@@ -29,7 +29,7 @@ headers += \
         runtime/pmix_rte.h \
         runtime/pmix_progress_threads.h
 
-libpmix_la_SOURCES += \
+sources += \
         runtime/pmix_finalize.c \
         runtime/pmix_init.c \
         runtime/pmix_params.c \

--- a/src/threads/Makefile.include
+++ b/src/threads/Makefile.include
@@ -32,7 +32,7 @@ headers += \
         threads/wait_sync.h \
 	threads/thread_usage.h
 
-libpmix_la_SOURCES += \
+sources += \
         threads/mutex.c \
         threads/thread.c \
         threads/wait_sync.c

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -51,13 +51,13 @@ pmi_client_SOURCES = $(headers) \
         pmi_client.c
 pmi_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi_client_LDADD = \
-    $(top_builddir)/src/libpmix.la
+    $(top_builddir)/src/libpmi.la
 
 pmi2_client_SOURCES = $(headers) \
         pmi2_client.c
 pmi2_client_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 pmi2_client_LDADD = \
-    $(top_builddir)/src/libpmix.la
+    $(top_builddir)/src/libpmi2.la
 endif
 
 pmix_client_SOURCES = $(headers) \


### PR DESCRIPTION
    Corrects operation of psec/munge, psec/none; provides separation of PMI/PMI2/PMIX
    symbols in their respective libraries; ensures no unresolved internal symbols.

    - PR #618: Cleanup separation of PMI-1/2 and PMIx symbols
    - PR #619: psec/munge: use munge configure.m4 vars; use C99 designated initializers
    - PR #621: psec/none: add a create_cred callback
    - PR #623: Some cleanup for the psec framework
    - from commit 0a5563ce3cef: src/mca/base/pmix_mca_base_var.h changes (PMIX_EXPORT)

Signed-off-by: Philip Kovacs <pkdevel@yahoo.com>