### PR TITLE
Minor cleanup

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -502,7 +502,7 @@ static void progress_local_event_hdlr(pmix_status_t status,
      * and code, then invoke it now */
     if (NULL != pmix_globals.events.last &&
         pmix_notify_check_range(&pmix_globals.events.last->rng, &chain->source) &&
-        pmix_notify_check_affected(nxt->affected, nxt->naffected,
+        pmix_notify_check_affected(pmix_globals.events.last->affected, pmix_globals.events.last->naffected,
                                    chain->affected, chain->naffected)) {
         chain->endchain = true;  // ensure we don't do this again
         if (1 == pmix_globals.events.last->ncodes &&

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -602,6 +602,10 @@ static pmix_status_t allocate(pmix_nspace_t *nptr,
                 pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                                     "pnet:tcp:allocate allocating %d ports/node for nspace %s",
                                     ports_per_node, nptr->nspace);
+                if (0 == ports_per_node) {
+                    /* nothing to allocate */
+                    return PMIX_ERR_TAKE_NEXT_OPTION;
+                }
                 avail = (tcp_available_ports_t*)pmix_list_get_first(&available);
                 if (NULL != avail) {
                     /* setup to track the assignment */
@@ -891,6 +895,8 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
             prefix = "tcp6://";
             inet_ntop(AF_INET6, &((struct sockaddr_in6*) &my_ss)->sin6_addr,
                       myconnhost, PMIX_MAXHOSTNAMELEN);
+        } else {
+            continue;
         }
         (void)snprintf(uri, 2048, "%s%s", prefix, myconnhost);
         pmix_output_verbose(2, pmix_pnet_base_framework. framework_output,

--- a/src/mca/psec/native/psec_native.c
+++ b/src/mca/psec/native/psec_native.c
@@ -158,8 +158,8 @@ static pmix_status_t validate_cred(struct pmix_peer_t *peer,
 #endif
     socklen_t crlen = sizeof (ucred);
 #endif
-    uid_t euid;
-    gid_t egid;
+    uid_t euid = -1;
+    gid_t egid = -1;
     char *ptr;
     size_t ln;
     bool takeus;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -568,7 +568,7 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
     pmix_rank_info_t *iptr;
     pmix_proc_t proc;
     pmix_cb_t cb;
-    pmix_peer_t *peer;
+    pmix_peer_t *peer = NULL;
     pmix_byte_object_t bo;
     char *data = NULL;
     size_t sz = 0;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -289,8 +289,8 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_kval_t *kptr;
     pmix_status_t rc;
     char hostname[PMIX_MAX_NSLEN];
-    char *evar, *nspace;
-    pmix_rank_t rank;
+    char *evar, *nspace = NULL;
+    pmix_rank_t rank = PMIX_RANK_UNDEF;
     bool gdsfound, do_not_connect = false;
     bool nspace_given = false;
     bool nspace_in_enviro = false;


### PR DESCRIPTION
Don't try to allocate ports if ports_per_node is 0.
Silence various warnings, some of which don't make sense

Signed-off-by: Ralph Castain <rhc@open-mpi.org>