### PR TITLE
Backport patch for bitmap class

### DIFF
--- a/src/class/pmix_bitmap.c
+++ b/src/class/pmix_bitmap.c
@@ -123,7 +123,7 @@ pmix_bitmap_set_bit(pmix_bitmap_t *bm, int bit)
          out of range. We don't throw any error here, because this is
          valid and we simply expand the bitmap */
 
-        new_size = (int)(((size_t)index / bm->array_size + 1 ) * bm->array_size);
+        new_size = index + 1;
         if( new_size > bm->max_size )
             new_size = bm->max_size;
 


### PR DESCRIPTION
Backport of https://github.com/open-mpi/ompi/pull/4670

Signed-off-by: Ralph Castain <rhc@open-mpi.org>