### PR TITLE
Fabric pre-configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,8 @@ test/simple/test_pmix
 test/simple/simptool
 test/simple/simpdie
 test/simple/simptimeout
+test/simple/gwclient
+test/simple/gwtest
 
 # coverity
 cov-int

--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -12,7 +12,7 @@
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
 # $COPYRIGHT$

--- a/examples/debuggerd.c
+++ b/examples/debuggerd.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -319,7 +319,7 @@ typedef uint32_t pmix_rank_t;
 /* attributes used by host server to pass data to the server convenience library - the
  * data will then be parsed and provided to the local clients */
 #define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
-#define PMIX_PROC_DATA                      "pmix.pdata"            // (pmix_data_array_t) starts with rank, then contains more data
+#define PMIX_PROC_DATA                      "pmix.pdata"            // (pmix_data_array_t*) starts with rank, then contains more data
 #define PMIX_NODE_MAP                       "pmix.nmap"             // (char*) regex of nodes containing procs for this job
 #define PMIX_PROC_MAP                       "pmix.pmap"             // (char*) regex describing procs on each node within this job
 #define PMIX_ANL_MAP                        "pmix.anlmap"           // (char*) process mapping in ANL notation (used in PMI-1/PMI-2)
@@ -405,7 +405,7 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_JOB_CONTINUOUS                 "pmix.continuous"       // (bool) application is continuous, all failed procs should
                                                                         //        be immediately restarted
 #define PMIX_MAX_RESTARTS                   "pmix.maxrestarts"      // (uint32_t) max number of times to restart a job
-#define PMIX_FWD_STDIN                      "pmix.fwd.stdin"        // (bool) forward the stdin from this process to the spawned processes
+#define PMIX_FWD_STDIN                      "pmix.fwd.stdin"        // (bool) forward the stdin from this process to the target processes
 #define PMIX_FWD_STDOUT                     "pmix.fwd.stdout"       // (bool) forward stdout from the spawned processes to this process (typically used by a tool)
 #define PMIX_FWD_STDERR                     "pmix.fwd.stderr"       // (bool) forward stderr from the spawned processes to this process (typically used by a tool)
 #define PMIX_FWD_STDDIAG                    "pmix.fwd.stddiag"      // (bool) if a diagnostic channel exists, forward any output on it
@@ -430,9 +430,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_QUERY_QUEUE_LIST               "pmix.qry.qlst"         // (char*) request a comma-delimited list of scheduler queues
 #define PMIX_QUERY_QUEUE_STATUS             "pmix.qry.qst"          // (TBD) status of a specified scheduler queue
 #define PMIX_QUERY_PROC_TABLE               "pmix.qry.ptable"       // (char*) input nspace of job whose info is being requested
-                                                                    //         returns (pmix_data_array_t) an array of pmix_proc_info_t
+                                                                    //         returns (pmix_data_array_t*) an array of pmix_proc_info_t
 #define PMIX_QUERY_LOCAL_PROC_TABLE         "pmix.qry.lptable"      // (char*) input nspace of job whose info is being requested
-                                                                    //         returns (pmix_data_array_t) an array of pmix_proc_info_t for
+                                                                    //         returns (pmix_data_array_t*) an array of pmix_proc_info_t for
                                                                     //         procs in job on same node
 #define PMIX_QUERY_AUTHORIZATIONS           "pmix.qry.auths"        // (bool) return operations tool is authorized to perform
 #define PMIX_QUERY_SPAWN_SUPPORT            "pmix.qry.spawn"        // (bool) return a comma-delimited list of supported spawn attributes
@@ -514,14 +514,40 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_ALLOC_NUM_CPU_LIST             "pmix.alloc.ncpulist"   // (char*) regex of #cpus for each node
 #define PMIX_ALLOC_CPU_LIST                 "pmix.alloc.cpulist"    // (char*) regex of specific cpus indicating the cpus involved.
 #define PMIX_ALLOC_MEM_SIZE                 "pmix.alloc.msize"      // (float) number of Mbytes
-#define PMIX_ALLOC_NETWORK                  "pmix.alloc.net"        // (array) array of pmix_info_t describing network resources. If not
-                                                                    //         given as part of an info struct that identifies the
-                                                                    //         impacted nodes, then the description will be applied
-                                                                    //         across all nodes in the requestor's allocation
-#define PMIX_ALLOC_NETWORK_ID               "pmix.alloc.netid"      // (char*) name of network
+#define PMIX_ALLOC_NETWORK                  "pmix.alloc.net"        // (pmix_data_array_t*) Array of pmix_info_t describing
+                                                                    //         network resource request. This must include at least:
+                                                                    //           * PMIX_ALLOC_NETWORK_ID
+                                                                    //           * PMIX_ALLOC_NETWORK_TYPE
+                                                                    //           * PMIX_ALLOC_NETWORK_ENDPTS
+                                                                    //         plus whatever other descriptors are desired
+#define PMIX_ALLOC_NETWORK_ID               "pmix.alloc.netid"      // (char*) key to be used when accessing this requested network allocation. The
+                                                                    //         allocation will be returned/stored as a pmix_data_array_t of
+                                                                    //         pmix_info_t indexed by this key and containing at least one
+                                                                    //         entry with the same key and the allocated resource description.
+                                                                    //         The type of the included value depends upon the network
+                                                                    //         support. For example, a TCP allocation might consist of a
+                                                                    //         comma-delimited string of socket ranges such as
+                                                                    //         "32000-32100,33005,38123-38146". Additional entries will consist
+                                                                    //         of any provided resource request directives, along with their
+                                                                    //         assigned values. Examples include:
+                                                                    //           * PMIX_ALLOC_NETWORK_TYPE - the type of resources provided
+                                                                    //           * PMIX_ALLOC_NETWORK_PLANE - if applicable, what plane the
+                                                                    //               resources were assigned from
+                                                                    //           * PMIX_ALLOC_NETWORK_QOS - the assigned QoS
+                                                                    //           * PMIX_ALLOC_BANDWIDTH - the allocated bandwidth
+                                                                    //           * PMIX_ALLOC_NETWORK_SEC_KEY - a security key for the requested
+                                                                    //               network allocation
+                                                                    //         NOTE: the assigned values may differ from those requested,
+                                                                    //         especially if the "required" flag was not set in the request
 #define PMIX_ALLOC_BANDWIDTH                "pmix.alloc.bw"         // (float) Mbits/sec
 #define PMIX_ALLOC_NETWORK_QOS              "pmix.alloc.netqos"     // (char*) quality of service level
-#define PMIX_ALLOC_TIME                     "pmix.alloc.time"       // (uint32_t) time in seconds
+#define PMIX_ALLOC_TIME                     "pmix.alloc.time"       // (uint32_t) time in seconds that the allocation shall remain valid
+#define PMIX_ALLOC_NETWORK_TYPE             "pmix.alloc.nettype"    // (char*) type of desired transport (e.g., tcp, udp)
+#define PMIX_ALLOC_NETWORK_PLANE            "pmix.alloc.netplane"   // (char*) id string for the NIC (aka plane) to be used for this allocation
+                                                                    //         (e.g., CIDR for Ethernet)
+#define PMIX_ALLOC_NETWORK_ENDPTS           "pmix.alloc.endpts"     // (size_t) number of endpoints to allocate
+#define PMIX_ALLOC_NETWORK_SEC_KEY          "pmix.alloc.nsec"       // (pmix_byte_object_t) network security key
+
 
 /* job control attributes */
 #define PMIX_JOB_CTRL_ID                    "pmix.jctrl.id"         // (char*) provide a string identifier for this request
@@ -575,11 +601,13 @@ typedef uint32_t pmix_rank_t;
                                                                     //            generating the event
 
 /* security attributes */
-#define PMIX_CRED_TYPE                      "pmix.sec.ctype"        //  when passed in PMIx_Get_credential, a prioritized,
+#define PMIX_CRED_TYPE                      "pmix.sec.ctype"        // (char*) when passed in PMIx_Get_credential, a prioritized,
                                                                     // comma-delimited list of desired credential types for use
                                                                     // in environments where multiple authentication mechanisms
                                                                     // may be available. When returned in a callback function, a
                                                                     // string identifier of the credential type
+#define PMIX_CRYPTO_KEY                     "pmix.sec.key"          // (pmix_byte_object_t) blob containing crypto key
+
 
 /* IO Forwarding Attributes */
 #define PMIX_IOF_CACHE_SIZE                 "pmix.iof.csize"        // (uint32_t) requested size of the server cache in bytes for each specified channel.
@@ -872,6 +900,7 @@ typedef uint8_t pmix_data_range_t;
 #define PMIX_RANGE_GLOBAL       5   // data available to all procs
 #define PMIX_RANGE_CUSTOM       6   // range is specified in a pmix_info_t
 #define PMIX_RANGE_PROC_LOCAL   7   // restrict range to the local proc
+#define PMIX_RANGE_INVALID   UINT8_MAX
 
 /* define a "persistence" policy for data published by clients */
 typedef uint8_t pmix_persistence_t;
@@ -880,6 +909,7 @@ typedef uint8_t pmix_persistence_t;
 #define PMIX_PERSIST_PROC           2   // retain until publishing process terminates
 #define PMIX_PERSIST_APP            3   // retain until application terminates
 #define PMIX_PERSIST_SESSION        4   // retain until session/allocation terminates
+#define PMIX_PERSIST_INVALID   UINT8_MAX
 
 /* define a set of bit-mask flags for specifying behavior of
  * command directives via pmix_info_t arrays */
@@ -1377,6 +1407,40 @@ typedef struct pmix_value {
             (m) = NULL;                                 \
         }                                               \
     } while (0)
+
+#define PMIX_VALUE_GET_NUMBER(s, m, n, t)               \
+    do {                                                \
+        (s) = PMIX_SUCCESS;                             \
+        if (PMIX_SIZE == (m)->type) {                   \
+            (n) = (t)((m)->data.size);                  \
+        } else if (PMIX_INT == (m)->type) {             \
+            (n) = (t)((m)->data.integer);               \
+        } else if (PMIX_INT8 == (m)->type) {            \
+            (n) = (t)((m)->data.int8);                  \
+        } else if (PMIX_INT16 == (m)->type) {           \
+            (n) = (t)((m)->data.int16);                 \
+        } else if (PMIX_INT32 == (m)->type) {           \
+            (n) = (t)((m)->data.int32);                 \
+        } else if (PMIX_INT64 == (m)->type) {           \
+            (n) = (t)((m)->data.int64);                 \
+        } else if (PMIX_UINT == (m)->type) {            \
+            (n) = (t)((m)->data.uint);                  \
+        } else if (PMIX_UINT8 == (m)->type) {           \
+            (n) = (t)((m)->data.uint8);                 \
+        } else if (PMIX_UINT16 == (m)->type) {          \
+            (n) = (t)((m)->data.uint16);                \
+        } else if (PMIX_UINT32 == (m)->type) {          \
+            (n) = (t)((m)->data.uint32);                \
+        } else if (PMIX_UINT64 == (m)->type) {          \
+            (n) = (t)((m)->data.uint64);                \
+        } else if (PMIX_FLOAT == (m)->type) {           \
+            (n) = (t)((m)->data.fval);                  \
+        } else if (PMIX_DOUBLE == (m)->type) {          \
+            (n) = (t)((m)->data.dval);                  \
+        } else {                                        \
+            (s) = PMIX_ERR_BAD_PARAM;                   \
+        }                                               \
+    } while(0)
 
 /* expose some functions that are resolved in the
  * PMIx library, but part of a header that

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -679,12 +679,13 @@ typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Provide a function by which the resource manager can request
- * any application-specific environmental variables prior to
- * launch of an application. For example, network libraries may
- * opt to provide security credentials for the application. This
- * is defined as a non-blocking operation in case network
- * libraries need to perform some action before responding. The
- * returned env will be distributed along with the application */
+ * any application-specific environmental variables, resource
+ * assignments, and/or other data prior to launch of an application.
+ * For example, network libraries may opt to provide security
+ * credentials for the application. This is defined as a non-blocking
+ * operation in case network libraries need to perform some action
+ * before responding. Any returned env will be distributed along
+ * with the application */
 PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
                                                         pmix_info_t info[], size_t ninfo,
                                                         pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
