### PR TITLE
Unlock thread prior to object release

### DIFF
--- a/src/mca/plog/base/plog_base_stubs.c
+++ b/src/mca/plog/base/plog_base_stubs.c
@@ -59,7 +59,9 @@ static void localcbfunc(pmix_status_t status, void *cbdata)
         if (NULL != mycount->cbfunc) {
             mycount->cbfunc(mycount->status, mycount->cbdata);
         }
+        PMIX_RELEASE_THREAD(&mycount->lock);
         PMIX_RELEASE(mycount);
+        return;
     }
     PMIX_RELEASE_THREAD(&mycount->lock);
 }


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>