### PR TITLE
pmix_perf: Add the barrier at the end of measured key fetching

### DIFF
--- a/contrib/perf_tools/pmi_intra_perf.c
+++ b/contrib/perf_tools/pmi_intra_perf.c
@@ -302,6 +302,12 @@ int main(int argc, char **argv)
                 commit_time, fence_time);
     }
 
+    /*
+     * The barrier ensures that all procs finished key fetching
+     * we had issues with dstor/lockless case evaluation
+     */
+    pmi_fence( 0 );
+
     /* Out of the perf path - send our results to rank 0 using same PMI */
     char key[128];
     sprintf(key, "PMIX_PERF_get_total_time.%d", rank);


### PR DESCRIPTION
This ensures that service activity is not overlapped with the performance
measured region

Signed-off-by: Artem Polyakov <artpol84@gmail.com>