@@ -693,6 +694,13 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
  * any application-specific operations prior to spawning local
  * clients of a given application. For example, a network library
  * might need to setup the local driver for "instant on" addressing.
+ * Data provided in the info array will be stored in the job-info
+ * region for the nspace. Operations included in the info array
+ * will be cached until the server calls PMIx_server_setup_fork,
+ * thereby indicating that local clients of this nspace will exist.
+ * Operations indicated by the provided data will only be executed
+ * for the first local client - i.e., they will only be executed
+ * once for a given nspace
  */
 PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const char nspace[],
                                                           pmix_info_t info[], size_t ninfo,
@@ -729,6 +737,16 @@ PMIX_EXPORT pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
                                                   const pmix_byte_object_t *bo,
                                                   const pmix_info_t info[], size_t ninfo,
                                                   pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Collect inventory of local resources. If the PMIX_MASTER_SERVER
+ * attribute is passed, and the plugin for a particular resource
+ * is capable of obtaining a global map of its resources, then
+ * only that server shall grab it - all other plugins for
+ * that resource will ignore the request. This is a non-blocking
+ * API as it may involve somewhat lengthy operations to obtain
+ * the requested information */
+PMIX_EXPORT pmix_status_t PMIx_server_collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                                        pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_tool.h
+++ b/include/pmix_tool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science

