### PR TITLE
Properly ensure that resources are returned at child end

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -177,7 +177,6 @@ static void pcon(pmix_peer_t *p)
     p->proc_cnt = 0;
     p->index = 0;
     p->sd = -1;
-    p->finalized = false;
     p->send_ev_active = false;
     p->recv_ev_active = false;
     PMIX_CONSTRUCT(&p->send_queue, pmix_list_t);

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -84,7 +84,7 @@ PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
                                                              pmix_info_t info[],
                                                              size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *peer, char ***env);
-PMIX_EXPORT void pmix_pnet_base_child_finalized(pmix_peer_t *peer);
+PMIX_EXPORT void pmix_pnet_base_child_finalized(pmix_proc_t *peer);
 PMIX_EXPORT void pmix_pnet_base_local_app_finalized(pmix_nspace_t *nptr);
 PMIX_EXPORT void pmix_pnet_base_deregister_nspace(char *nspace);
 PMIX_EXPORT void pmix_pnet_base_collect_inventory(pmix_info_t directives[], size_t ndirs,

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -198,7 +198,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
     return PMIX_SUCCESS;
 }
 
-void pmix_pnet_base_child_finalized(pmix_peer_t *peer)
+void pmix_pnet_base_child_finalized(pmix_proc_t *peer)
 {
     pmix_pnet_base_active_module_t *active;
 

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -61,7 +61,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
 static pmix_status_t setup_fork(pmix_nspace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env);
-static void child_finalized(pmix_peer_t *peer);
+static void child_finalized(pmix_proc_t *peer);
 static void local_app_finalized(pmix_nspace_t *nptr);
 static void deregister_nspace(pmix_nspace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
@@ -327,7 +327,7 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static void child_finalized(pmix_peer_t *peer)
+static void child_finalized(pmix_proc_t *peer)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:opa child finalized");

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -84,7 +84,7 @@ typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(pmix_nspace_t *np
  * Provide an opportunity for the local network library to cleanup when a
  * local application process terminates
  */
-typedef void (*pmix_pnet_base_module_child_finalized_fn_t)(pmix_peer_t *peer);
+typedef void (*pmix_pnet_base_module_child_finalized_fn_t)(pmix_proc_t *peer);
 
 /**
  * Provide  an opportunity for the local network library to cleanup after

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -55,7 +55,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
                                          size_t ninfo);
 static pmix_status_t setup_fork(pmix_nspace_t *nptr,
                                 const pmix_proc_t *peer, char ***env);
-static void child_finalized(pmix_peer_t *peer);
+static void child_finalized(pmix_proc_t *peer);
 static void local_app_finalized(pmix_nspace_t *nptr);
 static void deregister_nspace(pmix_nspace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
@@ -750,7 +750,7 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
 /* when a local client finalizes, the server gives us a chance
  * to do any required local cleanup for that peer. We don't
  * have anything we need to do */
-static void child_finalized(pmix_peer_t *peer)
+static void child_finalized(pmix_proc_t *peer)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:tcp child finalized");

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -55,7 +55,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
 static pmix_status_t setup_fork(pmix_nspace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env);
-static void child_finalized(pmix_peer_t *peer);
+static void child_finalized(pmix_proc_t *peer);
 static void local_app_finalized(pmix_nspace_t *nptr);
 static void deregister_nspace(pmix_nspace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
@@ -412,10 +412,10 @@ static pmix_status_t setup_fork(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static void child_finalized(pmix_peer_t *peer)
+static void child_finalized(pmix_proc_t *peer)
 {
     pmix_output(0, "pnet:test CHILD %s:%d FINALIZED",
-                peer->info->pname.nspace, peer->info->pname.rank);
+                peer->nspace, peer->rank);
 }
 
 static void local_app_finalized(pmix_nspace_t *nptr)


### PR DESCRIPTION
Resources are allocated prior to knowing the type of application being executed. If the app never calls PMIx_Init, then no connection is made to the server and no pmix_peer_t object is created for it. This also means that PMIx_Finalize will never be called.

Together, this caused the client_finalized and app_finalized routines to fail to be called, thus leaking resources. Move those calls to the deregister_client function as the host RM is _always_ required to call that upon process termination, regardless of the type of application.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>