### PR TITLE
Revert connect/disconnect to v2 signatures

### DIFF
--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -44,7 +44,7 @@ int main(int argc, char **argv)
     int rc;
     pmix_value_t value;
     pmix_value_t *val = &value;
-    pmix_proc_t proc, newproc;
+    pmix_proc_t proc;
     uint32_t nprocs;
     char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
@@ -135,13 +135,13 @@ int main(int argc, char **argv)
     /* just cycle the connect/disconnect functions */
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Connect(&proc, 1, NULL, 0, newproc.nspace, &newproc.rank))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Connect(&proc, 1, NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Connect failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    fprintf(stderr, "Client ns %s rank %d: PMIx_Connect succeeded - new ID: %s:%d\n",
-            myproc.nspace, myproc.rank, newproc.nspace, newproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(newproc.nspace, NULL, 0))) {
+    fprintf(stderr, "Client ns %s rank %d: PMIx_Connect succeeded\n",
+            myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(&proc, 1, NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Disonnect failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }

--- a/examples/server.c
+++ b/examples/server.c
@@ -80,8 +80,8 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                               pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t disconnect_fn(const char nspace[],
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
@@ -748,7 +748,7 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
 
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_output(0, "SERVER: CONNECT");
 
@@ -756,14 +756,14 @@ static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
      * resource manager for handling */
 
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, "FOOBAR", 1, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
 
     return PMIX_SUCCESS;
 }
 
 
-static pmix_status_t disconnect_fn(const char nspace[],
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -353,9 +353,11 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
  * appropriate action. Note that different resource managers may respond to
  * failures in different manners.
  *
- * The host RM will assign a unique nspace to the resulting process group. The
- * new nspace must be provided when disconnecting from the group. All procs are
- * required to disconnect from the nspace prior to terminating.
+ * The callback function is to be called once all participating processes have
+ * called connect. The server is required to return any job-level info for the
+ * connecting processes that might not already have - i.e., if the connect
+ * request involves procs from different nspaces, then each proc shall receive
+ * the job-level info from those nspaces other than their own.
  *
  * Note: a process can only engage in _one_ connect operation involving the identical
  * set of processes at a time. However, a process _can_ be simultaneously engaged
@@ -364,61 +366,24 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn_nb(const pmix_info_t job_info[], size_t nin
  * As in the case of the fence operation, the info array can be used to pass
  * user-level directives regarding the algorithm to be used for the collective
  * operation involved in the "connect", timeout constraints, and other options
- * available from the host RM.
- *
- * The server is required to return any job-level info for the connecting
- * processes that they might not already have - i.e., if the connect request
- * involves procs from different nspaces, then each proc shall receive the
- * job-level info from those nspaces other than their own.
- */
-
-
-/* The blocking form of this call must provide a character array of size
- * PMIX_MAX_NSLEN+1 for the assigned nspace of the resulting group, and a pointer
- * to an pmix_rank_t location where the new rank of this process in the assigned
- * nspace can be returned. Calls will return once the specified operation
- * is complete (i.e., all participants have called PMIx_Connect).
- */
-
+ * available from the host RM */
 PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char nspace[], pmix_rank_t *newrank);
-
-/* The callback function for the non-blocking form of the PMIx_Connect
- * operation will be called once the operation is complete. Any participant
- * that fails to call "connect" prior to terminating will cause the
- * operation to return a "failed" status to all other participants. This
- * is the default behavior in the absence of any provided directive.
- *
- * Some additional info keys are provided for this operation:
- *
- * (a) PMIX_CONNECT_NOTIFY_EACH: generate a local event notification using
- *     the PMIX_PROC_HAS_CONNECTED event each time a process connects
- *
- * (b) PMIX_CONNECT_NOTIFY_REQ: notify each of the indicated procs that
- *     they are requested to connect using the PMIX_CONNECT_REQUESTED event
- *
- * (c) PMIX_CONNECT_OPTIONAL: participation is optional - do not return
- *     error if procs terminate without having connected
- */
+                                       const pmix_info_t info[], size_t ninfo);
 
 PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
                                           const pmix_info_t info[], size_t ninfo,
-                                          pmix_connect_cbfunc_t cbfunc, void *cbdata);
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-/* Disconnect this process from a specified nspace. An error will be returned
- * if the specified nspace is not recognized. The info array is used as above.
- *
- * Processes that terminate while connected to other processes will generate a
- * "termination error" event that will be reported to any process in the connected
- * group that has registered for such events. Calls to "disconnect" that include the
- * PMIX_CONNECT_NOTIFY_EACH info key will cause other processes in the nspace to receive
- * an event notification of the disconnect, if they are registered for such events.
- */
-PMIX_EXPORT pmix_status_t PMIx_Disconnect(const char nspace[],
+/* Disconnect a previously connected set of processes. An error will be returned
+ * if the specified set of procs was not previously "connected". As above, a process
+ * may be involved in multiple simultaneous disconnect operations. However, a process
+ * is not allowed to reconnect to a set of procs that has not fully completed
+ * disconnect - i.e., you have to fully disconnect before you can reconnect to the
+ * _same_ group of processes. The info array is used as above. */
+PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
                                           const pmix_info_t info[], size_t ninfo);
 
-PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t ranges[], size_t nprocs,
                                              const pmix_info_t info[], size_t ninfo,
                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1865,18 +1865,6 @@ typedef void (*pmix_modex_cbfunc_t)(pmix_status_t status,
 typedef void (*pmix_spawn_cbfunc_t)(pmix_status_t status,
                                     char nspace[], void *cbdata);
 
-/* define a callback function for calls to PMIx_Connect_nb - the function
- * will be called upon completion of the command. The status will indicate
- * whether or not the connect operation succeeded. The nspace will contain
- * the new identity assigned by the host RM to the specified group of
- * processes, and the rank will be the rank of this process within that new
- * group. Note that the returned nspace value may be
- * released by the library upon return from the callback function, so
- * the receiver must copy it if it needs to be retained */
-typedef void (*pmix_connect_cbfunc_t)(pmix_status_t status,
-                                      char nspace[], int rank,
-                                      void *cbdata);
-
 /* define a callback for common operations that simply return
  * a status. Examples include the non-blocking versions of
  * Fence, Connect, and Disconnect */

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -198,48 +198,38 @@ typedef pmix_status_t (*pmix_server_spawn_fn_t)(const pmix_proc_t *proc,
                                                 const pmix_app_t apps[], size_t napps,
                                                 pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 
-/* Record the specified processes as "connected". This means that:
+/* Record the specified processes as "connected". This means that the resource
+ * manager should treat the failure of any process in the specified group as
+ * a reportable event, and take appropriate action. The callback function is
+ * to be called once all participating processes have called connect. Note that
+ * a process can only engage in *one* connect operation involving the identical
+ * set of procs at a time. However, a process *can* be simultaneously engaged
+ * in multiple connect operations, each involving a different set of procs
  *
- * (a) the resource manager should treat the specified group as
- *     a group when reporting events.
- *
- * (b) processes can address the group by the newly assigned nspace
- *     when passing requests
- *
- * As in the case of the fence operation, the info array can be used to pass
- * user-level directives regarding the algorithm to be used for the collective
- * operation involved in the "connect", timeout constraints, and other options
- * available from the host RM.
- *
- * The callback function will be called once the operation is complete. Any
- * participant that fails to call "connect" prior to terminating will cause the
- * operation to return a "failed" status to all other participants. This
- * is the default behavior in the absence of any provided directive.
- *
- * Some additional info keys are provided for this operation:
- *
- * (a) PMIX_CONNECT_NOTIFY_EACH: generate a local event notification using
- *     the PMIX_PROC_HAS_CONNECTED event each time a process connects
- *
- * (b) PMIX_CONNECT_NOTIFY_REQ: notify each of the indicated procs that
- *     they are requested to connect using the PMIX_CONNECT_REQUESTED event
- *
- * (c) PMIX_CONNECT_OPTIONAL: participation is optional - do not return
- *     error if procs terminate without having connected
- */
+ * Note also that this is a collective operation within the client library, and
+ * thus the client will be blocked until all procs participate. Thus, the info
+ * array can be used to pass user directives, including a timeout.
+ * The directives are optional _unless_ the _mandatory_ flag
+ * has been set - in such cases, the host RM is required to return an error
+ * if the directive cannot be met. */
 typedef pmix_status_t (*pmix_server_connect_fn_t)(const pmix_proc_t procs[], size_t nprocs,
                                                   const pmix_info_t info[], size_t ninfo,
-                                                  pmix_connect_cbfunc_t cbfunc, void *cbdata);
+                                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
 
-/* Disconnect this process from a specified nspace. An error will be returned
- * if the specified nspace is not recognized. The info array is used as above.
- *
- * Processes that terminate while connected to other processes will generate a
- * "termination error" event that will be reported to any process in the connected
- * group that has registered for such events. Calls to "disconnect" that include the
- * PMIX_CONNECT_NOTIFY_EACH info key will cause other processes in the nspace to receive
- * an event notification of the disconnect, if they are registered for such events. */
-typedef pmix_status_t (*pmix_server_disconnect_fn_t)(const char nspace[],
+/* Disconnect a previously connected set of processes. An error should be returned
+ * if the specified set of procs was not previously "connected". As above, a process
+ * may be involved in multiple simultaneous disconnect operations. However, a process
+ * is not allowed to reconnect to a set of ranges that has not fully completed
+ * disconnect - i.e., you have to fully disconnect before you can reconnect to the
+ * same group of processes.
+  *
+ * Note also that this is a collective operation within the client library, and
+ * thus the client will be blocked until all procs participate. Thus, the info
+ * array can be used to pass user directives, including a timeout.
+ * The directives are optional _unless_ the _mandatory_ flag
+ * has been set - in such cases, the host RM is required to return an error
+ * if the directive cannot be met. */
+typedef pmix_status_t (*pmix_server_disconnect_fn_t)(const pmix_proc_t procs[], size_t nprocs,
                                                      const pmix_info_t info[], size_t ninfo,
                                                      pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -327,8 +327,6 @@ PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_proc_t proc;
-    char nspace[PMIX_MAX_NSLEN+1];
-    pmix_rank_t rank;
 
     PMI2_CHECK();
 
@@ -343,14 +341,14 @@ PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
     memset(proc.nspace, 0, sizeof(proc.nspace));
     (void)strncpy(proc.nspace, (jobid ? jobid : proc.nspace), sizeof(proc.nspace)-1);
     proc.rank = PMIX_RANK_WILDCARD;
-    rc = PMIx_Connect(&proc, 1, NULL, 0, nspace, &rank);
+    rc = PMIx_Connect(&proc, 1, NULL, 0);
     return convert_err(rc);
 }
 
 PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[])
 {
     pmix_status_t rc = PMIX_SUCCESS;
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_proc_t proc;
 
     PMI2_CHECK();
 
@@ -358,9 +356,10 @@ PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[])
         return PMI2_SUCCESS;
     }
 
-    memset(nspace, 0, sizeof(nspace));
-    (void)strncpy(nspace, (jobid ? jobid : nspace), sizeof(nspace)-1);
-    rc = PMIx_Disconnect(nspace, NULL, 0);
+    memset(proc.nspace, 0, sizeof(proc.nspace));
+    (void)strncpy(proc.nspace, (jobid ? jobid : proc.nspace), sizeof(proc.nspace)-1);
+    proc.rank = PMIX_RANK_WILDCARD;
+    rc = PMIx_Disconnect(&proc, 1, NULL, 0);
     return convert_err(rc);
 }
 

--- a/src/client/pmix_client_connect.c
+++ b/src/client/pmix_client_connect.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -62,22 +62,13 @@
 static void wait_cbfunc(struct pmix_peer_t *pr,
                         pmix_ptl_hdr_t *hdr,
                         pmix_buffer_t *buf, void *cbdata);
-static void discbfunc(struct pmix_peer_t *pr,
-                      pmix_ptl_hdr_t *hdr,
-                      pmix_buffer_t *buf, void *cbdata);
-static void cnct_cbfunc(pmix_status_t status,
-                        char nspace[], int rank,
-                        void *cbdata);
-
 static void op_cbfunc(pmix_status_t status, void *cbdata);
 
 PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
-                                       const pmix_info_t info[], size_t ninfo,
-                                       char nspace[], pmix_rank_t *newrank)
+                                       const pmix_info_t info[], size_t ninfo)
 {
     pmix_status_t rc;
     pmix_cb_t *cb;
-    size_t n;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -100,18 +91,9 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
-    /* see if this connect request was to return a new nspace/rank, or
-     * was just an exchange of info */
-    cb->checked = true;
-    for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_CONNECT_XCHG_ONLY, PMIX_MAX_KEYLEN)) {
-            cb->checked = false;
-            break;
-        }
-    }
 
     /* push the message into our event base to send to the server */
