### PR TITLE
Do not cleanup resources for tools

### DIFF
--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1655,6 +1655,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         /* probably cannot send an error reply if we are out of memory */
         return;
     }
+    info->peerid = peer->index;
 
     /* start the events for this tool */
     pmix_event_assign(&peer->recv_event, pmix_globals.evbase, peer->sd,


### PR DESCRIPTION
Add missing assignment of info->peerid for tools. Check peer is not tool before calling child_finalized

Signed-off-by: Ralph Castain <rhc@open-mpi.org>