### PR TITLE
Ensure the buffer type gets set

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -1675,7 +1675,6 @@ PMIX_EXPORT const char* PMIx_Get_version(void);
 PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
                                               const char *key, pmix_value_t *val);
 
-
 /**
  * Top-level interface function to pack one or more values into a
  * buffer.
@@ -1693,6 +1692,17 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
  * cases. Sending a number larger than can be handled by the recipient
  * will return an error code (generated upon unpacking) -
  * the error cannot be detected during packing.
+ *
+ * The identity of the intended recipient of the packed buffer (i.e., the
+ * process that will be unpacking it) is used solely to resolve any data type
+ * differences between PMIx versions. The recipient must, therefore, be
+ * known to the user prior to calling the pack function so that the
+ * PMIx library is aware of the version the recipient is using.
+ *
+ * @param *target Pointer to a pmix_proc_t structure containing the
+ * nspace/rank of the process that will be unpacking the final buffer.
+ * A NULL value may be used to indicate that the target is based on
+ * the same PMIx version as the caller.
  *
  * @param *buffer A pointer to the buffer into which the value is to
  * be packed.
@@ -1727,7 +1737,8 @@ PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
  * status_code = PMIx_Data_pack(buffer, &src, 1, PMIX_INT32);
  * @endcode
  */
-PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
+PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target,
+                                         pmix_data_buffer_t *buffer,
                                          void *src, int32_t num_vals,
                                          pmix_data_type_t type);
 
@@ -1773,6 +1784,17 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
  * cases. Sending a number larger than can be handled by the recipient
  * will return an error code generated upon unpacking - these errors
  * cannot be detected during packing.
+ *
+ * The identity of the source of the packed buffer (i.e., the
+ * process that packed it) is used solely to resolve any data type
+ * differences between PMIx versions. The source must, therefore, be
+ * known to the user prior to calling the unpack function so that the
+ * PMIx library is aware of the version the source used.
+ *
+ * @param *source Pointer to a pmix_proc_t structure containing the
+ * nspace/rank of the process that packed the provided buffer.
+ * A NULL value may be used to indicate that the source is based on
+ * the same PMIx version as the caller.
  *
  * @param *buffer A pointer to the buffer from which the value will be
  * extracted.
@@ -1823,7 +1845,8 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
  *
  * @endcode
  */
-PMIX_EXPORT pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *source,
+                                           pmix_data_buffer_t *buffer, void *dest,
                                            int32_t *max_num_values,
                                            pmix_data_type_t type);
 

--- a/src/client/pmix_client_ops.h
+++ b/src/client/pmix_client_ops.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,6 +15,7 @@
 
 #include "src/threads/threads.h"
 #include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
 #include "src/include/pmix_globals.h"
 
 BEGIN_C_DECLS
@@ -22,6 +23,7 @@ BEGIN_C_DECLS
 typedef struct {
     pmix_peer_t *myserver;          // messaging support to/from my server
     pmix_list_t pending_requests;   // list of pmix_cb_t pending data requests
+    pmix_pointer_array_t peers;     // array of pmix_peer_t cached for data ops
 } pmix_client_globals_t;
 
 PMIX_EXPORT extern pmix_client_globals_t pmix_client_globals;

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -31,11 +31,13 @@
 #include <stdlib.h>
 #endif
 
-#include <pmix_common.h>
+#include <pmix.h>
 #include <pmix_rename.h>
 
 #include "src/mca/bfrops/bfrops.h"
 #include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/client/pmix_client_ops.h"
 
 #define PMIX_EMBED_DATA_BUFFER(b, db)                       \
     do {                                                    \
@@ -66,12 +68,121 @@
         (b)->bytes_used = 0;                            \
     } while (0)
 
-PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
+static pmix_peer_t* find_peer(const pmix_proc_t *proc)
+{
+    pmix_status_t rc;
+    pmix_peer_t *peer;
+    pmix_proc_t wildcard;
+    pmix_value_t *value;
+    int i;
+
+    if (NULL == proc) {
+        return pmix_globals.mypeer;
+    }
+
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+        /* see if we know this proc */
+        for (i=0; i < pmix_server_globals.clients.size; i++) {
+            if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {
+                continue;
+            }
+            if (0 == strncmp(proc->nspace, peer->nptr->nspace, PMIX_MAX_NSLEN)) {
+                return peer;
+            }
+        }
+        /* didn't find it, so try to get the library version of the target
+         * from the host - the result will be cached, so we will only have
+         * to retrieve it once */
+        (void)strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
+        wildcard.rank = PMIX_RANK_WILDCARD;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value))) {
+            /* couldn't get it - nothing we can do */
+            return NULL;
+        }
+        /* setup a peer for this nspace */
+        peer = PMIX_NEW(pmix_peer_t);
+        if (NULL == peer) {
+            PMIX_RELEASE(value);
+            return NULL;
+        }
+        peer->nptr = PMIX_NEW(pmix_nspace_t);
+        if (NULL == peer->nptr) {
+            PMIX_RELEASE(peer);
+            PMIX_RELEASE(value);
+            return NULL;
+        }
+        peer->nptr->nspace = strdup(proc->nspace);
+        /* assign a module to it based on the returned version */
+        peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(value->data.string);
+        PMIX_RELEASE(value);
+        if (NULL == peer->nptr->compat.bfrops) {
+            PMIX_RELEASE(peer);
+            return NULL;
+        }
+        /* cache the peer object */
+        pmix_pointer_array_add(&pmix_server_globals.clients, peer);
+        return peer;
+    }
+
+    // we are a client or tool
+
+    /* If the target is for the server, then
+     * pack it using that peer. */
+    if (0 == strncmp(proc->nspace, pmix_client_globals.myserver->info->pname.nspace, PMIX_MAX_NSLEN)) {
+        return pmix_client_globals.myserver;
+    }
+
+    /* if the target is another member of my nspace, then
+     * they must be using the same version */
+    if (0 == strncmp(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN)) {
+        return pmix_globals.mypeer;
+    }
+
+    /* try to get the library version of this peer - the result will be
+     * cached, so we will only have to retrieve it once */
+    (void)strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    wildcard.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value))) {
+        /* couldn't get it - nothing we can do */
+        return NULL;
+    }
+    /* setup a peer for this nspace */
+    peer = PMIX_NEW(pmix_peer_t);
+    if (NULL == peer) {
+        PMIX_RELEASE(value);
+        return NULL;
+    }
+    peer->nptr = PMIX_NEW(pmix_nspace_t);
+    if (NULL == peer->nptr) {
+        PMIX_RELEASE(peer);
+        PMIX_RELEASE(value);
+        return NULL;
+    }
+    peer->nptr->nspace = strdup(proc->nspace);
+    /* assign a module to it based on the returned version */
+    peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(value->data.string);
+    PMIX_RELEASE(value);
+    if (NULL == peer->nptr->compat.bfrops) {
+        PMIX_RELEASE(peer);
+        return NULL;
+    }
+    /* need to cache the peer someplace so we can clean it
+     * up later */
+    return peer;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Data_pack(const pmix_proc_t *target,
+                                         pmix_data_buffer_t *buffer,
                                          void *src, int32_t num_vals,
                                          pmix_data_type_t type)
 {
     pmix_status_t rc;
     pmix_buffer_t buf;
+    pmix_peer_t *peer;
+
+    if (NULL == (peer = find_peer(target))) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
 
     /* setup the host */
     PMIX_CONSTRUCT(&buf, pmix_buffer_t);
@@ -80,7 +191,7 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
     PMIX_EMBED_DATA_BUFFER(&buf, buffer);
 
     /* pack the value */
-    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer,
+    PMIX_BFROPS_PACK(rc, peer,
                      &buf, src, num_vals, type);
 
     /* extract the data buffer - the pointers may have changed */
@@ -91,12 +202,18 @@ PMIX_EXPORT pmix_status_t PMIx_Data_pack(pmix_data_buffer_t *buffer,
 }
 
 
-PMIX_EXPORT pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t PMIx_Data_unpack(const pmix_proc_t *source,
+                                           pmix_data_buffer_t *buffer, void *dest,
                                            int32_t *max_num_values,
                                            pmix_data_type_t type)
 {
     pmix_status_t rc;
     pmix_buffer_t buf;
+    pmix_peer_t *peer;
+
+    if (NULL == (peer = find_peer(source))) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
 
     /* setup the host */
     PMIX_CONSTRUCT(&buf, pmix_buffer_t);
@@ -105,7 +222,7 @@ PMIX_EXPORT pmix_status_t PMIx_Data_unpack(pmix_data_buffer_t *buffer, void *des
     PMIX_EMBED_DATA_BUFFER(&buf, buffer);
 
     /* unpack the value */
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+    PMIX_BFROPS_UNPACK(rc, peer,
                        &buf, dest, max_num_values, type);
 
     /* extract the data buffer - the pointers may have changed */

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -37,18 +37,19 @@
 #include "src/mca/bfrops/bfrops.h"
 #include "src/include/pmix_globals.h"
 
-#define PMIX_EMBED_DATA_BUFFER(b, db)                   \
-    do {                                                \
-        (b)->base_ptr = (db)->base_ptr;                 \
-        (b)->pack_ptr = (db)->pack_ptr;                 \
-        (b)->unpack_ptr = (db)->unpack_ptr;             \
-        (b)->bytes_allocated = (db)->bytes_allocated;   \
-        (b)->bytes_used = (db)->bytes_used;             \
-        (db)->base_ptr = NULL;                          \
-        (db)->pack_ptr = NULL;                          \
-        (db)->unpack_ptr = NULL;                        \
-        (db)->bytes_allocated = 0;                      \
-        (db)->bytes_used = 0;                           \
+#define PMIX_EMBED_DATA_BUFFER(b, db)                       \
+    do {                                                    \
+        (b)->type = pmix_globals.mypeer->nptr->compat.type; \
+        (b)->base_ptr = (db)->base_ptr;                     \
+        (b)->pack_ptr = (db)->pack_ptr;                     \
+        (b)->unpack_ptr = (db)->unpack_ptr;                 \
+        (b)->bytes_allocated = (db)->bytes_allocated;       \
+        (b)->bytes_used = (db)->bytes_used;                 \
+        (db)->base_ptr = NULL;                              \
+        (db)->pack_ptr = NULL;                              \
+        (db)->unpack_ptr = NULL;                            \
+        (db)->bytes_allocated = 0;                          \
+        (db)->bytes_used = 0;                               \
     } while (0)
 
 #define PMIX_EXTRACT_DATA_BUFFER(b, db)                 \

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
  *                         and Technology (RIST). All rights reserved.
@@ -57,6 +57,7 @@ static void nscon(pmix_nspace_t *p)
     p->nspace = NULL;
     p->nlocalprocs = 0;
     p->all_registered = false;
+    p->version_stored = false;
     p->jobbkt = NULL;
     p->ndelivered = 0;
     PMIX_CONSTRUCT(&p->ranks, pmix_list_t);

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -10,7 +10,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,6 +50,8 @@ BEGIN_C_DECLS
 #define PMIX_MAX_CRED_SIZE      131072              // set max at 128kbytes
 #define PMIX_MAX_ERR_CONSTANT   INT_MIN
 
+/* internal-only attributes */
+#define PMIX_BFROPS_MODULE                  "pmix.bfrops.mod"       // (char*) name of bfrops plugin in-use by a given nspace
 
 /* define an internal-only process name that has
  * a dynamically-sized nspace field to save memory */
@@ -125,6 +127,7 @@ typedef struct {
     char *nspace;
     size_t nlocalprocs;
     bool all_registered;         // all local ranks have been defined
+    bool version_stored;         // the version string used by this nspace has been stored
     pmix_buffer_t *jobbkt;       // packed version of jobinfo
     size_t ndelivered;           // count of #local clients that have received the jobinfo
     pmix_list_t ranks;           // list of pmix_rank_info_t for connection support of my clients

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
@@ -112,6 +112,7 @@ typedef struct {
     pmix_hash_table_t internal;
     pmix_hash_table_t remote;
     pmix_hash_table_t local;
+    bool gdata_added;
 } pmix_hash_trkr_t;
 
 static void htcon(pmix_hash_trkr_t *p)
@@ -124,6 +125,7 @@ static void htcon(pmix_hash_trkr_t *p)
     pmix_hash_table_init(&p->remote, 256);
     PMIX_CONSTRUCT(&p->local, pmix_hash_table_t);
     pmix_hash_table_init(&p->local, 256);
+    p->gdata_added = false;
 }
 static void htdes(pmix_hash_trkr_t *p)
 {
@@ -515,26 +517,29 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
     }
 
     /* now add any global data that was provided */
-    PMIX_LIST_FOREACH(kvptr, &pmix_server_globals.gdata, pmix_kval_t) {
-        /* sadly, the data cannot simultaneously exist on two lists,
-         * so we must make a copy of it here */
-        kp2 = PMIX_NEW(pmix_kval_t);
-        if (NULL == kp2) {
-            rc = PMIX_ERR_NOMEM;
-            goto release;
+    if (!trk->gdata_added) {
+        PMIX_LIST_FOREACH(kvptr, &pmix_server_globals.gdata, pmix_kval_t) {
+            /* sadly, the data cannot simultaneously exist on two lists,
+             * so we must make a copy of it here */
+            kp2 = PMIX_NEW(pmix_kval_t);
+            if (NULL == kp2) {
+                rc = PMIX_ERR_NOMEM;
+                goto release;
+            }
+            kp2->key = strdup(kvptr->key);
+            PMIX_VALUE_XFER(rc, kp2->value, kvptr->value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                goto release;
+            }
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                break;
+            }
         }
-        kp2->key = strdup(kvptr->key);
-        PMIX_VALUE_XFER(rc, kp2->value, kvptr->value);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kp2);
-            goto release;
-        }
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, PMIX_RANK_WILDCARD, kp2))) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(kp2);
-            break;
-        }
+        trk->gdata_added = true;
     }
 
   release:
@@ -1153,7 +1158,6 @@ static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
 {
     pmix_nspace_t *ns = (pmix_nspace_t*)nspace;
     pmix_hash_trkr_t *trk, *t;
-    pmix_server_caddy_t *scd;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
     pmix_buffer_t pbkt;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -1206,14 +1206,25 @@ static void connection_handler(int sd, short args, void *cbdata)
     } else {
         peer->nptr->compat.gds = pmix_gds_base_assign_module(NULL, 0);
     }
-    free(msg);  // can now release the data buffer
     if (NULL == peer->nptr->compat.gds) {
+        free(msg);
         info->proc_cnt--;
         pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
         PMIX_RELEASE(peer);
         /* send an error reply to the client */
         goto error;
     }
+
+    /* if we haven't previously stored the version for this
+     * nspace, do so now */
+    if (!nptr->version_stored) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_BFROPS_MODULE, peer->nptr->compat.bfrops->version, PMIX_STRING);
+        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, peer->nptr, &ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
+        nptr->version_stored = true;
+    }
+
+    free(msg);  // can now release the data buffer
 
     /* the choice of PTL module is obviously us */
     peer->nptr->compat.ptl = &pmix_ptl_tcp_module;
@@ -1430,12 +1441,22 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     /* set the gds */
     PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, pnd->gds, PMIX_STRING);
     peer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
