### PR TITLE
Update check package

### DIFF
--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
-# Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$
@@ -65,18 +65,22 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
                 [AC_HELP_STRING([--with-libevent-libdir=DIR],
                                 [Search for libevent libraries in DIR ])])
 
+    # get rid of the trailing slash(es)
+    libevent_prefix=$(echo $with_libevent | sed -e 'sX/*$XXg')
+    libeventdir_prefix=$(echo $with_libevent_libdir | sed -e 'sX/*$XXg')
+
     AC_MSG_CHECKING([for libevent in])
-    if test ! -z "$with_libevent" && test "$with_libevent" != "yes"; then
+    if test ! -z "$libevent_prefix" && test "$libevent_prefix" != "yes"; then
         pmix_event_defaults=no
-        pmix_event_dir=$with_libevent
-        if test -d $with_libevent/lib; then
-            pmix_event_libdir=$with_libevent/lib
-        elif test -d $with_libevent/lib64; then
-            pmix_event_libdir=$with_libevent/lib64
-        elif test -d $with_libevent; then
-            pmix_event_libdir=$with_libevent
+        pmix_event_dir=$libevent_prefix
+        if test -d $libevent_prefix/lib; then
+            pmix_event_libdir=$libevent_prefix/lib
+        elif test -d $libevent_prefix/lib64; then
+            pmix_event_libdir=$libevent_prefix/lib64
+        elif test -d $libevent_prefix; then
+            pmix_event_libdir=$libevent_prefix
         else
-            AC_MSG_RESULT([Could not find $with_libevent/lib, $with_libevent/lib64, or $with_libevent])
+            AC_MSG_RESULT([Could not find $libevent_prefix/lib, $libevent_prefix/lib64, or $libevent_prefix])
             AC_MSG_ERROR([Can not continue])
         fi
         AC_MSG_RESULT([$pmix_event_dir and $pmix_event_libdir])
@@ -90,13 +94,13 @@ AC_DEFUN([_PMIX_LIBEVENT_EXTERNAL],[
         else
             AC_MSG_RESULT([not found])
             AC_MSG_WARN([Could not find /usr/lib or /usr/lib64 - you may])
-            AC_MSG_WARN([to specify --with-libevent-libdir=<path>])
+            AC_MSG_WARN([need to specify --with-libevent-libdir=<path>])
             AC_MSG_ERROR([Can not continue])
         fi
         AC_MSG_RESULT([(default search paths)])
     fi
-    AS_IF([test ! -z "$with_libevent_libdir" && "$with_libevent_libdir" != "yes"],
-          [pmix_event_libdir="$with_libevent_libdir"])
+    AS_IF([test ! -z "$libeventdir_prefix" && "$libeventdir_prefix" != "yes"],
+          [pmix_event_libdir="$libeventdir_prefix"])
 
     PMIX_CHECK_PACKAGE([pmix_libevent],
                        [event.h],


### PR DESCRIPTION
Fix a typo that led to incorrect -L for standard locations. If using non-standard locations, then always check the given location first - before appending "/include", or "/lib", or "/lib64" as the user may have pointed us directly to the location

Signed-off-by: Ralph Castain <rhc@open-mpi.org>