--- a/src/class/pmix_hotel.c
+++ b/src/class/pmix_hotel.c
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -288,7 +288,9 @@ static void notification_fn(size_t evhdlr_registration_id,
         }
         /* if the object wasn't returned, then that is an error */
         if (NULL == lock) {
-            fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+            pmix_output_verbose(2, pmix_client_globals.base_output,
+                                "event handler %s failed to return object",
+                                (NULL == name) ? "NULL" : name);
             /* let the event handler progress */
             if (NULL != cbfunc) {
                 cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);

--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -340,6 +340,8 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         myflags.xml = pmix_globals.xml_output;
         if (pmix_globals.timestamp_output) {
             time(&myflags.timestamp);
+        } else {
+            myflags.timestamp = 0;
         }
         myflags.tag = pmix_globals.tag_output;
     } else {
@@ -356,6 +358,8 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
 
     /* setup output object */
     output = PMIX_NEW(pmix_iof_write_output_t);
+    memset(starttag, 0, PMIX_IOF_BASE_TAG_MAX);
+    memset(endtag, 0, PMIX_IOF_BASE_TAG_MAX);
 
     /* write output data to the corresponding tag */
     if (PMIX_FWD_STDIN_CHANNEL & stream) {
@@ -402,7 +406,7 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         cptr = ctime(&myflags.timestamp);
         cptr[strlen(cptr)-1] = '\0';  /* remove trailing newline */
 
-        if (pmix_globals.tag_output) {
+        if (myflags.tag) {
             /* if we want it tagged as well, use both */
             snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "%s[%s]<%s>:",
                      cptr, PMIX_NAME_PRINT(name), suffix);
@@ -415,7 +419,7 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
         goto construct;
     }
 
-    if (pmix_globals.tag_output) {
+    if (myflags.tag) {
         snprintf(starttag, PMIX_IOF_BASE_TAG_MAX, "[%s]<%s>:",
                  PMIX_NAME_PRINT(name), suffix);
         /* no endtag for this option */
@@ -448,7 +452,7 @@ pmix_status_t pmix_iof_write_output(const pmix_proc_t *name,
      * and replace those with the tag
      */
     for (i=0; i < bo->size && k < PMIX_IOF_BASE_TAGGED_OUT_MAX; i++) {
-        if (pmix_globals.xml_output) {
+        if (myflags.xml) {
             if ('&' == bo->bytes[i]) {
                 if (k+5 >= PMIX_IOF_BASE_TAGGED_OUT_MAX) {
                     PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -121,6 +121,8 @@ PMIX_EXPORT const char* PMIx_Persistence_string(pmix_persistence_t persist)
             return "RETAIN UNTIL APPLICATION OF PUBLISHING PROCESS TERMINATES";
         case PMIX_PERSIST_SESSION:
             return "RETAIN UNTIL ALLOCATION OF PUBLISHING PROCESS TERMINATES";
+        case PMIX_PERSIST_INVALID:
+            return "INVALID";
         default:
             return "UNKNOWN PERSISTENCE";
     }
@@ -145,6 +147,8 @@ PMIX_EXPORT const char* PMIx_Data_range_string(pmix_data_range_t range)
             return "AVAIL AS SPECIFIED IN DIRECTIVES";
         case PMIX_RANGE_PROC_LOCAL:
             return "AVAIL ON LOCAL PROC ONLY";
+        case PMIX_RANGE_INVALID:
+            return "INVALID";
         default:
             return "UNKNOWN";
     }

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -636,7 +636,7 @@ pmix_status_t pmix_bfrops_base_copy_darray(pmix_data_array_t **dest,
             pd = (pmix_pdata_t*)p->array;
             sd = (pmix_pdata_t*)src->array;
             for (n=0; n < src->size; n++) {
-                PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data.flag, sd[n].value.type);
+                PMIX_PDATA_XFER(&pd[n], &sd[n]);
             }
             break;
         case PMIX_BUFFER:

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -361,6 +361,7 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
                                             pmix_value_t *p1)
 {
     pmix_value_cmp_t rc = PMIX_VALUE1_GREATER;
+    int ret;
 
     if (p->type != p1->type) {
         return rc;
@@ -457,10 +458,10 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
                 if (NULL == p1->data.envar.envar) {
                     return PMIX_VALUE1_GREATER;
                 }
-                rc = strcmp(p->data.envar.envar, p1->data.envar.envar);
-                if (rc < 0) {
+                ret = strcmp(p->data.envar.envar, p1->data.envar.envar);
+                if (ret < 0) {
                     return PMIX_VALUE2_GREATER;
-                } else if (0 < rc) {
+                } else if (0 < ret) {
                     return PMIX_VALUE1_GREATER;
                 }
             } else if (NULL != p1->data.envar.envar) {
@@ -473,10 +474,10 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
                 if (NULL == p1->data.envar.value) {
                     return PMIX_VALUE1_GREATER;
                 }
-                rc = strcmp(p->data.envar.value, p1->data.envar.value);
-                if (rc < 0) {
+                ret = strcmp(p->data.envar.value, p1->data.envar.value);
+                if (ret < 0) {
                     return PMIX_VALUE2_GREATER;
-                } else if (0 < rc) {
+                } else if (0 < ret) {
                     return PMIX_VALUE1_GREATER;
                 }
             } else if (NULL != p1->data.envar.value) {

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -111,6 +111,7 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
         }
         if (PMIX_INT32 != local_type) { /* if the length wasn't first, then error */
             *num_vals = 0;
+            PMIX_ERROR_LOG(PMIX_ERR_UNPACK_FAILURE);
             return PMIX_ERR_UNPACK_FAILURE;
         }
     }

--- a/src/mca/plog/default/plog_default.h
+++ b/src/mca/plog/default/plog_default.h
@@ -32,7 +32,7 @@ BEGIN_C_DECLS
  * Plog interfaces
  */
 
-extern pmix_plog_base_component_t mca_plog_default_component;
+PMIX_EXPORT extern pmix_plog_base_component_t mca_plog_default_component;
 extern pmix_plog_module_t pmix_plog_default_module;
 
 END_C_DECLS

--- a/src/mca/plog/smtp/plog_smtp.h
+++ b/src/mca/plog/smtp/plog_smtp.h
@@ -59,7 +59,7 @@ typedef struct {
 /*
  * Plog interfaces
  */
-extern pmix_plog_smtp_component_t mca_plog_smtp_component;
+PMIX_EXPORT extern pmix_plog_smtp_component_t mca_plog_smtp_component;
 extern pmix_plog_module_t pmix_plog_smtp_module;
 
 END_C_DECLS

--- a/src/mca/plog/stdfd/plog_stdfd.h
+++ b/src/mca/plog/stdfd/plog_stdfd.h
@@ -32,7 +32,7 @@ BEGIN_C_DECLS
  * Plog interfaces
  */
 
-extern pmix_plog_base_component_t mca_plog_stdfd_component;
+PMIX_EXPORT extern pmix_plog_base_component_t mca_plog_stdfd_component;
 extern pmix_plog_module_t pmix_plog_stdfd_module;
 
 END_C_DECLS

--- a/src/mca/plog/syslog/plog_syslog.h
+++ b/src/mca/plog/syslog/plog_syslog.h
@@ -39,7 +39,7 @@ typedef struct {
     int facility;
 } pmix_plog_syslog_component_t;
 
-extern pmix_plog_syslog_component_t mca_plog_syslog_component;
+PMIX_EXPORT extern pmix_plog_syslog_component_t mca_plog_syslog_component;
 extern pmix_plog_module_t pmix_plog_syslog_module;
 
 END_C_DECLS

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -78,15 +78,20 @@ typedef struct pmix_pnet_globals_t pmix_pnet_globals_t;
 
 PMIX_EXPORT extern pmix_pnet_globals_t pmix_pnet_globals;
 
-PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_app(char *nspace,
-                                                   pmix_info_t info[], size_t ninfo,
-                                                   pmix_list_t *ilist);
+PMIX_EXPORT pmix_status_t pmix_pnet_base_allocate(char *nspace,
+                                                  pmix_info_t info[], size_t ninfo,
+                                                  pmix_list_t *ilist);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
                                                              pmix_info_t info[],
                                                              size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *peer, char ***env);
 PMIX_EXPORT void pmix_pnet_base_child_finalized(pmix_peer_t *peer);
 PMIX_EXPORT void pmix_pnet_base_local_app_finalized(char *nspace);
+PMIX_EXPORT void pmix_pnet_base_deregister_nspace(char *nspace);
+PMIX_EXPORT void pmix_pnet_base_collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                                  pmix_info_cbfunc_t cbfunc, void *cbdata);
+PMIX_EXPORT pmix_status_t pmix_pnet_base_harvest_envars(char **incvars, char **excvars,
+                                                        pmix_list_t *ilist);
 
 END_C_DECLS
 

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
@@ -25,29 +25,30 @@
 
 /* NOTE: a tool (e.g., prun) may call this function to
  * harvest local envars for inclusion in a call to
- * PMIx_Spawn */
-pmix_status_t pmix_pnet_base_setup_app(char *nspace,
-                                       pmix_info_t info[], size_t ninfo,
-                                       pmix_list_t *ilist)
+ * PMIx_Spawn, or it might be called in response to
+ * a call to PMIx_Allocate_resources */
+pmix_status_t pmix_pnet_base_allocate(char *nspace,
+                                      pmix_info_t info[], size_t ninfo,
+                                      pmix_list_t *ilist)
 {
     pmix_pnet_base_active_module_t *active;
     pmix_status_t rc;
     pmix_nspace_t *nptr, *ns;
+    size_t n;
 
     if (!pmix_pnet_globals.initialized) {
         return PMIX_ERR_INIT;
     }
 
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
-                        "pnet: setup_app called");
+                        "pnet:allocate called");
 
     /* protect against bozo inputs */
     if (NULL == nspace || NULL == ilist) {
         return PMIX_ERR_BAD_PARAM;
     }
-
-    nptr = NULL;
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        nptr = NULL;
         /* find this nspace - note that it may not have
          * been registered yet */
         PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
@@ -65,12 +66,36 @@ pmix_status_t pmix_pnet_base_setup_app(char *nspace,
             nptr->nspace = strdup(nspace);
             pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
         }
-    }
 
-    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
-        if (NULL != active->module->setup_app) {
-            if (PMIX_SUCCESS != (rc = active->module->setup_app(nptr, info, ninfo, ilist))) {
-                return rc;
+        /* if the info param is NULL, then we make one pass thru the actives
+         * in case someone specified an allocation or collection of envars
+         * via MCA param */
+        if (NULL == info) {
+            PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+                if (NULL != active->module->allocate) {
+                    if (PMIX_SUCCESS == (rc = active->module->allocate(nptr, NULL, ilist))) {
+                        break;
+                    }
+                }
+                if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                    /* true error */
+                    return rc;
+                }
+            }
+        } else {
+            /* process the allocation request */
+            for (n=0; n < ninfo; n++) {
+                PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+                    if (NULL != active->module->allocate) {
+                        if (PMIX_SUCCESS == (rc = active->module->allocate(nptr, &info[n], ilist))) {
+                            break;
+                        }
+                    }
+                    if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                        /* true error */
+                        return rc;
+                    }
+                }
             }
         }
     }
@@ -199,6 +224,7 @@ void pmix_pnet_base_child_finalized(pmix_peer_t *peer)
 void pmix_pnet_base_local_app_finalized(char *nspace)
 {
     pmix_pnet_base_active_module_t *active;
+    pmix_nspace_t *nptr, *ns;
 
     if (!pmix_pnet_globals.initialized) {
         return;
@@ -206,15 +232,303 @@ void pmix_pnet_base_local_app_finalized(char *nspace)
 
     /* protect against bozo inputs */
     if (NULL == nspace) {
-        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return;
+    }
+
+    /* find this nspace object */
+    nptr = NULL;
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+        if (0 == strcmp(ns->nspace, nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        /* nothing we can do */
         return;
     }
 
     PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
         if (NULL != active->module->local_app_finalized) {
-            active->module->local_app_finalized(nspace);
+            active->module->local_app_finalized(nptr);
         }
     }
 
     return;
+}
+
+void pmix_pnet_base_deregister_nspace(char *nspace)
+{
+    pmix_pnet_base_active_module_t *active;
+    pmix_nspace_t *nptr, *ns;
+
+    if (!pmix_pnet_globals.initialized) {
+        return;
+    }
+
+    /* protect against bozo inputs */
+    if (NULL == nspace) {
+        return;
+    }
+
+    /* find this nspace object */
+    nptr = NULL;
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+        if (0 == strcmp(ns->nspace, nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        /* nothing we can do */
+        return;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->deregister_nspace) {
+            active->module->deregister_nspace(nptr);
+        }
+    }
+
+    return;
+}
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_release_cbfunc_t release_fn;
+    void *release_cbdata;
+} pmix_inventory_payload_t;
+static void ipcon(pmix_inventory_payload_t *p)
+{
+    p->info = NULL;
+    p->ninfo = 0;
+    p->release_fn = NULL;
+    p->release_cbdata = NULL;
+}
+static PMIX_CLASS_INSTANCE(pmix_inventory_payload_t,
+                           pmix_list_item_t,
+                           ipcon, NULL);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_lock_t lock;
+    int requests;
+    int replies;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_list_t payload;   // list of pmix_inventory_payload_t containing the replies
+    pmix_info_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_pnet_inventory_lock_t;
+static void ilcon(pmix_pnet_inventory_lock_t *p)
+{
+    PMIX_CONSTRUCT_LOCK(&p->lock);
+    p->requests = 0;
+    p->replies = 0;
+    PMIX_CONSTRUCT(&p->payload, pmix_list_t);
+}
+static void ildes(pmix_pnet_inventory_lock_t *p)
+{
+    PMIX_DESTRUCT_LOCK(&p->lock);
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    PMIX_LIST_DESTRUCT(&p->payload);
+}
+static PMIX_CLASS_INSTANCE(pmix_pnet_inventory_lock_t,
+                           pmix_object_t,
+                           ilcon, ildes);
+
+static void cirelease(void *cbdata)
+{
+    pmix_pnet_inventory_lock_t *lock = (pmix_pnet_inventory_lock_t*)cbdata;
+    PMIX_RELEASE_THREAD(&lock->lock);
+    PMIX_RELEASE(lock);
+}
+
+static void cicbfunc(pmix_status_t status,
+                     pmix_info_t *info, size_t ninfo,
+                     void *cbdata,
+                     pmix_release_cbfunc_t release_fn,
+                     void *release_cbdata)
+{
+    pmix_pnet_inventory_lock_t *lock = (pmix_pnet_inventory_lock_t*)cbdata;
+    pmix_inventory_payload_t *pyload;
+    pmix_status_t ret;
+    size_t n;
+
+    PMIX_ACQUIRE_THREAD(&lock->lock);
+    /* transfer the returned values */
+    pyload = PMIX_NEW(pmix_inventory_payload_t);
+    if (NULL == pyload) {
+        ret = PMIX_ERR_NOMEM;
+        goto error;
+    }
+    pyload->info = info;
+    pyload->ninfo = ninfo;
+    pyload->release_fn = release_fn;
+    pyload->release_cbdata = release_cbdata;
+    pmix_list_append(&lock->payload, &pyload->super);
+    lock->ninfo += ninfo;
+    lock->replies++;
+    if (lock->replies < lock->requests) {
+        PMIX_RELEASE_THREAD(&lock->lock);
+        return;
+    }
+
+    /* if we get here, then collection is complete */
+    ret = PMIX_SUCCESS;
+
+    /* construct the reply info array */
+    PMIX_INFO_CREATE(lock->info, lock->ninfo);
+    if (NULL == lock->info) {
+        ret = PMIX_ERR_NOMEM;
+        goto error;
+    }
+    /* transfer the results */
+    n=0;
+    PMIX_LIST_FOREACH(pyload, &lock->payload, pmix_inventory_payload_t) {
+        memcpy(&lock->info[n], pyload->info, sizeof(pmix_info_t));
+        ++n;
+    }
+    /* now call the requestor back */
+    lock->cbfunc(ret, lock->info, lock->ninfo, lock->cbdata, cirelease, lock);
+    return;
+
+  error:
+    /* cycle across the collected payloads and let
+     * providers release them */
+    PMIX_LIST_FOREACH(pyload, &lock->payload, pmix_inventory_payload_t) {
+        if (NULL != pyload->release_fn) {
+            pyload->release_fn(pyload->release_cbdata);
+        }
+    }
+    PMIX_RELEASE_THREAD(&lock->lock);
+    PMIX_RELEASE(lock);
+}
+
+void pmix_pnet_base_collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                      pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_pnet_base_active_module_t *active;
+    pmix_pnet_inventory_lock_t *mylock;
+    pmix_status_t rc;
+
+    /* we cannot block here as each plugin could take some time to
+     * complete the request. So instead, we call each active plugin
+     * and get their immediate response - if "in progress", then
+     * we record that we have to wait for their answer before providing
+     * the caller with a response. If "error", then we know we
+     * won't be getting a response from them */
+
+    if (!pmix_pnet_globals.initialized) {
+        /* need to call them back so they know */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_ERR_INIT, NULL, 0, cbdata, NULL, NULL);
+        }
+        return;
+    }
+    /* create the lock */
+    mylock = PMIX_NEW(pmix_pnet_inventory_lock_t);
+    if (NULL == mylock) {
+        /* need to call them back so they know */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_ERR_NOMEM, NULL, 0, cbdata, NULL, NULL);
+        }
+        return;
+    }
+
+    /* hold the lock until all active modules have been called
+     * to avoid race condition where replies come in before
+     * the requests counter has been fully updated */
+    PMIX_ACQUIRE_THREAD(&mylock->lock);
+
+    PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
+        if (NULL != active->module->collect_inventory) {
+            rc = active->module->collect_inventory(directives, ndirs, cicbfunc, &mylock);
+            if (PMIX_ERR_OPERATION_IN_PROGRESS == rc) {
+                mylock->requests++;
+            }
+        }
+    }
+    if (0 == mylock->requests) {
+        /* there will be no replies */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, cbdata, NULL, NULL);
+        }
+    } else {
+        PMIX_INFO_CREATE(mylock->info, mylock->requests);
+        if (NULL == mylock->info) {
+            /* better let them know */
+            if (NULL != cbfunc) {
+                cbfunc(PMIX_ERR_NOMEM, NULL, 0, cbdata, NULL, NULL);
+            }
+        } else {
+            mylock->ninfo = mylock->requests;
+            PMIX_RELEASE_THREAD(&mylock->lock);
+            return;
+        }
+    }
+
+    PMIX_RELEASE_THREAD(&mylock->lock);
+    PMIX_RELEASE(mylock);
+    return;
+}
+
+pmix_status_t pmix_pnet_base_harvest_envars(char **incvars, char **excvars,
+                                            pmix_list_t *ilist)
+{
+    int i, j;
+    size_t len;
+    pmix_kval_t *kv, *next;
+    char *cs_env, *string_key;
+
+    /* harvest envars to pass along */
+    for (j=0; NULL != incvars[j]; j++) {
+        len = strlen(incvars[j]);
+        if ('*' == incvars[j][len-1]) {
+            --len;
+        }
+        for (i = 0; NULL != environ[i]; ++i) {
+            if (0 == strncmp(environ[i], incvars[j], len)) {
+                cs_env = strdup(environ[i]);
+                kv = PMIX_NEW(pmix_kval_t);
+                if (NULL == kv) {
+                    return PMIX_ERR_OUT_OF_RESOURCE;
+                }
+                kv->key = strdup(PMIX_SET_ENVAR);
+                kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                if (NULL == kv->value) {
+                    PMIX_RELEASE(kv);
+                    return PMIX_ERR_OUT_OF_RESOURCE;
+                }
+                kv->value->type = PMIX_ENVAR;
+                string_key = strchr(cs_env, '=');
+                *string_key = '\0';
+                ++string_key;
+                PMIX_ENVAR_LOAD(&kv->value->data.envar, cs_env, string_key, ':');
+                pmix_list_append(ilist, &kv->super);
+                free(cs_env);
+            }
+        }
+    }
+
+    /* now check the exclusions and remove any that match */
+    if (NULL != excvars) {
+        for (j=0; NULL != excvars[j]; j++) {
+            len = strlen(excvars[j]);
+            if ('*' == excvars[j][len-1]) {
+                --len;
+            }
+            PMIX_LIST_FOREACH_SAFE(kv, next, ilist, pmix_kval_t) {
+                if (0 == strncmp(kv->value->data.envar.envar, excvars[j], len)) {
+                    pmix_list_remove_item(ilist, &kv->super);
+                    PMIX_RELEASE(kv);
+                }
+            }
+        }
+    }
+    return PMIX_SUCCESS;
 }

--- a/src/mca/pnet/base/pnet_base_frame.c
+++ b/src/mca/pnet/base/pnet_base_frame.c
@@ -46,11 +46,13 @@
 /* Instantiate the global vars */
 pmix_pnet_globals_t pmix_pnet_globals = {{{0}}};
 pmix_pnet_API_module_t pmix_pnet = {
-    .setup_app = pmix_pnet_base_setup_app,
+    .allocate = pmix_pnet_base_allocate,
     .setup_local_network = pmix_pnet_base_setup_local_network,
     .setup_fork = pmix_pnet_base_setup_fork,
     .child_finalized = pmix_pnet_base_child_finalized,
-    .local_app_finalized = pmix_pnet_base_local_app_finalized
+    .local_app_finalized = pmix_pnet_base_local_app_finalized,
+    .deregister_nspace = pmix_pnet_base_deregister_nspace,
+    .collect_inventory = pmix_pnet_base_collect_inventory
 };
 
 static pmix_status_t pmix_pnet_close(void)

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
-# Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -29,6 +29,67 @@ AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
     PMIX_CHECK_PSM2([pnet_opa],
                     [pnet_opa_happy="yes"],
                     [pnet_opa_happy="no"])