-    if (PMIX_SUCCESS != (rc = PMIx_Connect_nb(procs, nprocs, info, ninfo, cnct_cbfunc, cb))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Connect_nb(procs, nprocs, info, ninfo, op_cbfunc, cb))) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -119,15 +101,6 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
     /* wait for the connect to complete */
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
-
-    if (cb->checked && PMIX_SUCCESS == rc) {
-        if (NULL != nspace) {
-            (void)strncpy(nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
-        }
-        if (NULL != newrank) {
-            *newrank = cb->pname.rank;
-        }
-    }
     PMIX_RELEASE(cb);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
@@ -138,13 +111,12 @@ PMIX_EXPORT pmix_status_t PMIx_Connect(const pmix_proc_t procs[], size_t nprocs,
 
 PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t nprocs,
                                           const pmix_info_t info[], size_t ninfo,
-                                          pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                                          pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_CONNECTNB_CMD;
     pmix_status_t rc;
     pmix_cb_t *cb;
-    size_t n;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -213,18 +185,8 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
      * recv routine so we know which callback to use when
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
-    cb->cbfunc.cnctfn = cbfunc;
+    cb->cbfunc.opfn = cbfunc;
     cb->cbdata = cbdata;
-
-    /* see if this connect request was to return a new nspace/rank, or
-     * was just an exchange of info */
-    cb->checked = true;
-    for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_CONNECT_XCHG_ONLY, PMIX_MAX_KEYLEN)) {
-            cb->checked = false;
-            break;
-        }
-    }
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
@@ -237,7 +199,7 @@ PMIX_EXPORT pmix_status_t PMIx_Connect_nb(const pmix_proc_t procs[], size_t npro
     return rc;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Disconnect(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_Disconnect(const pmix_proc_t procs[], size_t nprocs,
                                           const pmix_info_t info[], size_t ninfo)
 {
     pmix_status_t rc;
@@ -261,7 +223,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect(const char nspace[],
      * the return message is recvd */
     cb = PMIX_NEW(pmix_cb_t);
 
-    if (PMIX_SUCCESS != (rc = PMIx_Disconnect_nb(nspace, info, ninfo, op_cbfunc, cb))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Disconnect_nb(procs, nprocs, info, ninfo, op_cbfunc, cb))) {
         PMIX_RELEASE(cb);
         return rc;
     }
@@ -277,7 +239,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect(const char nspace[],
     return rc;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t procs[], size_t nprocs,
                                              const pmix_info_t info[], size_t ninfo,
                                              pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
@@ -290,6 +252,13 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: disconnect called");
+
+    size_t cnt;
+    for (cnt = 0; cnt < nprocs; cnt++) {
+        if (0 != strcmp(pmix_globals.myid.nspace, procs[cnt].nspace)) {
+            PMIX_GDS_DEL_NSPACE(rc, procs[cnt].nspace);
+        }
+    }
 
     if (pmix_globals.init_cntr <= 0) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -304,13 +273,8 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* check for bozo input */
-    if (NULL == nspace) {
+    if (NULL == procs || 0 >= nprocs) {
         return PMIX_ERR_BAD_PARAM;
-    }
-
-    /* release our internal resources */
-    if (0 != strncmp(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN)) {
-        PMIX_GDS_DEL_NSPACE(rc, nspace);
     }
 
     msg = PMIX_NEW(pmix_buffer_t);
@@ -322,9 +286,15 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
         return rc;
     }
 
-    /* pack the nspace */
+    /* pack the number of procs */
     PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                     msg, &nspace, 1, PMIX_STRING);
+                     msg, &nprocs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, procs, nprocs, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         return rc;
@@ -357,7 +327,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const char nspace[],
 
     /* push the message into our event base to send to the server */
     PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
-                       msg, discbfunc, (void*)cb);
+                       msg, wait_cbfunc, (void*)cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(msg);
         PMIX_RELEASE(cb);
@@ -380,7 +350,6 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
     char *nspace;
     pmix_buffer_t bkt;
     pmix_byte_object_t bo;
-    pmix_proc_t pname;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix:client recv callback activated with %d bytes",
@@ -398,10 +367,6 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
         goto report;
     }
 
-    /* set the default nspace/rank */
-    memset(pname.nspace, 0, PMIX_MAX_NSLEN+1);
-    pname.rank = PMIX_RANK_UNDEF;
-
     /* unpack the returned status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
@@ -410,23 +375,6 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
-
-    if (PMIX_SUCCESS != ret) {
-        goto report;
-    }
-
-    if (cb->checked) {
-        /* unpack the returned nspace/rank */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
-                           buf, &pname, &cnt, PMIX_PROC);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            ret = rc;
-            goto report;
-        }
-    }
-
     /* connect has to also pass back data from all nspace's involved in
      * the operation, including our own. Each will come as a byte object */
     cnt = 1;
