### PR TITLE
Add support for "timeout" directives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ test/simple/simpdyn
 test/simple/test_pmix
 test/simple/simptool
 test/simple/simpdie
+test/simple/simptimeout
 
 # coverity
 cov-int

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -185,16 +185,6 @@ typedef struct pmix_peer_t {
 PMIX_CLASS_DECLARATION(pmix_peer_t);
 
 
-/* define an object for moving a send
- * request into the server's event base
- * - instanced in pmix_server_ops.c */
-typedef struct {
-    pmix_list_item_t super;
-    pmix_ptl_hdr_t hdr;
-    pmix_peer_t *peer;
-} pmix_server_caddy_t;
-PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
-
 /* caddy for query requests */
 typedef struct {
     pmix_object_t super;
@@ -241,6 +231,20 @@ typedef struct {
     pmix_connect_cbfunc_t cnct_cbfunc;
 } pmix_server_trkr_t;
 PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
+
+/* define an object for moving a send
+ * request into the server's event base and
+ * dealing with some request timeouts
+ * - instanced in pmix_server_ops.c */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_event_t ev;
+    bool event_active;
+    pmix_server_trkr_t *trk;
+    pmix_ptl_hdr_t hdr;
+    pmix_peer_t *peer;
+} pmix_server_caddy_t;
+PMIX_CLASS_DECLARATION(pmix_server_caddy_t);
 
 /****    THREAD-RELATED    ****/
  /* define a caddy for thread-shifting operations */

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -58,7 +58,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
 {
     pmix_server_trkr_t *trk;
     pmix_server_caddy_t *rinfo, *rnext;
-    pmix_trkr_caddy_t *tcd;
     pmix_regevents_info_t *reginfoptr, *regnext;
     pmix_peer_events_info_t *pr, *pnext;
     pmix_rank_info_t *info, *pinfo;
@@ -102,13 +101,21 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 /* remove it from the list */
                 pmix_list_remove_item(&trk->local_cbs, &rinfo->super);
                 PMIX_RELEASE(rinfo);
-                /* check for completion */
-                if (pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
-                    /* complete, so now we need to process it
-                     * we don't want to block someone
-                     * here, so kick any completed trackers into a
-                     * new event for processing */
-                    PMIX_EXECUTE_COLLECTIVE(tcd, trk, pmix_server_execute_collective);
+                /* we need to let the other participants know that this
+                 * proc has disappeared as otherwise the collective will never
+                 * complete */
+                if (PMIX_FENCENB_CMD == trk->type) {
+                    if (NULL != trk->modexcbfunc) {
+                        trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
+                    }
+                } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                    if (NULL != trk->cnct_cbfunc) {
+                        trk->cnct_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, PMIX_RANK_WILDCARD, trk);
+                    }
+                } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                    if (NULL != trk->op_cbfunc) {
+                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                    }
                 }
             }
         }

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -91,7 +91,10 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_modex_cbfunc_t cbfunc,
                                           void *cbdata,
-                                          pmix_dmdx_local_t **lcd);
+                                          pmix_dmdx_local_t **lcd,
+                                          pmix_dmdx_request_t **rq);
+
+static void get_timeout(int sd, short args, void *cbdata);
 
 
 /* declare a function whose sole purpose is to
@@ -120,8 +123,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_info_t *info=NULL;
     size_t ninfo=0;
     pmix_dmdx_local_t *lcd;
+    pmix_dmdx_request_t *req;
     bool local;
     bool localonly = false;
+    struct timeval tv = {0, 0};
     pmix_buffer_t pbkt, pkt;
     pmix_byte_object_t bo;
     pmix_cb_t cb;
@@ -175,10 +180,12 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
 
     /* search for directives we can deal with here */
     for (n=0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, PMIX_IMMEDIATE)) {
+        if (0 == strncmp(info[n].key, PMIX_IMMEDIATE, PMIX_MAX_KEYLEN)) {
             /* just check our own data - don't wait
              * or request it from someone else */
             localonly = PMIX_INFO_TRUE(&info[n]);
+        } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
+            tv.tv_sec = info[n].value.data.uint32;
         }
     }
 
@@ -234,7 +241,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * back when we receive it */
         rc = create_local_tracker(nspace, rank,
                                   info, ninfo,
-                                  cbfunc, cbdata, &lcd);
+                                  cbfunc, cbdata, &lcd, &req);
         if (PMIX_ERR_NOMEM == rc) {
             PMIX_INFO_FREE(info, ninfo);
             return rc;
@@ -256,6 +263,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
         }
 
+        /* if they specified a timeout, set it up now */
+        if (0 < tv.tv_sec) {
+            pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
+                                   get_timeout, req);
+            pmix_event_evtimer_add(&req->ev, &tv);
+            req->event_active = true;
+        }
         return PMIX_SUCCESS;
     }
 
@@ -336,7 +350,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         /* we cannot do anything further, so just track this request
          * for now */
         rc = create_local_tracker(nspace, rank, info, ninfo,
-                                  cbfunc, cbdata, &lcd);
+                                  cbfunc, cbdata, &lcd, &req);
         if (PMIX_ERR_NOMEM == rc) {
             PMIX_INFO_FREE(info, ninfo);
         }