+
+    AC_ARG_WITH([opamgt],
+        [AC_HELP_STRING([--with-opamgt(=DIR)],
+        [Build OmniPath Fabric Management support (optionally adding DIR/include, DIR/include/opamgt, DIR/lib, and DIR/lib64 to the search path for headers and libraries])])
+
+    AC_ARG_WITH([opamgt-libdir],
+                [AC_HELP_STRING([--with-opamgt-libdir=DIR],
+                                [Search for OmniPath Fabric Management libraries in DIR])])
+    PMIX_CHECK_WITHDIR([opamgt-libdir], [$with_opamgt_libdir], [libopamgt.*])
+
+    pmix_check_opamgt_save_CPPFLAGS="$CPPFLAGS"
+    pmix_check_opamgt_save_LDFLAGS="$LDFLAGS"
+    pmix_check_opamgt_save_LIBS="$LIBS"
+
+    pmix_check_opamgt_libdir=
+    pmix_check_opamgt_dir=
+
+    AS_IF([test "$with_opamgt" != "no"],
+          [AS_IF([test ! -z "$with_opamgt" && test "$with_opamgt" != "yes"],
+                 [pmix_check_opamgt_dir="$with_opamgt"
+                  AS_IF([test ! -d "$pmix_check_opamgt_dir" -o test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
+                         [$pmix_check_opamgt_dir=$pmix_check_opamgt_dir/include
+                          AS_IF([test ! -d "$pmix_check_opamgt_dir" -o test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
+                                [$pmix_check_opamgt_dir=$pmix_check_opamgt_dir/opamgt
+                                 AS_IF([test ! -d "$pmix_check_opamgt_dir" -o test ! -f "$pmix_check_opamgt_dir/opamgt.h"],
+                                       [AC_MSG_WARN([OmniPath Fabric Management support requested, but])
+                                        AC_MSG_WARN([required header file opamgt.h not found. Locations tested:])
+                                        AC_MSG_WARN([    $with_opamgt])
+                                        AC_MSG_WARN([    $with_opamgt/include])
+                                        AC_MSG_WARN([    $with_opamgt/include/opamgt])
+                                        AC_MSG_ERROR([Cannot continue])])])])],
+                 [pmix_check_opamgt_dir="/usr/include/opamgt"])
+
+           AS_IF([test ! -z "$with_opamgt_libdir" && test "$with_opamgt_libdir" != "yes"],
+                 [pmix_check_opamgt_libdir="$with_opamgt_libdir"])
+
+           PMIX_CHECK_PACKAGE([pnet_opamgt],
+                              [opamgt.h],
+                              [opamgt],
+                              [omgt_query_sa],
+                              [],
+                              [$pmix_check_opamgt_dir],
+                              [$pmix_check_opamgt_libdir],
+                              [pmix_check_opamgt_happy="yes"],
+                              [pmix_check_opamgt_happy="no"])],
+          [pmix_check_opamgt_happy="no"])
+
+    pnet_opa_CLFAGS="$pnet_opa_CFLAGS $pnet_opamgt_CFLAGS"
+    pnet_opa_CPPFLAGS="$pnet_opa_CPPFLAGS $pnet_opamgt_CPPFLAGS"
+    pnet_opa_LDFLAGS="$pnet_opa_LDFLAGS $pnet_opamgt_LDFLAGS"
+    pnet_opa_LIBS="$pnet_opa_LIBS $pnet_opamgt_LIBS"
+
+    AS_IF([test "$pmix_check_opamgt_happy" = "yes"],
+          [pmix_want_opamgt=1],
+          [pmix_want_opamgt=0])
+    AC_DEFINE_UNQUOTED([PMIX_WANT_OPAMGT], [$pmix_want_opamgt],
+                       [Whether or not to include OmniPath Fabric Manager support])
+
+    CPPFLAGS="$pmix_check_opamgt_save_CPPFLAGS"
+    LDFLAGS="$pmix_check_opamgt_save_LDFLAGS"
+    LIBS="$pmix_check_opamgt_save_LIBS"
 
     AS_IF([test "$pnet_opa_happy" = "yes"],
           [$1],

--- a/src/mca/pnet/tcp/Makefile.am
+++ b/src/mca/pnet/tcp/Makefile.am
@@ -1,0 +1,56 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(pnet_tcp_CPPFLAGS)
+
+headers = pnet_tcp.h
+sources = \
+        pnet_tcp_component.c \
+        pnet_tcp.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pnet_tcp_DSO
+lib =
+lib_sources =
+component = mca_pnet_tcp.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_pnet_tcp.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_pnet_tcp_la_SOURCES = $(component_sources)
+mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
+mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
+
+noinst_LTLIBRARIES = $(lib)
+libmca_pnet_tcp_la_SOURCES = $(lib_sources)
+libmca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
+libmca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -1,0 +1,879 @@
+/*
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include <pmix_common.h>
+
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/util/parse_options.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/pnet/base/base.h"
+#include "pnet_tcp.h"
+
+#define PMIX_TCP_SETUP_APP_KEY  "pmix.tcp.setup.app.key"
+
+static pmix_status_t tcp_init(void);
+static void tcp_finalize(void);
+static pmix_status_t allocate(pmix_nspace_t *nptr,
+                              pmix_info_t *info,
+                              pmix_list_t *ilist);
+static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+                                         pmix_info_t info[],
+                                         size_t ninfo);
+static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+                                const pmix_proc_t *peer, char ***env);
+static void child_finalized(pmix_peer_t *peer);
+static void local_app_finalized(pmix_nspace_t *nptr);
+static void deregister_nspace(pmix_nspace_t *nptr);
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_info_cbfunc_t cbfunc, void *cbdata);
+
+pmix_pnet_module_t pmix_tcp_module = {
+    .init = tcp_init,
+    .finalize = tcp_finalize,
+    .allocate = allocate,
+    .setup_local_network = setup_local_network,
+    .setup_fork = setup_fork,
+    .child_finalized = child_finalized,
+    .local_app_finalized = local_app_finalized,
+    .deregister_nspace = deregister_nspace,
+    .collect_inventory = collect_inventory
+};
+
+/* local tracker objects */
+typedef struct {
+    pmix_list_item_t super;
+    char *type;
+    char *plane;
+    char **ports;
+    size_t nports;
+} tcp_available_ports_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    char *nspace;
+    char **ports;
+    tcp_available_ports_t *src;  // source of the allocated ports
+} tcp_port_tracker_t;
+
+
+static pmix_list_t allocations, available;
+static pmix_status_t process_request(pmix_nspace_t *nptr,
+                                     char *idkey, int ports_per_node,
+                                     tcp_port_tracker_t *trk,
+                                     pmix_list_t *ilist);
+
+static void tacon(tcp_available_ports_t *p)
+{
+    p->type = NULL;
+    p->plane = NULL;
+    p->ports = NULL;
+    p->nports = 0;
+}
+static void tades(tcp_available_ports_t *p)
+{
+    if (NULL != p->type) {
+        free(p->type);
+    }
+    if (NULL != p->plane) {
+        free(p->plane);
+    }
+    if (NULL != p->ports) {
+        pmix_argv_free(p->ports);
+    }
+}
+static PMIX_CLASS_INSTANCE(tcp_available_ports_t,
+                           pmix_list_item_t,
+                           tacon, tades);
+
+static void ttcon(tcp_port_tracker_t *p)
+{
+    p->nspace = NULL;
+    p->ports = NULL;
+    p->src = NULL;
+}
+static void ttdes(tcp_port_tracker_t *p)
+{
+    size_t n, m, mstart;
+
+    if (NULL != p->nspace) {
+        free(p->nspace);
+    }
+    if (NULL != p->src) {
+        if (NULL != p->ports) {
+            mstart = 0;
+            for (n=0; NULL != p->ports[n]; n++) {
+                /* find an empty position */
+                for (m=mstart; m < p->src->nports; m++) {
+                    if (NULL == p->src->ports[m]) {
+                        p->src->ports[m] = strdup(p->ports[n]);
+                        mstart = m + 1;
+                        break;
+                    }
+                }
+            }
+            pmix_argv_free(p->ports);
+        }
+        PMIX_RELEASE(p->src);  // maintain accounting
+    } else if (NULL != p->ports) {
+        pmix_argv_free(p->ports);
+    }
+}
+static PMIX_CLASS_INSTANCE(tcp_port_tracker_t,
+                           pmix_list_item_t,
+                           ttcon, ttdes);
+
+static pmix_status_t tcp_init(void)
+{
+    tcp_available_ports_t *trk;
+    char *p, **grps;
+    size_t n;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet: tcp init");
+
+    /* if we are not the "gateway", then there is nothing
+     * for us to do */
+    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        return PMIX_SUCCESS;
+    }
+
+    PMIX_CONSTRUCT(&allocations, pmix_list_t);
+    PMIX_CONSTRUCT(&available, pmix_list_t);
+
+    /* if we have no static ports, then disqualify ourselves
+     * as there is nothing for us to manage
+     *
+     * NOTE: need to check inventory in addition to MCA param as
+     * the inventory may have reported back static ports */
+    if (NULL == mca_pnet_tcp_component.static_ports) {
+        return PMIX_ERR_NOT_AVAILABLE;
+    }
+
+    /* split on semi-colons */
+    grps = pmix_argv_split(mca_pnet_tcp_component.static_ports, ';');
+    for (n=0; NULL != grps[n]; n++) {
+        trk = PMIX_NEW(tcp_available_ports_t);
+        if (NULL == trk) {
+            pmix_argv_free(grps);
+            return PMIX_ERR_NOMEM;
+        }
+        /* there must be at least one colon */
+        if (NULL == (p = strrchr(grps[n], ':'))) {
+            pmix_argv_free(grps);
+            return PMIX_ERR_BAD_PARAM;
+        }
+        /* extract the ports */
+        *p = '\0';
+        ++p;
+        pmix_util_parse_range_options(p, &trk->ports);
+        trk->nports = pmix_argv_count(trk->ports);
+        /* see if they provided a plane */
+        if (NULL != (p = strchr(grps[n], ':'))) {
+            /* yep - save the plane */
+            *p = '\0';
+            ++p;
+            trk->plane = strdup(p);
+        }
+        /* the type is just what is left at the front */
+        trk->type = strdup(grps[n]);
+        pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                            "TYPE: %s PLANE %s", trk->type,
+                            (NULL == trk->plane) ? "NULL" : trk->plane);
+        pmix_list_append(&available, &trk->super);
+    }
+    pmix_argv_free(grps);
+
+    return PMIX_SUCCESS;
+}
+
+static void tcp_finalize(void)
+{
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet: tcp finalize");
+    if (PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        PMIX_LIST_DESTRUCT(&allocations);
+        PMIX_LIST_DESTRUCT(&available);
+    }
+}
+
+/* some network users may want to encrypt their communications
+ * as a means of securing them, or include a token in their
+ * messaging headers for some minimal level of security. This
+ * is far from perfect, but is provided to illustrate how it
+ * can be done. The resulting info is placed into the
+ * app_context's env array so it will automatically be pushed
+ * into the environment of every MPI process when launched.
+ *
+ * In a more perfect world, there would be some privileged place
+ * to store the crypto key and the encryption would occur
+ * in a non-visible driver - but we don't have a mechanism
+ * for doing so.
+ */
+
+static inline void generate_key(uint64_t* unique_key) {
+    pmix_rng_buff_t rng;
+    pmix_srand(&rng,(unsigned int)time(NULL));
+    unique_key[0] = pmix_rand(&rng);
+    unique_key[1] = pmix_rand(&rng);
+}
+
+/* when allocate is called, we look at our table of available static addresses
+ * and assign an address to each process on a node based on its node rank.
+ * This will prevent collisions as the host RM is responsible for correctly
+ * setting the node rank. Note that node ranks will "rollover" when they
+ * hit whatever maximum value the host RM supports, and that they will
+ * increase monotonically as new jobs are launched until hitting that
+ * max value. So we need to take into account the number of static
+ * ports we were given and check to ensure we have enough to hand out
+ *
+ * NOTE: this implementation is offered as an example that can
+ * undoubtedly be vastly improved/optimized */
+
+static pmix_status_t allocate(pmix_nspace_t *nptr,
+                              pmix_info_t *info,
+                              pmix_list_t *ilist)
+{
+    uint64_t unique_key[2];
+    size_t n, nreqs=0;
+    int ports_per_node=0;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    pmix_info_t *requests = NULL;
+    char **reqs, *cptr;
+    bool allocated = false, seckey = false;
+    tcp_port_tracker_t *trk;
+    tcp_available_ports_t *avail, *aptr;
+    pmix_list_t mylist;
+    pmix_buffer_t buf;
+    char *type = NULL, *plane = NULL, *idkey = NULL;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:tcp:allocate for nspace %s", nptr->nspace);
+
+    /* if I am not the gateway, then ignore this call - should never
+     * happen, but check to be safe */
+    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        return PMIX_SUCCESS;
+    }
+
+    /* check directives to see if a crypto key and/or
+     * network resource allocations requested */
+    PMIX_CONSTRUCT(&mylist, pmix_list_t);
+    if (0 == strncmp(info->key, PMIX_SETUP_APP_ENVARS, PMIX_MAX_KEYLEN) ||
+        0 == strncmp(info->key, PMIX_SETUP_APP_ALL, PMIX_MAX_KEYLEN)) {
+        if (NULL != mca_pnet_tcp_component.include) {
+            rc = pmix_pnet_base_harvest_envars(mca_pnet_tcp_component.include,
+                                               mca_pnet_tcp_component.exclude,
+                                               ilist);
+            return rc;
+        }
+        return PMIX_SUCCESS;
+    } else if (0 != strncmp(info->key, PMIX_ALLOC_NETWORK, PMIX_MAX_KEYLEN)) {
+        /* not a network allocation request */
+        return PMIX_SUCCESS;
+    }
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:tcp:allocate alloc_network for nspace %s",
+                        nptr->nspace);
+    /* this info key includes an array of pmix_info_t, each providing
+     * a key (that is to be used as the key for the allocated ports) and
+     * a number of ports to allocate for that key */
+    if (PMIX_DATA_ARRAY != info->value.type ||
+        NULL == info->value.data.darray ||
+        PMIX_INFO != info->value.data.darray->type ||
+        NULL == info->value.data.darray->array) {
+        /* they made an error */
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    requests = (pmix_info_t*)info->value.data.darray->array;
+    nreqs = info->value.data.darray->size;
+    /* cycle thru the provided array and see if this refers to
+     * tcp/udp-based resources - there is no required ordering
+     * of the keys, so just have to do a search */
+    for (n=0; n < nreqs; n++) {
+        if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_NETWORK_TYPE, PMIX_MAX_KEYLEN)) {
+            /* check for bozo error */
+            if (PMIX_STRING != requests[n].value.type ||
+                NULL == requests[n].value.data.string) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            type = requests[n].value.data.string;
+        } else if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_NETWORK_PLANE, PMIX_MAX_KEYLEN)) {
+            /* check for bozo error */
+            if (PMIX_STRING != requests[n].value.type ||
+                NULL == requests[n].value.data.string) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            plane = requests[n].value.data.string;
+        } else if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_NETWORK_ENDPTS, PMIX_MAX_KEYLEN)) {
+            PMIX_VALUE_GET_NUMBER(rc, &requests[n].value, ports_per_node, int);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+        } else if (0 == strncmp(requests[n].key, PMIX_ALLOC_NETWORK_ID, PMIX_MAX_KEYLEN)) {
+            /* check for bozo error */
+            if (PMIX_STRING != requests[n].value.type ||
+                NULL == requests[n].value.data.string) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            idkey = requests[n].value.data.string;
+        } else if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_NETWORK_SEC_KEY, PMIX_MAX_KEYLEN)) {
+            seckey = PMIX_INFO_TRUE(&requests[n]);
+        }
+    }
+
+    /* we at least require an attribute key for the response */
+    if (NULL == idkey) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* must include the idkey */
+    kv = PMIX_NEW(pmix_kval_t);
+    if (NULL == kv) {
+        return PMIX_ERR_NOMEM;
+    }
+    kv->key = strdup(PMIX_ALLOC_NETWORK_ID);
+    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    if (NULL == kv->value) {
+        PMIX_RELEASE(kv);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_STRING;
+    kv->value->data.string = strdup(idkey);
+    pmix_list_append(&mylist, &kv->super);
+
+    /* note that they might not provide
+     * the network type (letting it fall to a default component
+     * based on priority), and they are not required to provide
+     * a plane. In addition, they are allowed to simply request
+     * a network security key without asking for endpts */
+
+    if (NULL != type) {
+        /* if it is tcp or udp, then this is something we should process */
+        if (0 == strcasecmp(type, "tcp")) {
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:tcp:allocate allocating TCP ports for nspace %s",
+                                nptr->nspace);
+            /* do we have static tcp ports? */
+            avail = NULL;
+            PMIX_LIST_FOREACH(aptr, &available, tcp_available_ports_t) {
+                if (0 == strcmp(aptr->type, "tcp")) {
+                    /* if they specified a plane, then require it */
+                    if (NULL != plane && (NULL == aptr->plane || 0 != strcmp(aptr->plane, plane))) {
+                        continue;
+                    }
+                    avail = aptr;
+                    break;
+                }
+            }
+            /* nope - they asked for something that we cannot do */
+            if (NULL == avail) {
+                return PMIX_ERR_NOT_AVAILABLE;
+            }
+            /* setup to track the assignment */
+            trk = PMIX_NEW(tcp_port_tracker_t);
+            if (NULL == trk) {
+                return PMIX_ERR_NOMEM;
+            }
+            trk->nspace = strdup(nptr->nspace);
+            PMIX_RETAIN(avail);
+            trk->src = avail;
+            pmix_list_append(&allocations, &trk->super);
+            rc = process_request(nptr, idkey, ports_per_node, trk, &mylist);
+            if (PMIX_SUCCESS != rc) {
+                /* return the allocated ports */
+                pmix_list_remove_item(&allocations, &trk->super);
+                PMIX_RELEASE(trk);
+                return rc;
+            }
+            allocated = true;
+
+        } else if (0 == strcasecmp(requests[n].value.data.string, "udp")) {
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:tcp:allocate allocating UDP ports for nspace %s",
+                                nptr->nspace);
+            /* do we have static udp ports? */
+            avail = NULL;
+            PMIX_LIST_FOREACH(aptr, &available, tcp_available_ports_t) {
+                if (0 == strcmp(aptr->type, "udp")) {
+                    /* if they specified a plane, then require it */
+                    if (NULL != plane && (NULL == aptr->plane || 0 != strcmp(aptr->plane, plane))) {
+                        continue;
+                    }
+                    avail = aptr;
+                    break;
+                }
+            }
+            /* nope - they asked for something that we cannot do */
+            if (NULL == avail) {
+                return PMIX_ERR_NOT_AVAILABLE;
+            }
+            /* setup to track the assignment */
+            trk = PMIX_NEW(tcp_port_tracker_t);
+            if (NULL == trk) {
+                return PMIX_ERR_NOMEM;
+            }
+            trk->nspace = strdup(nptr->nspace);
+            PMIX_RETAIN(avail);
+            trk->src = avail;
+            pmix_list_append(&allocations, &trk->super);
+            rc = process_request(nptr, idkey, ports_per_node, trk, &mylist);
+            if (PMIX_SUCCESS != rc) {
+                /* return the allocated ports */
+                pmix_list_remove_item(&allocations, &trk->super);
+                PMIX_RELEASE(trk);
+                return rc;
+            }
+            allocated = true;
+        } else {
+            /* unsupported type */
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:tcp:allocate unsupported type %s for nspace %s",
+                                type, nptr->nspace);
+            return PMIX_ERR_TAKE_NEXT_OPTION;
+        }
+
+    } else {
+        if (NULL != plane) {
+            /* if they didn't specify a type, but they did specify a plane, we can
+             * see if that is a plane we recognize */
+            PMIX_LIST_FOREACH(aptr, &available, tcp_available_ports_t) {
+                if (0 != strcmp(aptr->plane, plane)) {
+                    continue;
+                }
+                /* setup to track the assignment */
+                trk = PMIX_NEW(tcp_port_tracker_t);
+                if (NULL == trk) {
+                    return PMIX_ERR_NOMEM;
+                }
+                trk->nspace = strdup(nptr->nspace);
+                PMIX_RETAIN(aptr);
+                trk->src = aptr;
+                pmix_list_append(&allocations, &trk->super);
+                rc = process_request(nptr, idkey, ports_per_node, trk, &mylist);
+                if (PMIX_SUCCESS != rc) {
+                    /* return the allocated ports */
+                    pmix_list_remove_item(&allocations, &trk->super);
+                    PMIX_RELEASE(trk);
+                    return rc;
+                }
+                allocated = true;
+                break;
+            }
+        } else {
+            /* if they didn't specify either type or plane, then we got here because
+             * nobody of a higher priority could act as a default transport - so try
+             * to provide something here, starting by looking at any provided setting */
+            if (NULL != mca_pnet_tcp_component.default_request) {
+                pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                    "pnet:tcp:allocate allocating default ports %s for nspace %s",
+                                    mca_pnet_tcp_component.default_request, nptr->nspace);
+                reqs = pmix_argv_split(mca_pnet_tcp_component.default_request, ';');
+                for (n=0; NULL != reqs[n]; n++) {
+                    /* if there is no colon, then it is just
+                     * a number of ports to use */
+                    type = NULL;
+                    plane = NULL;
+                    if (NULL == (cptr = strrchr(reqs[n], ':'))) {
+                        avail = (tcp_available_ports_t*)pmix_list_get_first(&available);
+                    } else {
+                        *cptr = '\0';
+                        ++cptr;
+                        ports_per_node = strtoul(cptr, NULL, 10);
+                        /* look for the plane */
+                        cptr -= 2;
+                        if (NULL != (cptr = strrchr(cptr, ':'))) {
+                            *cptr = '\0';
+                            ++cptr;
+                            plane = cptr;
+                        }
+                        type = reqs[n];
+                        avail = NULL;
+                        PMIX_LIST_FOREACH(aptr, &available, tcp_available_ports_t) {
+                            if (0 == strcmp(aptr->type, type)) {
+                                /* if they specified a plane, then require it */
+                                if (NULL != plane && (NULL == aptr->plane || 0 != strcmp(aptr->plane, plane))) {
+                                    continue;
+                                }
+                                avail = aptr;
+                                break;
+                            }
+                        }
+                        /* if we didn't find it, that isn't an error - just ignore */
+                        if (NULL == avail) {
+                            continue;
+                        }
+                        /* setup to track the assignment */
+                        trk = PMIX_NEW(tcp_port_tracker_t);
+                        if (NULL == trk) {
+                            pmix_argv_free(reqs);
+                            return PMIX_ERR_NOMEM;
+                        }
+                        trk->nspace = strdup(nptr->nspace);
+                        PMIX_RETAIN(avail);
+                        trk->src = avail;
+                        pmix_list_append(&allocations, &trk->super);
+                        rc = process_request(nptr, idkey, ports_per_node, trk, &mylist);
+                        if (PMIX_SUCCESS != rc) {
+                            /* return the allocated ports */
+                            pmix_list_remove_item(&allocations, &trk->super);
+                            PMIX_RELEASE(trk);
+                            return rc;
+                        }
+                        allocated = true;
+                    }
+                }
+            } else {
+                avail = (tcp_available_ports_t*)pmix_list_get_first(&available);
+                if (NULL != avail) {
+                    /* setup to track the assignment */
+                    trk = PMIX_NEW(tcp_port_tracker_t);
+                    if (NULL == trk) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    trk->nspace = strdup(nptr->nspace);
+                    PMIX_RETAIN(avail);
+                    trk->src = avail;
+                    pmix_list_append(&allocations, &trk->super);
+                    rc = process_request(nptr, idkey, ports_per_node, trk, &mylist);
+                    if (PMIX_SUCCESS != rc) {
+                        /* return the allocated ports */
+                        pmix_list_remove_item(&allocations, &trk->super);
+                        PMIX_RELEASE(trk);
+                    } else {
+                        allocated = true;
+                    }
+                }
+            }
+        }
+        if (!allocated) {
+            /* nope - we cannot help */
+            return PMIX_ERR_TAKE_NEXT_OPTION;
+        }
+    }
+
+    if (seckey) {
+        generate_key(unique_key);
+        kv = PMIX_NEW(pmix_kval_t);
+        if (NULL == kv) {
+            return PMIX_ERR_NOMEM;
+        }
+        kv->key = strdup(PMIX_ALLOC_NETWORK_SEC_KEY);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        kv->value->type = PMIX_BYTE_OBJECT;
+        kv->value->data.bo.bytes = (char*)malloc(2 * sizeof(uint64_t));
+        if (NULL == kv->value->data.bo.bytes) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        memcpy(kv->value->data.bo.bytes, unique_key, 2 * sizeof(uint64_t));
+        kv->value->data.bo.size = 2 * sizeof(uint64_t);
+        pmix_list_append(&mylist, &kv->super);
+    }
+
+
+    n = pmix_list_get_size(&mylist);
+    if (0 < n) {
+        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+        /* pack the number of kvals for ease on the remote end */
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &n, 1, PMIX_SIZE);
+        /* cycle across the list and pack the kvals */
+        while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&mylist))) {
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv, 1, PMIX_KVAL);
+            PMIX_RELEASE(kv);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DESTRUCT(&buf);
+                PMIX_LIST_DESTRUCT(&mylist);
+                return rc;
+            }
+        }
+        PMIX_LIST_DESTRUCT(&mylist);
+        kv = PMIX_NEW(pmix_kval_t);
+        kv->key = strdup(PMIX_TCP_SETUP_APP_KEY);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            PMIX_DESTRUCT(&buf);
+            return PMIX_ERR_NOMEM;
+        }
+        kv->value->type = PMIX_BYTE_OBJECT;
+        PMIX_UNLOAD_BUFFER(&buf, kv->value->data.bo.bytes, kv->value->data.bo.size);
+        PMIX_DESTRUCT(&buf);
+        pmix_list_append(ilist, &kv->super);
+    }
+
+    /* if we got here, then we processed this specific request, so
+     * indicate that by returning success */
+    return PMIX_SUCCESS;
+}
+
+/* upon receipt of the launch message, each daemon adds the
+ * static address assignments to the job-level info cache
+ * for that job */
+static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+                                         pmix_info_t info[],
+                                         size_t ninfo)
+{
+    size_t n, m, nkvals;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    pmix_info_t *jinfo, stinfo;
+    char *idkey = NULL;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:tcp:setup_local_network");
+
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            /* look for my key */
+            if (0 == strncmp(info[n].key, PMIX_TCP_SETUP_APP_KEY, PMIX_MAX_KEYLEN)) {
+                /* this macro NULLs and zero's the incoming bo */
+                PMIX_LOAD_BUFFER(pmix_globals.mypeer, &bkt,
+                                 info[n].value.data.bo.bytes,
+                                 info[n].value.data.bo.size);
+                /* unpack the number of kvals */
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                   &bkt, &nkvals, &cnt, PMIX_SIZE);
+                /* setup the info array */
+                PMIX_INFO_CREATE(jinfo, nkvals);
+                /* cycle thru the blob and extract the kvals */
+                kv = PMIX_NEW(pmix_kval_t);
+                cnt = 1;
+                PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                   &bkt, kv, &cnt, PMIX_KVAL);
+                m = 0;
+                while (PMIX_SUCCESS == rc) {
+                    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                        "recvd KEY %s %s", kv->key,
+                                        (PMIX_STRING == kv->value->type) ? kv->value->data.string : "NON-STRING");
+                    /* xfer the value to the info */
+                    (void)strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
+                    PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
+                                           &jinfo[m].value, kv->value);
+                    /* if this is the ID key, save it */
+                    if (0 == strncmp(kv->key, PMIX_ALLOC_NETWORK_ID, PMIX_MAX_KEYLEN)) {
+                        idkey = strdup(kv->value->data.string);
+                    }
+                    ++m;
+                    PMIX_RELEASE(kv);
+                    kv = PMIX_NEW(pmix_kval_t);
+                    cnt = 1;
+                    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                       &bkt, kv, &cnt, PMIX_KVAL);
+                }
+                /* restore the incoming data */
+                info[n].value.data.bo.bytes = bkt.base_ptr;
+                info[n].value.data.bo.size = bkt.bytes_used;
+                bkt.base_ptr = NULL;
+                bkt.bytes_used = 0;
+
+                /* if they didn't include a network ID, then this is an error */
+                if (NULL == idkey) {
+                    PMIX_INFO_FREE(jinfo, nkvals);
+                    return PMIX_ERR_BAD_PARAM;
+                }
+                /* the data gets stored as a pmix_data_array_t on the provided key */
+                PMIX_INFO_CONSTRUCT(&stinfo);
+                (void)strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
+                stinfo.value.type = PMIX_DATA_ARRAY;
+                PMIX_DATA_ARRAY_CREATE(stinfo.value.data.darray, nkvals, PMIX_INFO);
+                stinfo.value.data.darray->array = jinfo;
+
+                /* cache the info on the job */
+                PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr,
+                                        &stinfo, 1);
+                PMIX_INFO_DESTRUCT(&stinfo);
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+                                const pmix_proc_t *peer, char ***env)
+{
+    return PMIX_SUCCESS;
+}
+
+/* when a local client finalizes, the server gives us a chance
+ * to do any required local cleanup for that peer. We don't
+ * have anything we need to do */
+static void child_finalized(pmix_peer_t *peer)
+{
+
+}
+
+/* when all local clients for a given job finalize, the server
+ * provides an opportunity for the local network to cleanup
+ * any resources consumed locally by the clients of that job.
+ * We don't have anything we need to do */
+static void local_app_finalized(pmix_nspace_t *nptr)
+{
+
+}
+
+/* when the job completes, the scheduler calls the "deregister nspace"
+ * PMix function, which in turn calls my TCP component to release the
+ * assignments for that job. The addresses are marked as "available"
+ * for reuse on the next job. */
+static void deregister_nspace(pmix_nspace_t *nptr)
+{
+    tcp_port_tracker_t *trk;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:tcp deregister nspace %s", nptr->nspace);
+
+    /* if we are not the "gateway", then there is nothing
+     * for us to do */
+    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        return;
+    }
+
+    /* find this tracker */
+    PMIX_LIST_FOREACH(trk, &allocations, tcp_port_tracker_t) {
+        if (0 == strcmp(nptr->nspace, trk->nspace)) {
+            pmix_list_remove_item(&allocations, &trk->super);
+            PMIX_RELEASE(trk);
+            pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                "pnet:tcp released tracker for nspace %s", nptr->nspace);
+            return;
+        }
+    }
+}
+
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+static pmix_status_t process_request(pmix_nspace_t *nptr,
+                                     char *idkey, int ports_per_node,
+                                     tcp_port_tracker_t *trk,
+                                     pmix_list_t *ilist)
+{
+    char **plist;
+    pmix_kval_t *kv;
+    size_t m;
+    int p, ppn;
+    tcp_available_ports_t *avail = trk->src;
+
+    kv = PMIX_NEW(pmix_kval_t);
+    if (NULL == kv) {
+        return PMIX_ERR_NOMEM;
+    }
+    kv->key = strdup(idkey);
+    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    if (NULL == kv->value) {
+        PMIX_RELEASE(kv);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_STRING;
+    kv->value->data.string = NULL;
+    if (0 == ports_per_node) {
+        /* find the maxprocs on the nodes in this nspace and
+         * allocate that number of resources */
+        return PMIX_ERR_NOT_SUPPORTED;
+    } else {
+        ppn = ports_per_node;
+    }
+
+    /* assemble the list of ports */
+    p = 0;
+    plist = NULL;
+    for (m=0; p < ppn && m < avail->nports; m++) {
+        if (NULL != avail->ports[m]) {
+            pmix_argv_append_nosize(&trk->ports, avail->ports[m]);
+            pmix_argv_append_nosize(&plist, avail->ports[m]);
+            free(avail->ports[m]);
+            avail->ports[m] = NULL;
+            ++p;
+        }
+    }
+    /* if we couldn't find enough, then that's an error */
+    if (p < ppn) {
+        PMIX_RELEASE(kv);
+        /* the caller will release trk, and that will return
+         * any allocated ports back to the available list */
+        return PMIX_ERR_OUT_OF_RESOURCE;
+    }
+    /* pass the value */
+    kv->value->data.string = pmix_argv_join(plist, ',');
+    pmix_argv_free(plist);
+    pmix_list_append(ilist, &kv->super);
+
+    /* track where it came from */
+    kv = PMIX_NEW(pmix_kval_t);
+    if (NULL == kv) {
+        return PMIX_ERR_NOMEM;
+    }
+    kv->key = strdup(idkey);
+    kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+    if (NULL == kv->value) {
+        PMIX_RELEASE(kv);
+        return PMIX_ERR_NOMEM;
+    }
+    kv->value->type = PMIX_STRING;
+    kv->value->data.string = strdup(trk->src->type);
+    pmix_list_append(ilist, &kv->super);
+    if (NULL != trk->src->plane) {
+        kv = PMIX_NEW(pmix_kval_t);
+        if (NULL == kv) {
+            return PMIX_ERR_NOMEM;
+        }
+        kv->key = strdup(idkey);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        kv->value->type = PMIX_STRING;
+        kv->value->data.string = strdup(trk->src->plane);
+        pmix_list_append(ilist, &kv->super);
+    }
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/tcp/pnet_tcp.h
+++ b/src/mca/pnet/tcp/pnet_tcp.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PNET_OPA_H
+#define PMIX_PNET_OPA_H
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/mca/pnet/pnet.h"
+
+BEGIN_C_DECLS
+
+typedef struct {
+    pmix_pnet_base_component_t super;
+    char *static_ports;
+    char *default_request;
+    char **include;
+    char **exclude;
+} pmix_pnet_tcp_component_t;
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pnet_tcp_component_t mca_pnet_tcp_component;
+extern pmix_pnet_module_t pmix_tcp_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pnet/tcp/pnet_tcp_component.c
+++ b/src/mca/pnet/tcp/pnet_tcp_component.c
@@ -1,0 +1,133 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include <src/include/pmix_config.h>
+#include "pmix_common.h"
+
+#include "src/util/argv.h"
+#include "src/mca/pnet/pnet.h"
+#include "pnet_tcp.h"
+
+static pmix_status_t component_register(void);
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pnet_tcp_component_t mca_pnet_tcp_component = {
+    .super = {
+        .base = {
+            PMIX_PNET_BASE_VERSION_1_0_0,
+
+            /* Component name and version */
+            .pmix_mca_component_name = "tcp",
+            PMIX_MCA_BASE_MAKE_VERSION(component,
+                                       PMIX_MAJOR_VERSION,
+                                       PMIX_MINOR_VERSION,
+                                       PMIX_RELEASE_VERSION),
+
+            /* Component open and close functions */
+            .pmix_mca_register_component_params = component_register,
+            .pmix_mca_open_component = component_open,
+            .pmix_mca_close_component = component_close,
+            .pmix_mca_query_component = component_query,
+        },
+        .data = {
+            /* The component is checkpoint ready */
+            PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+        }
+    },
+    .static_ports = NULL,
+    .default_request = NULL,
+    .include = NULL,
+    .exclude = NULL
+};
+
+static char *includeparam;
+static char *excludeparam;
+
+static pmix_status_t component_register(void)
+{
+    pmix_mca_base_component_t *component = &mca_pnet_tcp_component.super.base;
+
+    mca_pnet_tcp_component.static_ports = NULL;
+    (void)pmix_mca_base_component_var_register(component, "static_ports",
+                                               "Static ports for procs, expressed as a semi-colon delimited "
+                                               "list of type:(optional)plane:Comma-delimited list of ranges (e.g., "
+                                               "\"tcp:10.10.10.0/24:32000-32100,33000;udp:40000,40005\")",
+                                               PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                               PMIX_INFO_LVL_2,
+                                               PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                               &mca_pnet_tcp_component.static_ports);
+
+    (void)pmix_mca_base_component_var_register(component, "default_network_allocation",
+                                               "Semi-colon delimited list of (optional)type:(optional)plane:Comma-delimited list of ranges  "
+                                               "(e.g., \"udp:10.10.10.0/24:3\", or \"5\" if the choice of "
+                                               "type and plane isn't critical)",
+                                               PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                               PMIX_INFO_LVL_2,
+                                               PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                               &mca_pnet_tcp_component.default_request);
+
+    includeparam = NULL;
+    (void)pmix_mca_base_component_var_register(component, "include_envars",
+                                               "Comma-delimited list of envars to harvest (\'*\' and \'?\' supported)",
+                                               PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                               PMIX_INFO_LVL_2,
+                                               PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
+                                               &includeparam);
+    if (NULL != includeparam) {
+        mca_pnet_tcp_component.include = pmix_argv_split(includeparam, ',');
+    }
+
+    excludeparam = NULL;
+    (void)pmix_mca_base_component_var_register(component, "exclude_envars",
+                                               "Comma-delimited list of envars to exclude (\'*\' and \'?\' supported)",
+                                               PMIX_MCA_BASE_VAR_TYPE_STRING, NULL, 0, 0,
+                                               PMIX_INFO_LVL_2,
+                                               PMIX_MCA_BASE_VAR_SCOPE_LOCAL,
+                                               &excludeparam);
+    if (NULL != excludeparam) {
+        mca_pnet_tcp_component.exclude = pmix_argv_split(excludeparam, ',');
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module,
+                                     int *priority)
+{
+    *priority = 5;
+    *module = (pmix_mca_base_module_t *)&pmix_tcp_module;
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t component_close(void)
+{
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -46,9 +46,9 @@
 
 static pmix_status_t test_init(void);
 static void test_finalize(void);
-static pmix_status_t setup_app(pmix_nspace_t *nptr,
-                               pmix_info_t info[], size_t ninfo,
-                               pmix_list_t *ilist);
+static pmix_status_t allocate(pmix_nspace_t *nptr,
+                              pmix_info_t *info,
+                              pmix_list_t *ilist);
 static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo);
@@ -56,16 +56,21 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env);
 static void child_finalized(pmix_peer_t *peer);
-static void local_app_finalized(char *nspace);
+static void local_app_finalized(pmix_nspace_t *nptr);
+static void deregister_nspace(pmix_nspace_t *nptr);
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 pmix_pnet_module_t pmix_test_module = {
     .init = test_init,
     .finalize = test_finalize,
-    .setup_app = setup_app,
+    .allocate = allocate,
     .setup_local_network = setup_local_network,
     .setup_fork = setup_fork,
     .child_finalized = child_finalized,
-    .local_app_finalized = local_app_finalized
+    .local_app_finalized = local_app_finalized,
+    .deregister_nspace = deregister_nspace,
+    .collect_inventory = collect_inventory
 };
 
 static pmix_status_t test_init(void)
@@ -84,49 +89,34 @@ static void test_finalize(void)
 /* NOTE: if there is any binary data to be transferred, then
  * this function MUST pack it for transport as the host will
  * not know how to do so */
-static pmix_status_t setup_app(pmix_nspace_t *nptr,
-                               pmix_info_t info[], size_t ninfo,
-                               pmix_list_t *ilist)
+static pmix_status_t allocate(pmix_nspace_t *nptr,
+                              pmix_info_t *info,
+                              pmix_list_t *ilist)
 {
     pmix_kval_t *kv;
-    bool envars, seckeys;
-    size_t n;
+    bool seckey;
+    pmix_list_t mylist;
+    size_t n, nreqs=0;
+    pmix_info_t *requests = NULL;
+    char *idkey = NULL;
+    uint64_t unique_key = 12345;
+    pmix_buffer_t buf;
+    pmix_status_t rc;
 
-    if (NULL == info) {
-        envars = true;
-        seckeys = true;
-    } else {
-        envars = false;
-        seckeys = false;
-        for (n=0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_SETUP_APP_ENVARS, PMIX_MAX_KEYLEN)) {
-                envars = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_SETUP_APP_ALL, PMIX_MAX_KEYLEN)) {
-                envars = PMIX_INFO_TRUE(&info[n]);
-                seckeys = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_SETUP_APP_NONENVARS, PMIX_MAX_KEYLEN)) {
-                seckeys = PMIX_INFO_TRUE(&info[n]);
-            }
-        }
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:test:allocate for nspace %s", nptr->nspace);
+
+    /* if I am not the gateway, then ignore this call - should never
+     * happen, but check to be safe */
+    if (!PMIX_PROC_IS_GATEWAY(pmix_globals.mypeer)) {
+        return PMIX_SUCCESS;
     }
 
-    if (seckeys) {
-        kv = PMIX_NEW(pmix_kval_t);
-        if (NULL == kv) {
-            return PMIX_ERR_NOMEM;
-        }
-        kv->key = strdup(PMIX_SET_ENVAR);
-        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-        if (NULL == kv->value) {
-            PMIX_RELEASE(kv);
-            return PMIX_ERR_NOMEM;
-        }
-        kv->value->type = PMIX_ENVAR;
-        PMIX_ENVAR_LOAD(&kv->value->data.envar, "PMIX_TEST_SECKEY", "1", ':');
-        pmix_list_append(ilist, &kv->super);
-    }
-
-    if (envars) {
+    /* check directives to see if a crypto key and/or
+     * network resource allocations requested */
+    PMIX_CONSTRUCT(&mylist, pmix_list_t);
+    if (0 == strncmp(info->key, PMIX_SETUP_APP_ENVARS, PMIX_MAX_KEYLEN) ||
+        0 == strncmp(info->key, PMIX_SETUP_APP_ALL, PMIX_MAX_KEYLEN)) {
         kv = PMIX_NEW(pmix_kval_t);
         if (NULL == kv) {
             return PMIX_ERR_NOMEM;
@@ -140,23 +130,115 @@ static pmix_status_t setup_app(pmix_nspace_t *nptr,
         kv->value->type = PMIX_ENVAR;
         PMIX_ENVAR_LOAD(&kv->value->data.envar, "PMIX_TEST_ENVAR", "1", ':');
         pmix_list_append(ilist, &kv->super);
+        return PMIX_SUCCESS;
+    } else if (0 != strncmp(info->key, PMIX_ALLOC_NETWORK, PMIX_MAX_KEYLEN)) {
+        /* not a network allocation request */
+        return PMIX_SUCCESS;
     }
 
-    /* provide a blob so setup_local_network will get called */
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:test:allocate alloc_network for nspace %s",
+                        nptr->nspace);
+
+    /* this info key includes an array of pmix_info_t, each providing
+     * a key (that is to be used as the key for the allocated ports) and
+     * a number of ports to allocate for that key */
+    if (PMIX_DATA_ARRAY != info->value.type ||
+        NULL == info->value.data.darray ||
+        PMIX_INFO != info->value.data.darray->type ||
+        NULL == info->value.data.darray->array) {
+        /* they made an error */
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    requests = (pmix_info_t*)info->value.data.darray->array;
+    nreqs = info->value.data.darray->size;
+    /* cycle thru the provided array and get the ID key */
+    for (n=0; n < nreqs; n++) {
+        if (0 == strncmp(requests[n].key, PMIX_ALLOC_NETWORK_ID, PMIX_MAX_KEYLEN)) {
+            /* check for bozo error */
+            if (PMIX_STRING != requests[n].value.type ||
+                NULL == requests[n].value.data.string) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            idkey = requests[n].value.data.string;
+        } else if (0 == strncasecmp(requests[n].key, PMIX_ALLOC_NETWORK_SEC_KEY, PMIX_MAX_KEYLEN)) {
+               seckey = PMIX_INFO_TRUE(&requests[n]);
+           }
+       }
+
+    /* we at least require an attribute key for the response */
+    if (NULL == idkey) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* must include the idkey */
     kv = PMIX_NEW(pmix_kval_t);
     if (NULL == kv) {
         return PMIX_ERR_NOMEM;
     }
-    kv->key = strdup("pmix-pnet-test-blob");
+    kv->key = strdup(PMIX_ALLOC_NETWORK_ID);
     kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
     if (NULL == kv->value) {
         PMIX_RELEASE(kv);
         return PMIX_ERR_NOMEM;
     }
     kv->value->type = PMIX_STRING;
-    kv->value->data.string = strdup("foobar");
-    pmix_list_append(ilist, &kv->super);
+    kv->value->data.string = strdup(idkey);
+    pmix_list_append(&mylist, &kv->super);
 
+    if (seckey) {
+        kv = PMIX_NEW(pmix_kval_t);
+        if (NULL == kv) {
+            return PMIX_ERR_NOMEM;
+        }
+        kv->key = strdup(PMIX_ALLOC_NETWORK_SEC_KEY);
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        kv->value->type = PMIX_BYTE_OBJECT;
+        kv->value->data.bo.bytes = (char*)malloc(sizeof(uint64_t));
+        if (NULL == kv->value->data.bo.bytes) {
+            PMIX_RELEASE(kv);
+            return PMIX_ERR_NOMEM;
+        }
+        memcpy(kv->value->data.bo.bytes, &unique_key, sizeof(uint64_t));
+        kv->value->data.bo.size = sizeof(uint64_t);
+        pmix_list_append(&mylist, &kv->super);
+    }
+
+    n = pmix_list_get_size(&mylist);
+    if (0 < n) {
+        PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+        /* pack the number of kvals for ease on the remote end */
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &n, 1, PMIX_SIZE);
+        /* cycle across the list and pack the kvals */
+        while (NULL != (kv = (pmix_kval_t*)pmix_list_remove_first(&mylist))) {
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, kv, 1, PMIX_KVAL);
+            PMIX_RELEASE(kv);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DESTRUCT(&buf);
+                PMIX_LIST_DESTRUCT(&mylist);
+                return rc;
+            }
+        }
+        PMIX_LIST_DESTRUCT(&mylist);
+        kv = PMIX_NEW(pmix_kval_t);
+        kv->key = strdup("pmix-pnet-test-blob");
+        kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+        if (NULL == kv->value) {
+            PMIX_RELEASE(kv);
+            PMIX_DESTRUCT(&buf);
+            return PMIX_ERR_NOMEM;
+        }
+        kv->value->type = PMIX_BYTE_OBJECT;
+        PMIX_UNLOAD_BUFFER(&buf, kv->value->data.bo.bytes, kv->value->data.bo.size);
+        PMIX_DESTRUCT(&buf);
+        pmix_list_append(ilist, &kv->super);
+    }
 
     return PMIX_SUCCESS;
 }
