### PR TITLE
Transfer all cached data to client gds

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -99,6 +99,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cleanup_dir_t,
 static void nscon(pmix_nspace_t *p)
 {
     p->nspace = NULL;
+    p->nprocs = 0;
     p->nlocalprocs = 0;
     p->all_registered = false;
     p->version_stored = false;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -161,6 +161,7 @@ PMIX_CLASS_DECLARATION(pmix_cleanup_dir_t);
 typedef struct {
     pmix_list_item_t super;
     char *nspace;
+    pmix_rank_t nprocs;          // num procs in this nspace
     size_t nlocalprocs;
     bool all_registered;         // all local ranks have been defined
     bool version_stored;         // the version string used by this nspace has been stored

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -527,6 +527,10 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
                 PMIX_RELEASE(kp2);
                 goto release;
             }
+            /* if this is the job size, then store it */
+            if (0 == strncmp(info[n].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN)) {
+                nptr->nprocs = info[n].value.data.uint32;
+            }
         }
     }
 
@@ -574,7 +578,6 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     pmix_hash_table_t *ht;
     pmix_value_t *val, blob;
     pmix_status_t rc = PMIX_SUCCESS;
-    pmix_rank_info_t *rinfo;
     pmix_info_t *info;
     size_t ninfo, n;
     pmix_kval_t kv;
@@ -621,9 +624,9 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         PMIX_VALUE_RELEASE(val);
     }
 
-    PMIX_LIST_FOREACH(rinfo, &ns->ranks, pmix_rank_info_t) {
+    for (rank=0; rank < ns->nprocs; rank++) {
         val = NULL;
-        rc = pmix_hash_fetch(ht, rinfo->pname.rank, NULL, &val);
+        rc = pmix_hash_fetch(ht, rank, NULL, &val);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             if (NULL != val) {
@@ -635,7 +638,6 @@ static pmix_status_t register_info(pmix_peer_t *peer,
             return PMIX_ERR_NOT_FOUND;
         }
         PMIX_CONSTRUCT(&buf, pmix_buffer_t);
-        rank = rinfo->pname.rank;
         PMIX_BFROPS_PACK(rc, peer, &buf, &rank, 1, PMIX_PROC_RANK);
 
         info = (pmix_info_t*)val->data.darray->array;


### PR DESCRIPTION
Upon first connection, the server transfers its cached nspace registration data to the gds being used by the client's nspace. Any data registered for a specific proc must go as well, even if the proc is remote. Otherwise, the client library won't find it, and won't ask the server for it because the key starts with "pmix", and must therefore have been provided at startup.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>