@@ -344,6 +358,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
                             "%s:%d TRACKER CREATED - WAITING",
                             pmix_globals.myid.nspace,
                             pmix_globals.myid.rank);
+        /* if they specified a timeout, set it up now */
+        if (0 < tv.tv_sec) {
+            pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
+                                   get_timeout, req);
+            pmix_event_evtimer_add(&req->ev, &tv);
+            req->event_active = true;
+        }
         return rc;
     }
 
@@ -373,7 +394,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     /* Check to see if we already have a pending request for the data - if
      * we do, then we can just wait for it to arrive */
     rc = create_local_tracker(nspace, rank, info, ninfo,
-                              cbfunc, cbdata, &lcd);
+                              cbfunc, cbdata, &lcd, &req);
     if (PMIX_SUCCESS == rc) {
        /* we are already waiting for the data - nothing more
         * for us to do as the function added the new request
@@ -393,6 +414,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * if this is one, then we have nothing further to do - we will
      * fulfill the request once the process commits its data */
     if (local) {
+        /* if they specified a timeout, set it up now */
+        if (0 < tv.tv_sec) {
+            pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
+                                   get_timeout, req);
+            pmix_event_evtimer_add(&req->ev, &tv);
+            req->event_active = true;
+        }
         return PMIX_SUCCESS;
     }
 
