### PR TITLE
Fix typo in configure so include files are found

### DIFF
--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -76,7 +76,7 @@ AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
                               [pmix_check_opamgt_happy="no"])],
           [pmix_check_opamgt_happy="no"])
 
-    pnet_opa_CLFAGS="$pnet_opa_CFLAGS $pnet_opamgt_CFLAGS"
+    pnet_opa_CFLAGS="$pnet_opa_CFLAGS $pnet_opamgt_CFLAGS"
     pnet_opa_CPPFLAGS="$pnet_opa_CPPFLAGS $pnet_opamgt_CPPFLAGS"
     pnet_opa_LDFLAGS="$pnet_opa_LDFLAGS $pnet_opamgt_LDFLAGS"
     pnet_opa_LIBS="$pnet_opa_LIBS $pnet_opamgt_LIBS"

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -27,7 +27,6 @@
 #include <time.h>
 
 #if PMIX_WANT_OPAMGT
-#include <opamgt/iba/ib_sa_records.h>
 #include <opamgt/opamgt.h>
 #include <opamgt/opamgt_sa.h>
 #endif


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>