### PR TITLE
v2.1: Fixed use of uninitialized value

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2081,6 +2081,7 @@ static void tcon(pmix_server_trkr_t *t)
     t->collect_type = PMIX_COLLECT_INVALID;
     t->modexcbfunc = NULL;
     t->op_cbfunc = NULL;
+    t->hybrid = false;
 }
 static void tdes(pmix_server_trkr_t *t)
 {


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit d5e4523bae0bef898c38e82e11927c3d3fd3c53a)

Conflicts:
	src/server/pmix_server_ops.c

Corresponds to #733 