@@ -401,6 +429,13 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * whomever is hosting the target process */
     if (NULL != pmix_host_server.direct_modex) {
         rc = pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
+        /* if they specified a timeout, set it up now */
+        if (0 < tv.tv_sec) {
+            pmix_event_evtimer_set(pmix_globals.evbase, &req->ev,
+                                   get_timeout, req);
+            pmix_event_evtimer_add(&req->ev, &tv);
+            req->event_active = true;
+        }
     } else {
         pmix_output_verbose(2, pmix_server_globals.get_output,
                             "%s:%d NO SERVER SUPPORT",
@@ -421,7 +456,8 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_modex_cbfunc_t cbfunc,
                                           void *cbdata,
-                                          pmix_dmdx_local_t **ld)
+                                          pmix_dmdx_local_t **ld,
+                                          pmix_dmdx_request_t **rq)
 {
     pmix_dmdx_local_t *lcd, *cd;
     pmix_dmdx_request_t *req;
@@ -429,6 +465,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
 
     /* define default */
     *ld = NULL;
+    *rq = NULL;
 
     /* see if we already have an existing request for data
      * from this namespace/rank */
@@ -464,10 +501,17 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
     /* track this specific requestor so we return the
      * data to them */
     req = PMIX_NEW(pmix_dmdx_request_t);
+    if (NULL == req) {
+        *ld = lcd;
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_RETAIN(lcd);
+    req->lcd = lcd;
     req->cbfunc = cbfunc;
     req->cbdata = cbdata;
     pmix_list_append(&lcd->loc_reqs, &req->super);
     *ld = lcd;
+    *rq = req;
     return rc;
 }
 
@@ -931,4 +975,19 @@ static void dmdx_cbfunc(pmix_status_t status,
                         __FILE__, __LINE__,
                         caddy->lcd->proc.nspace, caddy->lcd->proc.rank);
     PMIX_THREADSHIFT(caddy, _process_dmdx_reply);
+}
+
+static void get_timeout(int sd, short args, void *cbdata)
+{
+    pmix_dmdx_request_t *req = (pmix_dmdx_request_t*)cbdata;
+
+    pmix_output_verbose(2, pmix_server_globals.get_output,
+                        "ALERT: get timeout fired");
+    /* execute the provided callback function with the error */
+    if (NULL != req->cbfunc) {
+        req->cbfunc(PMIX_ERR_TIMEOUT, NULL, 0, req->cbdata, NULL, NULL);
+    }
+    req->event_active = false;
+    pmix_list_remove_item(&req->lcd->loc_reqs, &req->super);
+    PMIX_RELEASE(req);
 }

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -68,13 +68,6 @@ PMIX_CLASS_DECLARATION(pmix_dmdx_remote_t);
 
 typedef struct {
     pmix_list_item_t super;
-    pmix_modex_cbfunc_t cbfunc;     // cbfunc to be executed when data is available
-    void *cbdata;
-} pmix_dmdx_request_t;
-PMIX_CLASS_DECLARATION(pmix_dmdx_request_t);
-
-typedef struct {
-    pmix_list_item_t super;
     pmix_proc_t proc;               // id of proc whose data is being requested
     pmix_list_t loc_reqs;           // list of pmix_dmdx_request_t elem's keeping track of
                                     // all local ranks that are interested in this namespace-rank
@@ -82,6 +75,16 @@ typedef struct {
     size_t ninfo;                   // number of info structs
 } pmix_dmdx_local_t;
 PMIX_CLASS_DECLARATION(pmix_dmdx_local_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_event_t ev;
+    bool event_active;
+    pmix_dmdx_local_t *lcd;
+    pmix_modex_cbfunc_t cbfunc;     // cbfunc to be executed when data is available
+    void *cbdata;
+} pmix_dmdx_request_t;
+PMIX_CLASS_DECLARATION(pmix_dmdx_request_t);
 
 /* event/error registration book keeping */
 typedef struct {

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -21,7 +21,7 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex test_pmix simptool simpdie simplegacy
+noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex test_pmix simptool simpdie simplegacy simptimeout
 
 simptest_SOURCES = \
         simptest.c
@@ -81,4 +81,10 @@ simplegacy_SOURCES = \
         simplegacy.c
 simplegacy_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simplegacy_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simptimeout_SOURCES = \
+        simptimeout.c
+simptimeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simptimeout_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -172,6 +172,7 @@ static int exit_code = 0;
 static pmix_list_t pubdata;
 static pmix_event_t handler;
 static pmix_list_t children;
+static bool istimeouttest = false;
 
 static void set_namespace(int nprocs, char *ranks, char *nspace,
                           pmix_op_cbfunc_t cbfunc, myxfer_t *x);
@@ -284,6 +285,10 @@ int main(int argc, char **argv)
         } else if (0 == strcmp("-e", argv[n]) &&
                    NULL != argv[n+1]) {
             executable = strdup(argv[n+1]);
+            /* check for timeout test */
+            if (NULL != strstr(executable, "simptimeout")) {
+                istimeouttest = true;
+            }
             for (k=n+2; NULL != argv[k]; k++) {
                 pmix_argv_append_nosize(&client_argv, argv[k]);
             }
@@ -649,6 +654,11 @@ static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
                      pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_output(0, "SERVER: DMODEX");
+
+    /* if this is a timeout test, then do nothing */
+    if (istimeouttest) {
+        return PMIX_SUCCESS;
+    }
 
     /* we don't have any data for remote procs as this
      * test only runs one server - so report accordingly */

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+#define MAXCNT 1
+
+static volatile bool completed = false;
+static pmix_proc_t myproc;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    pmix_output(0, "Client %s:%d NOTIFIED with status %s", myproc.nspace, myproc.rank, PMIx_Error_string(status));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+    completed = true;
+}
+
+static void errhandler_reg_callbk(pmix_status_t status,
+                                  size_t errhandler_ref,
+                                  void *cbdata)
+{
+    volatile bool *active = (volatile bool*)cbdata;
+
+    pmix_output(0, "Client: ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
+                status, (unsigned long)errhandler_ref);
+    *active = false;
+}
+
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc, newproc;
+    uint32_t nprocs, n;
+    volatile bool active;
+    pmix_info_t info;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+
+    /* test something */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    PMIX_VALUE_RELEASE(val);
+
+    /* register our errhandler */
+    active = true;
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, errhandler_reg_callbk, (void*)&active);
+    while (active) {
+        usleep(10);
+    }
+
+    /* get our universe size */
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get universe size failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
+
+    /* if we are rank=0, then do a fence with timeout */
+    if (0 == myproc.rank) {
+        PMIX_INFO_CONSTRUCT(&info);
+        n = 1;
+        PMIX_INFO_LOAD(&info, PMIX_TIMEOUT, &n, PMIX_UINT32);
+        PMIX_PROC_CONSTRUCT(&proc);
+        (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+        proc.rank = PMIX_RANK_WILDCARD;
+        pmix_output(0, "TEST FENCE TIMEOUT");
+        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Fence(&proc, 1, &info, 1))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Fence did not timeout: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        pmix_output(0, "FENCE TIMEOUT SUCCEEDED");
+
+        /* check timeout on connect */
+        pmix_output(0, "TEST CONNECT TIMEOUT");
+        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Connect(&proc, 1, &info, 1, newproc.nspace, &newproc.rank))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Connect did not timeout: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        pmix_output(0, "CONNECT TIMEOUT SUCCEEDED");
+
+        /* check timeout on Get */
+        proc.rank = 1;
+        pmix_output(0, "TEST GET TIMEOUT");
+        if (PMIX_ERR_TIMEOUT == (rc = PMIx_Get(&proc, "1234", &info, 1, &val))) {
+            pmix_output(0, "Client ns %s rank %d: PMIx_Get did not timeout: %s",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        pmix_output(0, "GET TIMEOUT SUCCEEDED");
+
+    } else {
+        sleep(5);
+    }
+
+ done:
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(rc);
+}


### PR DESCRIPTION
Check for PMIX_TIMEOUT directives in the fence, get, and connect operations. Have the local PMIx server enforce the timeout, notifying the requesting proc when timeout hits. If a proc terminates (either finalize or die) before a collective it participates in has completed, then notify all other participants as the collective will never complete.

NOTE: this still leaves a few "gaps":
* only local participants are informed of a collective failure due to a proc going away. Need to decide on a way of notifying remote participants, most likely via the event notification system

* if a proc terminates prior to the collective being defined (i.e., another participant having called it), then the server loses all knowledge that the terminating proc existed and the collective "succeeds". This -might- be okay and possibly desirable for resilience since an abnormal termination is something we notify about, but still a behavior worth noting.

Fixes #128
Fixes #96

Signed-off-by: Ralph Castain <rhc@open-mpi.org>