+    PMIX_INFO_DESTRUCT(&ginfo);
     if (NULL == peer->nptr->compat.gds) {
         PMIX_RELEASE(peer);
         pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         CLOSE_THE_SOCKET(pnd->sd);
         goto done;
+    }
+
+    /* if we haven't previously stored the version for this
+     * nspace, do so now */
+    if (!peer->nptr->version_stored) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_BFROPS_MODULE, peer->nptr->compat.bfrops->version, PMIX_STRING);
+        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, peer->nptr, &ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
+        nptr->version_stored = true;
     }
 
     /* validate the connection */

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -656,6 +656,15 @@ static void connection_handler(int sd, short args, void *cbdata)
         PMIX_RELEASE(psave);
         /* send an error reply to the client */
         goto error;
+    }
+
+    /* if we haven't previously stored the version for this
+     * nspace, do so now */
+    if (!nptr->version_stored) {
+        PMIX_INFO_LOAD(&ginfo, PMIX_BFROPS_MODULE, nptr->compat.bfrops->version, PMIX_STRING);
+        PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr, &ginfo, 1);
+        PMIX_INFO_DESTRUCT(&ginfo);
+        nptr->version_stored = true;
     }
 
     /* the choice of PTL module was obviously made by the connecting


### PR DESCRIPTION
Ensure we set the buffer type when embedding user-level buffers into
PMIx internal buffers.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 89408baf927cf8bcdfed2eee18962e55cb96b303)