### PR TITLE
Use srcdir instead of top_srcdir

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1155,7 +1155,7 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
     fi
 
     AC_MSG_CHECKING([if Cython package installed])
-    have_cython=`$top_srcdir/config/pmix_check_cython.py 2> /dev/null`
+    have_cython=`$srcdir/config/pmix_check_cython.py 2> /dev/null`
     if test "$have_cython" = "0"; then
         AC_MSG_RESULT([yes])
     else


### PR DESCRIPTION
Fix VPATH builds when looking for Cython

Signed-off-by: Ralph Castain <rhc@open-mpi.org>