@@ -165,39 +247,113 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo)
 {
-    size_t n, m;
+    size_t n, m, nkvals;
     char *nodestring, **nodes;
     pmix_proc_t *procs;
     size_t nprocs;
+    pmix_buffer_t bkt;
+    int32_t cnt;
+    pmix_kval_t *kv;
+    pmix_status_t rc;
+    pmix_info_t *jinfo, stinfo;
+    char *idkey = NULL;
+
+    pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                        "pnet:test:setup_local_network");
 
     /* get the list of nodes in this job - returns a regex */
-    pmix_output(0, "pnet:setup_local_network NSPACE %s", (NULL == nptr) ? "NULL" : nptr->nspace);
+    pmix_output(0, "pnet:test setup_local_network NSPACE %s", (NULL == nptr) ? "NULL" : nptr->nspace);
     pmix_preg.resolve_nodes(nptr->nspace, &nodestring);
     if (NULL == nodestring) {
         return PMIX_SUCCESS;
     }
     pmix_preg.parse_nodes(nodestring, &nodes);  // get an argv array of node names
-    pmix_output(0, "pnet:setup_local_network NODES %s", (NULL == nodes) ? "NULL" : "NON-NULL");
+    pmix_output(0, "pnet:test setup_local_network NODES %s", (NULL == nodes) ? "NULL" : "NON-NULL");
     if (NULL == nodes) {
         free(nodestring);
         return PMIX_SUCCESS;
     }
     for (n=0; NULL != nodes[n]; n++) {
-        pmix_output(0, "pnet:setup_local_network NODE: %s", nodes[n]);
+        pmix_output(0, "pnet:test setup_local_network NODE: %s", nodes[n]);
     }
 
