### PR TITLE
Correct an extern statement

### DIFF
--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -18,7 +18,7 @@
 #include "server_callbacks.h"
 #include "src/util/argv.h"
 
-extern int spawn_wait;
+extern bool spawn_wait;
 
 pmix_server_module_t mymodule = {
     .client_connected = connected,


### PR DESCRIPTION
The spawn_wait variable is used as a bool, and declared as a bool, everywhere - but included as an "extern int" in server_callbacks.c. This causes a problem on strict alignment architectures such as ARM

Thanks to @brockpalen for the report

Fixes #682 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>