### PR TITLE
Provide spawned keys to resulting procs

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1727,7 +1727,7 @@ static void _spcb(int sd, short args, void *cbdata)
     PMIX_SERVER_QUEUE_REPLY(cd->cd->peer, cd->cd->hdr.tag, reply);
     /* cleanup */
     PMIX_RELEASE(cd->cd);
-    PMIX_WAKEUP_THREAD(&cd->lock);
+    PMIX_RELEASE(cd);
 }
 
 static void spawn_cbfunc(pmix_status_t status, char *nspace, void *cbdata)
@@ -1741,8 +1741,6 @@ static void spawn_cbfunc(pmix_status_t status, char *nspace, void *cbdata)
     cd->cd = (pmix_server_caddy_t*)cbdata;;
 
     PMIX_THREADSHIFT(cd, _spcb);
-    PMIX_WAIT_THREAD(&cd->lock);
-    PMIX_RELEASE(cd);
 }
 
 static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t ndata,

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -797,8 +797,22 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                     pmix_spawn_cbfunc_t cbfunc, void *cbdata)
 {
     myxfer_t *x;
+    size_t n;
+    pmix_proc_t *pptr;
+    bool spawned;
 
     pmix_output(0, "SERVER: SPAWN");
+
+    /* check the job info for parent and spawned keys */
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(job_info[n].key, PMIX_PARENT_ID, PMIX_MAX_KEYLEN)) {
+            pptr = job_info[n].value.data.proc;
+            pmix_output(0, "SPAWN: Parent ID %s:%d", pptr->nspace, pptr->rank);
+        } else if (0 == strncmp(job_info[n].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN)) {
+            spawned = PMIX_INFO_TRUE(&job_info[n]);
+            pmix_output(0, "SPAWN: Spawned %s", spawned ? "TRUE" : "FALSE");
+        }
+    }
 
     /* in practice, we would pass this request to the local
      * resource manager for launch, and then have that server


### PR DESCRIPTION
For consistency, always provide the PMIX_SPAWNED and PMIX_PARENT_ID keys
in the job-level info of procs started by PMIx_Spawn from a client. Do
not do so for procs started by a tool as the tool isn't part of the
resulting nspace.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>