@@ -464,47 +412,6 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
     }
 
   report:
-    if (NULL != cb->cbfunc.cnctfn) {
-        cb->cbfunc.cnctfn(ret, pname.nspace, pname.rank, cb->cbdata);
-    }
-    PMIX_RELEASE(cb);
-}
-
-static void discbfunc(struct pmix_peer_t *pr,
-                      pmix_ptl_hdr_t *hdr,
-                      pmix_buffer_t *buf, void *cbdata)
-{
-    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
-    pmix_status_t rc;
-    pmix_status_t ret;
-    int32_t cnt;
-
-    pmix_output_verbose(2, pmix_globals.debug_output,
-                        "pmix:client recv callback activated with %d bytes",
-                        (NULL == buf) ? -1 : (int)buf->bytes_used);
-
-    if (NULL == buf) {
-        ret = PMIX_ERR_BAD_PARAM;
-        goto report;
-    }
-
-    /* a zero-byte buffer indicates that this recv is being
-     * completed due to a lost connection */
-    if (PMIX_BUFFER_IS_EMPTY(buf)) {
-        ret = PMIX_ERR_UNREACH;
-        goto report;
-    }
-
-    /* unpack the returned status */
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
-                       buf, &ret, &cnt, PMIX_STATUS);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        ret = rc;
-    }
-
-  report:
     if (NULL != cb->cbfunc.opfn) {
         cb->cbfunc.opfn(ret, cb->cbdata);
     }
