### PR TITLE
Continue cleanup of finalize

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1467,7 +1467,17 @@ static pmix_status_t nspace_add(const char *nspace,
 
 static pmix_status_t nspace_del(const char *nspace)
 {
-    /* we don't need to do anything here */
+    pmix_hash_trkr_t *t;
+
+    /* find the hash table for this nspace */
+    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+        if (0 == strcmp(nspace, t->ns)) {
+            /* release it */
+            pmix_list_remove_item(&myhashes, &t->super);
+            PMIX_RELEASE(t);
+            break;
+        }
+    }
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1975,6 +1975,61 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
+static void connection_cleanup(int sd, short args, void *cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+
+    pmix_ptl_base_lost_connection(cd->peer, PMIX_SUCCESS);
+    /* cleanup the caddy */
+    PMIX_RELEASE(cd);
+}
+
+static void op_cbfunc2(pmix_status_t status, void *cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t rc;
+
+    /* no need to thread-shift here as no global data is
+     * being accessed */
+
+    /* setup the reply with the returned status */
+    if (NULL == (reply = PMIX_NEW(pmix_buffer_t))) {
+        PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+        PMIX_RELEASE(cd);
+        return;
+    }
+    PMIX_BFROPS_PACK(rc, cd->peer, reply, &status, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(reply);
+        PMIX_RELEASE(cd);
+        return;
+    }
+
+    /* the function that created the server_caddy did a
+     * retain on the peer, so we don't have to worry about
+     * it still being present - send a copy to the originator */
+    PMIX_PTL_SEND_ONEWAY(rc, cd->peer, reply, cd->hdr.tag);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(reply);
+    }
+
+    /* ensure that we know the peer has finalized else we
+     * will generate an event - yes, it should have been
+     * done, but it is REALLY important that it be set */
+    cd->peer->finalized = true;
+    /* cleanup any lingering references to this peer - note
+     * that we cannot call the lost_connection function
+     * directly as we need the connection to still
+     * exist for the message (queued above) to be
+     * sent. So we push this into an event, thus
+     * ensuring that it will "fire" after the message
+     * event has completed */
+    PMIX_THREADSHIFT(cd, connection_cleanup);
+}
+
 static void _spcb(int sd, short args, void *cbdata)
 {
     pmix_shift_caddy_t *cd = (pmix_shift_caddy_t*)cbdata;
@@ -3020,21 +3075,39 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
             pmix_event_del(&peer->recv_event);
             peer->recv_ev_active = false;
         }
+        PMIX_GDS_CADDY(cd, peer, tag);
         /* call the local server, if supported */
         if (NULL != pmix_host_server.client_finalized) {
-            PMIX_GDS_CADDY(cd, peer, tag);
             (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
             proc.rank = peer->info->pname.rank;
             /* now tell the host server */
             if (PMIX_SUCCESS == (rc = pmix_host_server.client_finalized(&proc, peer->info->server_object,
-                                                                        op_cbfunc, cd))) {
+                                                                        op_cbfunc2, cd))) {
                 /* don't reply to them ourselves - we will do so when the host
                  * server calls us back */
                 return rc;
             }
-            PMIX_RELEASE(cd);
+            /* if the call doesn't succeed (e.g., they provided the stub
+             * but return NOT_SUPPORTED), then the callback function
+             * won't be called, but we still need to cleanup
+             * any lingering references to this peer and answer
+             * the client. Thus, we call the callback function ourselves
+             * in this case */
+            op_cbfunc2(PMIX_SUCCESS, cd);
+            /* return SUCCESS as the cbfunc generated the return msg
+             * and released the cd object */
+            return PMIX_SUCCESS;
         }
-        return rc;
+        /* if the host doesn't provide a client_finalized function,
+         * we still need to ensure that we cleanup any lingering
+         * references to this peer. We use the callback function
+         * here as well to ensure the client gets its required
+         * response and that we delay before cleaning up the
+         * connection*/
+        op_cbfunc2(PMIX_SUCCESS, cd);
+        /* return SUCCESS as the cbfunc generated the return msg
+         * and released the cd object */
+        return PMIX_SUCCESS;
     }
 
 


### PR DESCRIPTION
@ggouaillardet Many thanks for the help!!! Looks like we are getting closer.
```shell
$ valgrind --track-fds=yes .libs/stability --reps 10
==188204== Memcheck, a memory error detector
==188204== Copyright (C) 2002-2015, and GNU GPL'd, by Julian Seward et al.
==188204== Using Valgrind-3.12.0 and LibVEX; rerun with -h for copyright info
==188204== Command: .libs/stability --reps 10
==188204== 
Testing version 3.0.0
Running cycle 0
Running cycle 1
Running cycle 2
Running cycle 3
Running cycle 4
Running cycle 5
Running cycle 6
Running cycle 7
Running cycle 8
Running cycle 9
Test finished OK!
==188204== 
==188204== FILE DESCRIPTORS: 3 open at exit.
==188204== Open file descriptor 2: /dev/pts/1
==188204==    <inherited from parent>
==188204== 
==188204== Open file descriptor 1: /dev/pts/1
==188204==    <inherited from parent>
==188204== 
==188204== Open file descriptor 0: /dev/pts/1
==188204==    <inherited from parent>
==188204== 
==188204== 
==188204== HEAP SUMMARY:
==188204==     in use at exit: 28,297 bytes in 373 blocks
==188204==   total heap usage: 9,802 allocs, 9,429 frees, 2,452,110 bytes allocated
==188204== 
==188204== LEAK SUMMARY:
==188204==    definitely lost: 9,555 bytes in 115 blocks
==188204==    indirectly lost: 9,963 bytes in 242 blocks
==188204==      possibly lost: 0 bytes in 0 blocks
==188204==    still reachable: 8,779 bytes in 16 blocks
==188204==         suppressed: 0 bytes in 0 blocks
==188204== Rerun with --leak-check=full to see details of leaked memory
==188204== 
==188204== For counts of detected and suppressed errors, rerun with: -v
==188204== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