-   for (n=0; NULL != nodes[n]; n++) {
+    for (n=0; NULL != nodes[n]; n++) {
     /* get an array of pmix_proc_t containing the names of the procs on that node */
-          pmix_preg.resolve_peers(nodes[n], nptr->nspace, &procs, &nprocs);
-          if (NULL == procs) {
-            continue;
-          }
-          for (m=0; m < nprocs; m++) {
-            pmix_output(0, "pnet:setup_local_network NODE %s: peer %s:%d", nodes[n], procs[m].nspace, procs[m].rank);
-          }
-          /* do stuff */
-          free(procs);
-   }
+      pmix_preg.resolve_peers(nodes[n], nptr->nspace, &procs, &nprocs);
+      if (NULL == procs) {
+        continue;
+    }
+    for (m=0; m < nprocs; m++) {
+        pmix_output(0, "pnet:test setup_local_network NODE %s: peer %s:%d", nodes[n], procs[m].nspace, procs[m].rank);
+    }
+        /* do stuff */
+        free(procs);
+    }
+
+    if (NULL != info) {
+       for (n=0; n < ninfo; n++) {
+               /* look for my key */
+           if (0 == strncmp(info[n].key, "pmix-pnet-test-blob", PMIX_MAX_KEYLEN)) {
+                   /* this macro NULLs and zero's the incoming bo */
+               PMIX_LOAD_BUFFER(pmix_globals.mypeer, &bkt,
+                                info[n].value.data.bo.bytes,
+                                info[n].value.data.bo.size);
+                   /* unpack the number of kvals */
+               cnt = 1;
+               PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                  &bkt, &nkvals, &cnt, PMIX_SIZE);
+                   /* setup the info array */
+               PMIX_INFO_CREATE(jinfo, nkvals);
+                   /* cycle thru the blob and extract the kvals */
+               kv = PMIX_NEW(pmix_kval_t);
+               cnt = 1;
+               PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                  &bkt, kv, &cnt, PMIX_KVAL);
+               m = 0;
+               while (PMIX_SUCCESS == rc) {
+                   pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
+                                       "recvd KEY %s %s", kv->key,
+                                       (PMIX_STRING == kv->value->type) ? kv->value->data.string : "NON-STRING");
+                       /* xfer the value to the info */
+                   (void)strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
+                   PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
+                                          &jinfo[m].value, kv->value);
+                       /* if this is the ID key, save it */
+                   if (0 == strncmp(kv->key, PMIX_ALLOC_NETWORK_ID, PMIX_MAX_KEYLEN)) {
+                       idkey = strdup(kv->value->data.string);
+                   }
+                   ++m;
+                   PMIX_RELEASE(kv);
+                   kv = PMIX_NEW(pmix_kval_t);
+                   cnt = 1;
+                   PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                                      &bkt, kv, &cnt, PMIX_KVAL);
+               }
+                   /* restore the incoming data */
+               info[n].value.data.bo.bytes = bkt.base_ptr;
+               info[n].value.data.bo.size = bkt.bytes_used;
+               bkt.base_ptr = NULL;
+               bkt.bytes_used = 0;
+
+                   /* if they didn't include a network ID, then this is an error */
+               if (NULL == idkey) {
+                   PMIX_INFO_FREE(jinfo, nkvals);
+                   return PMIX_ERR_BAD_PARAM;
+               }
+                   /* the data gets stored as a pmix_data_array_t on the provided key */
+               PMIX_INFO_CONSTRUCT(&stinfo);
+               (void)strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
+               stinfo.value.type = PMIX_DATA_ARRAY;
+               PMIX_DATA_ARRAY_CREATE(stinfo.value.data.darray, nkvals, PMIX_INFO);
+               stinfo.value.data.darray->array = jinfo;
+
+                   /* cache the info on the job */
+               PMIX_GDS_CACHE_JOB_INFO(rc, pmix_globals.mypeer, nptr,
+                                       &stinfo, 1);
+               PMIX_INFO_DESTRUCT(&stinfo);
+           }
+       }
+    }
 
     return PMIX_SUCCESS;
 }
