### PR TITLE
Add a `PMIX_VERSION_RELEASE` to the pmix_version.h

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -109,12 +109,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_MINOR_VERSION], [$PMIX_MINOR_VERSION],
                        [The library minor version is always available, contrary to VERSION])
 
-    pmixmajor=${PMIX_MAJOR_VERSION}L
-    pmixminor=${PMIX_MINOR_VERSION}L
-    AC_SUBST(pmixmajor)
-    AC_SUBST(pmixminor)
-    AC_CONFIG_FILES(pmix_config_prefix[include/pmix_version.h])
-
     PMIX_RELEASE_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --release`"
     if test "$?" != "0"; then
         AC_MSG_ERROR([Cannot continue])
@@ -122,6 +116,14 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_SUBST(PMIX_RELEASE_VERSION)
     AC_DEFINE_UNQUOTED([PMIX_RELEASE_VERSION], [$PMIX_RELEASE_VERSION],
                        [The library release version is always available, contrary to VERSION])
+
+    pmixmajor=${PMIX_MAJOR_VERSION}L
+    pmixminor=${PMIX_MINOR_VERSION}L
+    pmixrelease=${PMIX_RELEASE_VERSION}L
+    AC_SUBST(pmixmajor)
+    AC_SUBST(pmixminor)
+    AC_SUBST(pmixrelease)
+    AC_CONFIG_FILES(pmix_config_prefix[include/pmix_version.h])
 
     PMIX_GREEK_VERSION="`$PMIX_top_srcdir/config/pmix_get_version.sh $PMIX_top_srcdir/VERSION --greek`"
     if test "$?" != "0"; then

--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -15,5 +15,5 @@
 /* define PMIx version */
 #define PMIX_VERSION_MAJOR @pmixmajor@
 #define PMIX_VERSION_MINOR @pmixminor@
-
+#define PMIX_VERSION_RELEASE @pmixrelease@
 #endif


### PR DESCRIPTION
 * This would have been helpful in detecting one of the changes from the
   2.0.2 to 2.0.3 build. A downstream project needed to change behavior
   based upon the point release change.
 * Note that the `pmix_version.h` symbol is `PMIX_VERSION_RELEASE` to make
   it match the other version constants. The internal define is still
   called `PMIX_RELEASE_VERSION` and does not have the `L` suffix. I
   did that so that it does not break internal functionality.