@@ -516,21 +423,6 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
 
     cb->status = status;
-    PMIX_POST_OBJECT(cb);
-    PMIX_WAKEUP_THREAD(&cb->lock);
-}
-
-static void cnct_cbfunc(pmix_status_t status,
-                        char nspace[], int rank,
-                        void *cbdata)
-{
-    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
-
-    cb->status = status;
-    if (NULL != nspace) {
-        cb->pname.nspace = strdup(nspace);
-    }
-    cb->pname.rank = rank;
     PMIX_POST_OBJECT(cb);
     PMIX_WAKEUP_THREAD(&cb->lock);
 }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -295,7 +295,6 @@ typedef struct {
     pmix_collect_t collect_type;    // whether or not data is to be returned at completion
     pmix_modex_cbfunc_t modexcbfunc;
     pmix_op_cbfunc_t op_cbfunc;
-    pmix_connect_cbfunc_t cnct_cbfunc;
 } pmix_server_trkr_t;
 PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
 
@@ -363,7 +362,6 @@ typedef struct {
         pmix_value_cbfunc_t valuefn;
         pmix_lookup_cbfunc_t lookupfn;
         pmix_spawn_cbfunc_t spawnfn;
-        pmix_connect_cbfunc_t cnctfn;
         pmix_hdlr_reg_cbfunc_t hdlrregfn;
     } cbfunc;
     size_t errhandler_ref;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -110,8 +110,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                         trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
                     }
                 } else if (PMIX_CONNECTNB_CMD == trk->type) {
-                    if (NULL != trk->cnct_cbfunc) {
-                        trk->cnct_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, PMIX_RANK_WILDCARD, trk);
+                    if (NULL != trk->op_cbfunc) {
+                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
                     }
                 } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
                     if (NULL != trk->op_cbfunc) {

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -235,7 +235,7 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
 
 pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
                                   pmix_buffer_t *buf,
-                                  pmix_connect_cbfunc_t cbfunc);
+                                  pmix_op_cbfunc_t cbfunc);
 
 pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd,
                                      pmix_buffer_t *buf,

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -310,22 +310,18 @@ static int numconnect = 0;
 
 pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                          const pmix_info_t info[], size_t ninfo,
