### PR TITLE
Avoid sending unwanted notifications

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1110,6 +1110,7 @@ pmix_status_t pmix_server_notify_client_of_event(pmix_status_t status,
             }
         }
     }
+
     /*
      * If the range is PMIX_RANGE_NAMESPACE, then they should not have set a
      * PMIX_EVENT_CUSTOM_RANGE info object or at least we should ignore it

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -40,6 +40,8 @@
     size_t ncodes;
     pmix_info_t *info;
     size_t ninfo;
+    pmix_proc_t *affected;
+    size_t naffected;
     pmix_notification_fn_t evhdlr;
     pmix_hdlr_reg_cbfunc_t evregcbfn;
     void *cbdata;
@@ -55,6 +57,8 @@ static void rscon(pmix_rshift_caddy_t *p)
     p->ncodes = 0;
     p->info = NULL;
     p->ninfo = 0;
+    p->affected = NULL;
+    p->naffected = 0;
     p->evhdlr = NULL;
     p->evregcbfn = NULL;
     p->cbdata = NULL;
@@ -362,8 +366,10 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
         }
         found = false;
         if (NULL == cd->codes) {
-            /* they registered a default event handler - always matches */
-            found = true;
+            if (!ncd->nondefault) {
+                /* they registered a default event handler - always matches */
+                found = true;
+            }
         } else {
             for (n=0; n < cd->ncodes; n++) {
                 if (cd->codes[n] == ncd->status) {
@@ -393,6 +399,11 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
                 continue;
             }
         }
+       /* if they specified affected proc(s) they wanted to know about, check */
+       if (!pmix_notify_check_affected(cd->affected, cd->naffected,
+                                       ncd->affected, ncd->naffected)) {
+           continue;
+       }
        /* create the chain */
         chain = PMIX_NEW(pmix_event_chain_t);
         chain->status = ncd->status;
@@ -450,8 +461,8 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
     pmix_info_caddy_t *ixfer;
     void *cbobject = NULL;
     pmix_data_range_t range = PMIX_RANGE_UNDEF;
-    pmix_proc_t *parray = NULL, *affected = NULL;
-    size_t nprocs = 0, naffected = 0;
+    pmix_proc_t *parray = NULL;
+    size_t nprocs = 0;
 
     /* need to acquire the object from its originating thread */
     PMIX_ACQUIRE_OBJECT(cd);
@@ -506,11 +517,11 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 parray = (pmix_proc_t*)cd->info[n].value.data.darray->array;
                 nprocs = cd->info[n].value.data.darray->size;
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
-                affected = cd->info[n].value.data.proc;
-                naffected = 1;
+                cd->affected = cd->info[n].value.data.proc;
+                cd->naffected = 1;
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
-                affected = (pmix_proc_t*)cd->info[n].value.data.darray->array;
-                naffected = cd->info[n].value.data.darray->size;
+                cd->affected = (pmix_proc_t*)cd->info[n].value.data.darray->array;
+                cd->naffected = cd->info[n].value.data.darray->size;
             } else {
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
@@ -554,16 +565,16 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
             }
             memcpy(evhdlr->rng.procs, parray, nprocs * sizeof(pmix_proc_t));
         }
-        if (NULL != affected && 0 < naffected) {
-            evhdlr->naffected = naffected;
-            PMIX_PROC_CREATE(evhdlr->affected, naffected);
+        if (NULL != cd->affected && 0 < cd->naffected) {
+            evhdlr->naffected = cd->naffected;
+            PMIX_PROC_CREATE(evhdlr->affected, cd->naffected);
             if (NULL == evhdlr->affected) {
                 index = UINT_MAX;
                 rc = PMIX_ERR_EVENT_REGISTRATION;
                 PMIX_RELEASE(evhdlr);
                 goto ack;
             }
-            memcpy(evhdlr->affected, affected, naffected * sizeof(pmix_proc_t));
+            memcpy(evhdlr->affected, cd->affected, cd->naffected * sizeof(pmix_proc_t));
         }
         evhdlr->evhdlr = cd->evhdlr;
         evhdlr->cbobject = cbobject;
@@ -639,16 +650,16 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
         }
         memcpy(evhdlr->rng.procs, parray, nprocs * sizeof(pmix_proc_t));
     }
-    if (NULL != affected && 0 < naffected) {
-        evhdlr->naffected = naffected;
-        PMIX_PROC_CREATE(evhdlr->affected, naffected);
+    if (NULL != cd->affected && 0 < cd->naffected) {
+        evhdlr->naffected = cd->naffected;
+        PMIX_PROC_CREATE(evhdlr->affected, cd->naffected);
         if (NULL == evhdlr->affected) {
             index = UINT_MAX;
             rc = PMIX_ERR_EVENT_REGISTRATION;
             PMIX_RELEASE(evhdlr);
             goto ack;
         }
-        memcpy(evhdlr->affected, affected, naffected * sizeof(pmix_proc_t));
+        memcpy(evhdlr->affected, cd->affected, cd->naffected * sizeof(pmix_proc_t));
     }
     evhdlr->evhdlr = cd->evhdlr;
     evhdlr->cbobject = cbobject;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -762,7 +762,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     }
     /* if we are a tool and connected, then register any rendezvous files for cleanup */
     if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer) && pmix_globals.connected) {
-        char **clnup = NULL, *cptr;
+        char **clnup = NULL, *cptr = NULL;
         pmix_info_t dir;
         if (NULL != mca_ptl_tcp_component.nspace_filename) {
             pmix_argv_append_nosize(&clnup, mca_ptl_tcp_component.nspace_filename);
@@ -772,12 +772,12 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         }
         if (NULL != clnup) {
             cptr = pmix_argv_join(clnup, ',');
+            pmix_argv_free(clnup);
+            PMIX_INFO_LOAD(&dir, PMIX_REGISTER_CLEANUP, cptr, PMIX_STRING);
+            free(cptr);
+            PMIx_Job_control_nb(&pmix_globals.myid, 1, &dir, 1, NULL, NULL);
+            PMIX_INFO_DESTRUCT(&dir);
         }
-        pmix_argv_free(clnup);
-        PMIX_INFO_LOAD(&dir, PMIX_REGISTER_CLEANUP, cptr, PMIX_STRING);
-        free(cptr);
-        PMIx_Job_control_nb(&pmix_globals.myid, 1, &dir, 1, NULL, NULL);
-        PMIX_INFO_DESTRUCT(&dir);
     }
 
     /* we need listener thread support */


### PR DESCRIPTION
When an event is registered, we always check the cached notifications to see if we should deliver something previously received. Add checks to see if there really is a match between the newly registered handler and the cached notification before delivering it.

Silence coverity warning

Signed-off-by: Ralph Castain <rhc@open-mpi.org>