### PR TITLE
Provide a numeric version definition

### DIFF
--- a/include/pmix_version.h.in
+++ b/include/pmix_version.h.in
@@ -2,6 +2,7 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -17,4 +18,7 @@
 #define PMIX_VERSION_MAJOR @pmixmajor@
 #define PMIX_VERSION_MINOR @pmixminor@
 #define PMIX_VERSION_RELEASE @pmixrelease@
+
+#define PMIX_NUMERIC_VERSION 0x00020103
+
 #endif


### PR DESCRIPTION
Enable easier check of full version number. The numeric fields are:

bytes 0-3: major version number (hex)

bytes 4-5: minor version number (hex)

bytes 6-7: release number (hex)

Signed-off-by: Ralph Castain <rhc@open-mpi.org>