### PR TITLE
Fixed the direct modex request

### DIFF
--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -689,7 +689,14 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 
     /* retrieve the data for the specific rank they are asking about */
     if (PMIX_RANK_WILDCARD != rank) {
-        if (!peer->commit_cnt) {
+        if (!PMIX_PROC_IS_SERVER(peer) && !peer->commit_cnt) {
+            /* this condition works only for local requests, server does 
+             * count commits for local ranks, and check this count when 
+             * local request.
+             * if that request performs for remote rank on the remote 
+             * node (by direct modex) so `peer->commit_cnt` should be ignored,
+             * it is can not be counted for the remote side and this condition 
+             * does not matter for remote case */
             return PMIX_ERR_NOT_FOUND;
         }
         proc.rank = rank;


### PR DESCRIPTION
Fixed checking the commit counter which should be not checked for
server, otherwise clients have get error when direct modex.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>