-                         pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                         pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    char nspace[PMIX_MAX_NSLEN+1];
-
-    memset(nspace, 0, PMIX_MAX_NSLEN+1);
-    (void)snprintf(nspace, PMIX_MAX_NSLEN, "FOOBAR-%d", numconnect);
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, nspace, 1, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
     numconnect++;
     return PMIX_SUCCESS;
 }
 
-pmix_status_t disconnect_fn(const char nspace[],
-                  const pmix_info_t info[], size_t ninfo,
-                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
+                            const pmix_info_t info[], size_t ninfo,
+                            pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);

--- a/test/server_callbacks.h
+++ b/test/server_callbacks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -46,8 +46,8 @@ pmix_status_t spawn_fn(const pmix_proc_t *proc,
                        pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                          const pmix_info_t info[], size_t ninfo,
-                         pmix_connect_cbfunc_t cbfunc, void *cbdata);
-pmix_status_t disconnect_fn(const char nspace[],
+                         pmix_op_cbfunc_t cbfunc, void *cbdata);
+pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                             const pmix_info_t info[], size_t ninfo,
                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 pmix_status_t regevents_fn(pmix_status_t *codes, size_t ncodes,

--- a/test/simple/gwtest.c
+++ b/test/simple/gwtest.c
@@ -76,8 +76,8 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                               pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t disconnect_fn(const char nspace[],
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
@@ -839,26 +839,24 @@ static int numconnects = 0;
 
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_output(0, "SERVER: CONNECT");
-    char nspace[PMIX_MAX_NSLEN+1];
 
     /* in practice, we would pass this request to the local
      * resource manager for handling */
 
-    (void)snprintf(nspace, PMIX_MAX_NSLEN, "NEW%d", numconnects);
     numconnects++;
 
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, nspace, 0, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
 
     return PMIX_SUCCESS;
 }
 
 
-static pmix_status_t disconnect_fn(const char nspace[],
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {

--- a/test/simple/simpdyn.c
+++ b/test/simple/simpdyn.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -46,13 +46,12 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs;
-    char nsp2[PMIX_MAX_NSLEN+1], nsp3[PMIX_MAX_NSLEN+1];
+    char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
     char hostname[PMIX_MAXHOSTNAMELEN];
     pmix_proc_t *peers;
     size_t npeers, ntmp=0;
     char *nodelist;
-    pmix_rank_t newrank;
 
     gethostname(hostname, sizeof(hostname));
 
@@ -129,13 +128,13 @@ int main(int argc, char **argv)
     }
 
     /* just cycle the connect/disconnect functions */
-    if (PMIX_SUCCESS != (rc = PMIx_Connect(&proc, 1, NULL, 0, nsp3, &newrank))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Connect(&proc, 1, NULL, 0))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Connect failed: %d", myproc.nspace, myproc.rank, rc);
         goto done;
     }
-    pmix_output(0, "Client ns %s rank %d: PMIx_Connect succeeded - %s:%d",
-                myproc.nspace, myproc.rank, nsp3, newrank);
-    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(nsp3, NULL, 0))) {
+    pmix_output(0, "Client ns %s rank %d: PMIx_Connect succeeded",
+                myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(&proc, 1, NULL, 0))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Disonnect failed: %d", myproc.nspace, myproc.rank, rc);
         goto done;
     }

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -82,8 +82,8 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                               pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t disconnect_fn(const char nspace[],
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
@@ -954,26 +954,24 @@ static int numconnects = 0;
 
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_output(0, "SERVER: CONNECT");
-    char nspace[PMIX_MAX_NSLEN+1];
 
     /* in practice, we would pass this request to the local
      * resource manager for handling */
 
-    (void)snprintf(nspace, PMIX_MAX_NSLEN, "NEW%d", numconnects);
     numconnects++;
 
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, nspace, 0, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
 
     return PMIX_SUCCESS;
 }
 
 