@@ -243,7 +399,7 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
     }
     localrank = kv->value->data.uint16;
 
-    pmix_output(0, "LOCAL RANK FOR PROC %s: %d", PMIX_NAME_PRINT(proc), (int)localrank);
+    pmix_output(0, "pnet:test LOCAL RANK FOR PROC %s: %d", PMIX_NAME_PRINT(proc), (int)localrank);
 
     PMIX_DESTRUCT(&cb);
     return PMIX_SUCCESS;
@@ -251,10 +407,23 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
 
 static void child_finalized(pmix_peer_t *peer)
 {
-
+    pmix_output(0, "pnet:test CHILD %s:%d FINALIZED",
+                peer->info->pname.nspace, peer->info->pname.rank);
 }
 
-static void local_app_finalized(char *nspace)
+static void local_app_finalized(pmix_nspace_t *nptr)
 {
+    pmix_output(0, "pnet:test NSPACE %s LOCALLY FINALIZED", nptr->nspace);
+}
 
+static void deregister_nspace(pmix_nspace_t *nptr)
+{
+    pmix_output(0, "pnet:test DEREGISTER NSPACE %s", nptr->nspace);
+}
+
+static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
+                                       pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_output(0, "pnet:test COLLECT INVENTORY");
+    return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -749,7 +749,6 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
             mca_ptl_tcp_component.nspace_filename = NULL;
             goto sockerror;
         }
