### PR TITLE
Protect opa component when no hwloc available

### DIFF
--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -354,6 +354,7 @@ static void deregister_nspace(pmix_nspace_t *nptr)
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_inventory_cbfunc_t cbfunc, void *cbdata)
 {
+#if PMIX_HAVE_HWLOC
     pmix_inventory_rollup_t *cd = (pmix_inventory_rollup_t*)cbdata;
     hwloc_obj_t obj;
     unsigned n;
@@ -445,6 +446,9 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
     pmix_value_load(kv->value, &pbo, PMIX_BYTE_OBJECT);
     PMIX_BYTE_OBJECT_DESTRUCT(&pbo);
     pmix_list_append(&cd->payload, &kv->super);
+#else
+    return PMIX_ERR_TAKE_NEXT_OPTION;
+#endif
 
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit a1c54a890407b6baf793cb309d5808ccd4ed483b)