### PR TITLE
Resolve dmodex of job-level info

### DIFF
--- a/contrib/pmix_jenkins.sh
+++ b/contrib/pmix_jenkins.sh
@@ -395,4 +395,3 @@ if [ -n "$JENKINS_RUN_TESTS" -a "$JENKINS_RUN_TESTS" -ne "0" ]; then
         set -e
     fi
 fi
-

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -53,19 +53,23 @@
 
 #include "src/mca/ptl/base/static-components.h"
 
+#define PMIX_MAX_MSG_SIZE   16
+
 /* Instantiate the global vars */
 pmix_ptl_globals_t pmix_ptl_globals = {{{0}}};
 int pmix_ptl_base_output = -1;
 
+static size_t max_msg_size = PMIX_MAX_MSG_SIZE;
+
 static int pmix_ptl_register(pmix_mca_base_register_flag_t flags)
 {
-    pmix_ptl_globals.max_msg_size = 8000000;
     pmix_mca_base_var_register("pmix", "ptl", "base", "max_msg_size",
-                               "Max size (in bytes) of a client/server msg",
+                               "Max size (in Mbytes) of a client/server msg",
                                PMIX_MCA_BASE_VAR_TYPE_SIZE_T, NULL, 0, 0,
                                PMIX_INFO_LVL_2,
                                PMIX_MCA_BASE_VAR_SCOPE_READONLY,
-                               &pmix_ptl_globals.max_msg_size);
+                               &max_msg_size);
+    pmix_ptl_globals.max_msg_size = max_msg_size * 1024 * 1024;
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -838,6 +838,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
     pmix_dmdx_request_t *dm;
     bool found;
     pmix_buffer_t pbkt;
+    pmix_cb_t cb;
 
     PMIX_ACQUIRE_OBJECT(caddy);
 
@@ -871,7 +872,12 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
      * store the data first so we can immediately satisfy any future
      * requests. Then, rather than duplicate the resolve code here, we
      * will let the pmix_pending_resolve function go ahead and retrieve
-     * it from the GDS */
+     * it from the GDS
+     *
+     * NOTE: if the data returned is NULL, then it has already been
+     * stored (e.g., via a register_nspace call in response to a request
+     * for job-level data). For now, we will retrieve it so it can
+     * be stored for each peer */
     if (PMIX_SUCCESS == caddy->status) {
         /* cycle across all outstanding local requests and collect their
          * unique nspaces so we can store this for each one */
@@ -906,31 +912,66 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
                 peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, rinfo->peerid);
             }
             PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-
-            PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, caddy->data, caddy->ndata);
-            /* unpack and store it*/
-            kv = PMIX_NEW(pmix_kval_t);
-            cnt = 1;
-            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
-            while (PMIX_SUCCESS == rc) {
-                PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_REMOTE, kv);
+            if (NULL == caddy->data) {
+                /* we assume that the data was provided via a call to
+                 * register_nspace, so what we need to do now is simply
+                 * transfer it across to the individual nspace storage
+                 * components */
+                PMIX_CONSTRUCT(&cb, pmix_cb_t);
+                PMIX_PROC_CREATE(cb.proc, 1);
+                if (NULL == cb.proc) {
+                    PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                    PMIX_DESTRUCT(&cb);
+                    goto complete;
+                }
+                (void)strncpy(cb.proc->nspace, nm->ns->nspace, PMIX_MAX_NSLEN);
+                cb.proc->rank = PMIX_RANK_WILDCARD;
+                cb.scope = PMIX_INTERNAL;
+                cb.copy = false;
+                PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
                 if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DESTRUCT(&cb);
+                    goto complete;
+                }
+                PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
+                    PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_INTERNAL, kv);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        break;
+                    }
+                }
+                PMIX_DESTRUCT(&cb);
+            } else {
+                PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, caddy->data, caddy->ndata);
+                /* unpack and store it*/
+                kv = PMIX_NEW(pmix_kval_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+                while (PMIX_SUCCESS == rc) {
+                    if (caddy->lcd->proc.rank == PMIX_RANK_WILDCARD) {
+                        PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_INTERNAL, kv);
+                    } else {
+                        PMIX_GDS_STORE_KV(rc, peer, &caddy->lcd->proc, PMIX_REMOTE, kv);
+                    }
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        caddy->status = rc;
+                        goto complete;
+                    }
+                    PMIX_RELEASE(kv);
+                    kv = PMIX_NEW(pmix_kval_t);
+                    cnt = 1;
+                    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+                }
+                PMIX_RELEASE(kv);
+                pbkt.base_ptr = NULL;  // protect the data
+                PMIX_DESTRUCT(&pbkt);
+                if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
                     PMIX_ERROR_LOG(rc);
                     caddy->status = rc;
                     goto complete;
                 }
-                PMIX_RELEASE(kv);
-                kv = PMIX_NEW(pmix_kval_t);
-                cnt = 1;
-                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
-            }
-            PMIX_RELEASE(kv);
-            pbkt.base_ptr = NULL;  // protect the data
-            PMIX_DESTRUCT(&pbkt);
-            if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
-                PMIX_ERROR_LOG(rc);
-                caddy->status = rc;
-                goto complete;
             }
         }
         PMIX_LIST_DESTRUCT(&nspaces);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -333,7 +333,13 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     if (NULL == pmix_globals.mypeer->nptr->nspace) {
         pmix_globals.mypeer->nptr->nspace = strdup(proc->nspace);
     }
-    (void)strncpy(pmix_globals.mypeer->info->pname.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    /* setup a rank_info object for us */
+    pmix_globals.mypeer->info = PMIX_NEW(pmix_rank_info_t);
+    if (NULL == pmix_globals.mypeer->info) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_NOMEM;
+    }
+    pmix_globals.mypeer->info->pname.nspace = strdup(proc->nspace);
     pmix_globals.mypeer->info->pname.rank = proc->rank;
 
     /* increment our init reference counter */

--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -274,4 +274,3 @@ void errhandler_reg_callbk (pmix_status_t status,
     TEST_VERBOSE(("ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
                 status, (unsigned long)errhandler_ref));
 }
-

--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -75,5 +75,3 @@ void op_callbk(pmix_status_t status,
 void errhandler_reg_callbk (pmix_status_t status,
                             size_t errhandler_ref,
                             void *cbdata);
-
-


### PR DESCRIPTION
When a process requests job-level info for a namespace unknown to the PMIx server, the server generates a dmodex request to its local host. The request specifies the target nspace, but with a WILDCARD rank since the data being requested is from the job-level info. At least one way the host can respond is to register the nspace using the PMIx server's register nspace API. However, this results in the data being "cached" in the server's GDS module, not in that of the requesting client.

I took a shot at transferring the data in pmix_server_get.c, but the buffer format created by PMIX_GDS_REGISTER_JOB_INFO doesn't match that returned in a regular dmodex request, and so this fails. Alternatively, we could have the host create a job-level dmodex response buffer and give it to us - I chose not to go that way because it would require the host to basically duplicate the code already used to feed register_nspace.

Perhaps someone could take a look at resolving the problem?

Also included a few minor cleanups that cropped up when compiling and trying to commit (e.g., whitespace)

Signed-off-by: Ralph Castain <rhc@open-mpi.org>