-
     }
 
     /* we need listener thread support */

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -84,9 +84,6 @@ void pmix_rte_finalize(void)
     /* close the security framework */
     (void)pmix_mca_base_framework_close(&pmix_psec_base_framework);
 
-    /* close the pnet framework */
-    (void)pmix_mca_base_framework_close(&pmix_pnet_base_framework);
-
     /* close bfrops */
     (void)pmix_mca_base_framework_close(&pmix_bfrops_base_framework);
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -300,16 +300,6 @@ int pmix_rte_init(pmix_proc_type_t type,
         return ret;
     }
 
-    /* open the pnet and select the active modules for this environment */
-    if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_pnet_base_framework, 0))) {
-        error = "pmix_pnet_base_open";
-        goto return_error;
-    }
-    if (PMIX_SUCCESS != (ret = pmix_pnet_base_select())) {
-        error = "pmix_pnet_base_select";
-        goto return_error;
-    }
-
     /* open the preg and select the active plugins */
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_preg_base_framework, 0)) ) {
         error = "pmix_preg_base_open";

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1103,6 +1103,7 @@ static void spcbfunc(pmix_status_t status,
             }
         }
     }
+
     /* cleanup the caddy */
     if (NULL != cd->info) {
         PMIX_INFO_FREE(cd->info, cd->ninfo);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -200,7 +200,7 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
     pmix_invoke_local_event_hdlr(chain);
     return;
 
-  error:
+    error:
     /* we always need to return */
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "pmix:tool_notify_recv - unpack error status =%d, calling def errhandler", rc);
@@ -208,7 +208,6 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
     chain->status = rc;
     pmix_invoke_local_event_hdlr(chain);
 }
-
 
 static void tool_iof_handler(struct pmix_peer_t *pr,
                              pmix_ptl_hdr_t *hdr,
@@ -675,6 +674,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
             PMIX_IOF_READ_ACTIVATE(&stdinev);
         }
     }
+
     /* increment our init reference counter */
     pmix_globals.init_cntr++;
 

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -21,7 +21,8 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex test_pmix simptool simpdie simplegacy simptimeout
+noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
+                  test_pmix simptool simpdie simplegacy simptimeout gwtest gwclient
 
 simptest_SOURCES = \
         simptest.c
@@ -87,4 +88,16 @@ simptimeout_SOURCES = \
         simptimeout.c
 simptimeout_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simptimeout_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+gwtest_SOURCES = \
+        gwtest.c
+gwtest_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+gwtest_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+gwclient_SOURCES = \
+        gwclient.c
+gwclient_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+gwclient_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/gwclient.c
+++ b/test/simple/gwclient.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+static volatile bool completed = false;
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    uint64_t seckey[2];
+    pmix_proc_t proc;
+    pmix_info_t *info;
+    size_t n, ninfo;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "GWClient ns %s rank %d: Running", myproc.nspace, myproc.rank);
+
+    /* look for network data */
+    memset(&proc, 0, sizeof(pmix_proc_t));
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, "my.net.key", NULL, 0, &val)) ||
+        PMIX_DATA_ARRAY != val->type ||
+        NULL == val->data.darray ||
+        NULL == val->data.darray->array) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get my.net.key failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    /* the returned value has all the network allocation info in a
+     * pmix_data_array_t */
+    info = (pmix_info_t*)val->data.darray->array;
+    ninfo = val->data.darray->size;
+    pmix_output(0, "Client ns %s rank %d: got network assignment:",
+                myproc.nspace, myproc.rank);
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_STRING == info[n].value.type) {
+            pmix_output(0, "\tKey: %s Value: %s",
+                        info[n].key, info[n].value.data.string);
+        } else if (PMIX_BYTE_OBJECT == info[n].value.type) {
+            memcpy(seckey, info[n].value.data.bo.bytes, info[n].value.data.bo.size);
+            pmix_output(0, "\tKey: %s sec key: %ld.%ld",
+                        info[n].key, seckey[0], seckey[1]);
+        }
+    }
+    PMIX_VALUE_RELEASE(val);
+
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(rc);
+}

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -320,13 +320,16 @@ int main(int argc, char **argv)
 
     /* log something */
     PMIX_INFO_CONSTRUCT(&info);
-    (void)strncpy(info.key, "foobar", PMIX_MAX_KEYLEN);
-    info.value.type = PMIX_BOOL;
-    info.value.data.flag = true;
+    PMIX_INFO_LOAD(&info, PMIX_LOG_STDERR, "test log msg", PMIX_STRING);
     active = true;
-    PMIx_Log_nb(&info, 1, NULL, 0, opcbfunc, (void*)&active);
-    while (active) {
-        usleep(10);
+    rc = PMIx_Log_nb(&info, 1, NULL, 0, opcbfunc, (void*)&active);
+    if (PMIX_SUCCESS != rc) {
+        pmix_output(0, "Client ns %s rank %d - log_nb returned %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        while (active) {
+            usleep(10);
+        }
     }
     PMIX_INFO_DESTRUCT(&info);
 


### PR DESCRIPTION
Implement a pnet/tcp component and demonstrate how the existing PMIx_server_setup_application and PMIx_server_setup_local_support APIs can be used to pre-configure the network - in this example, by assigning static ports to the application's processes. Add a new "simple" test (both server and client) to illustrate the process.

Per the developer's conference, allow the caller to define the key by which the assigned network resources can be accessed. Note that some providers will define the network library themselves and won't need to necessarily expose the resource assignments.

Allow multiple network resource allocations per application to support the case where multiple libraries operate in parallel, each seeking its own network resources.