### PR TITLE
Ensure adequate space in the notification chain object

### DIFF
--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -391,11 +391,11 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
             chain->status = ncd->status;
             (void)strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             chain->source.rank = pmix_globals.myid.rank;
-            /* we already left space for evhandler name plus
-             * a callback object when we cached the notification */
-            chain->ninfo = ncd->ninfo;
-            PMIX_INFO_CREATE(chain->info, chain->ninfo);
+            /* we always leave space for event hdlr name and a callback object */
+            chain->nallocated = ncd->ninfo + 2;
+            PMIX_INFO_CREATE(chain->info, chain->nallocated);
             if (0 < cd->ninfo) {
+                chain->ninfo = ncd->ninfo;
                 /* need to copy the info */
                 for (n=0; n < ncd->ninfo; n++) {
                     PMIX_INFO_XFER(&chain->info[n], &ncd->info[n]);


### PR DESCRIPTION
Resolve a sporadic memory corruption problem reported in https://github.com/open-mpi/ompi/issues/5336.

Thanks to @ggouaillardet for tracking it down!

Signed-off-by: Ralph Castain <rhc@open-mpi.org>