### PR TITLE
Fixed hang in PMIx_server_init

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -393,8 +393,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     /* start listening for connections */
     if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
         pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
-        PMIx_server_finalize();
         PMIX_RELEASE_THREAD(&pmix_global_lock);
+        PMIx_server_finalize();
         return PMIX_ERR_INIT;
     }
 


### PR DESCRIPTION
Fixed a deadlock for an error case when the same lock
was acquired before it was released

Signed-off-by: Boris Karasev <karasev.b@gmail.com>