### PR TITLE
Transfer all cached data to client gds

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -55,6 +55,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namelist_t,
 static void nscon(pmix_nspace_t *p)
 {
     p->nspace = NULL;
+    p->nprocs = 0;
     p->nlocalprocs = 0;
     p->all_registered = false;
     p->version_stored = false;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -127,6 +127,7 @@ typedef struct pmix_personality_t {
 typedef struct {
     pmix_list_item_t super;
     char *nspace;
+    pmix_rank_t nprocs;          // num procs in this nspace
     size_t nlocalprocs;
     bool all_registered;         // all local ranks have been defined
     bool version_stored;         // the version string used by this nspace has been stored


### PR DESCRIPTION
Upon first connection, the server transfers its cached nspace registration data to the gds being used by the client's nspace. Any data registered for a specific proc must go as well, even if the proc is remote. Otherwise, the client library won't find it, and won't ask the server for it because the key starts with "pmix", and must therefore have been provided at startup.

Port of #707

Signed-off-by: Ralph Castain <rhc@open-mpi.org>