-static pmix_status_t disconnect_fn(const char nspace[],
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {

--- a/test/simple/simptimeout.c
+++ b/test/simple/simptimeout.c
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
     int rc;
     pmix_value_t value;
     pmix_value_t *val = &value;
-    pmix_proc_t proc, newproc;
+    pmix_proc_t proc;
     uint32_t nprocs, n;
     volatile bool active;
     pmix_info_t info;
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 
         /* check timeout on connect */
         pmix_output(0, "TEST CONNECT TIMEOUT");
-        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Connect(&proc, 1, &info, 1, newproc.nspace, &newproc.rank))) {
+        if (PMIX_ERR_TIMEOUT != (rc = PMIx_Connect(&proc, 1, &info, 1))) {
             pmix_output(0, "Client ns %s rank %d: PMIx_Connect did not timeout: %s",
                         myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;

--- a/test/simple/stability.c
+++ b/test/simple/stability.c
@@ -82,8 +82,8 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
                               pmix_spawn_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata);
-static pmix_status_t disconnect_fn(const char nspace[],
+                                pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t register_event_fn(pmix_status_t *codes, size_t ncodes,
@@ -733,25 +733,23 @@ static int numconnects = 0;
 
 static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
-                                pmix_connect_cbfunc_t cbfunc, void *cbdata)
+                                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    char nspace[PMIX_MAX_NSLEN+1];
 
     /* in practice, we would pass this request to the local
      * resource manager for handling */
 
-    (void)snprintf(nspace, PMIX_MAX_NSLEN, "NEW%d", numconnects);
     numconnects++;
 
     if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, nspace, 0, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
 
     return PMIX_SUCCESS;
 }
 
 
-static pmix_status_t disconnect_fn(const char nspace[],
+static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -61,7 +61,6 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
     int ns_num;
     char nspace[PMIX_MAX_NSLEN+1];
     pmix_proc_t procs[2];
-    pmix_proc_t pname;
 
     /* first resolve peers from the own namespace. */
     rc = resolve_nspace(my_nspace, params, my_nspace, my_rank);
@@ -99,11 +98,11 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         procs[1].rank = PMIX_RANK_WILDCARD;
 
         /* make a connection between processes from own namespace and processes from this namespace. */
-        rc = PMIx_Connect(procs, 2, NULL, 0, pname.nspace, &pname.rank);
+        rc = PMIx_Connect(procs, 2, NULL, 0);
         if (PMIX_SUCCESS == rc) {
-            TEST_VERBOSE(("%s:%d: Connect to %s succeeded %s.", my_nspace, my_rank, nspace));
+            TEST_VERBOSE(("%s:%d: Connect to %s succeeded.", my_nspace, my_rank, nspace));
         } else {
-            TEST_ERROR(("%s:%d: Connect to %s failed %s.", my_nspace, my_rank, nspace));
+            TEST_ERROR(("%s:%d: Connect to %s failed.", my_nspace, my_rank, nspace));
             return PMIX_ERROR;
         }
 
@@ -112,12 +111,12 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         if (PMIX_SUCCESS == rc) {
             TEST_VERBOSE(("%s:%d: Resolve peers succeeded for ns %s\n", my_nspace, my_rank, nspace));
         } else {
-            PMIx_Disconnect(pname.nspace, NULL, 0);
+            PMIx_Disconnect(procs, 2, NULL, 0);
             break;
         }
 
         /* disconnect from the processes of this namespace. */
-        rc = PMIx_Disconnect(pname.nspace, NULL, 0);
+        rc = PMIx_Disconnect(procs, 2, NULL, 0);
         if (PMIX_SUCCESS == rc) {
             TEST_VERBOSE(("%s:%d: Disconnect from %s succeeded %s.", my_nspace, my_rank, nspace));
         } else {


### PR DESCRIPTION
Although we are unaware of anyone who has implemented the server-side backend for PMIx_Connect/Disconnect, we really need to begin enforcing the backward compatibility guarantee. We had changed these signatures to accommodate the work being done in the MPI sessions working group, burt we will instead meet that request by adding a set of new APIs (PMIx_Group_*) in the future v4 of the standard.

Note: this effectively "rejects" RFC https://github.com/pmix/RFCs/pull/3 - it will be so marked and replaced by a new RFC for PMIx_Group

Signed-off-by: Ralph Castain <rhc@open-mpi.org>