### PR TITLE
preg: fixed object destructor: free(): invalid pointer

### DIFF
--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -699,7 +699,7 @@ static pmix_status_t resolve_nodes(const char *nspace,
     pmix_proc_t proc;
 
     cb = PMIX_NEW(pmix_cb_t);
-    cb->pname.nspace = (char*)nspace;
+    cb->pname.nspace = strdup(nspace);
 
     PMIX_THREADSHIFT(cb, _resolve_nodes);
 


### PR DESCRIPTION
The object destructor tries to free the `nspace` name pointer when it not NULL:
https://github.com/pmix/pmix/blob/master/src/include/pmix_globals.c#L286-L287
But this pointer was not allocated, and instead it points to another data that
shouldn't free here.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit ee313a337eebb58347f93d39d5f8ac1e70ab3e03)