### PR TITLE
Complete initial pass thru prototype Py bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,8 @@ config/py-compile
 bindings/python/pmix.c
 bindings/python/*.so
 bindings/python/build/
+bindings/python/pmix_constants.pxd
+bindings/python/pmix_constants.pxi
 
 examples/alloc
 examples/client

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -26,6 +26,7 @@ helpers = setup.py client.py server.py cpmix.pxd pmix.pyx
 if WANT_PYTHON_BINDINGS
 
 install-exec-local: $(helpers)
+	$(PYTHON) $(top_srcdir)/bindings/python/construct.py --src="$(top_builddir)/include"
 	$(PYTHON) $(top_srcdir)/bindings/python/setup.py build_ext --include-dirs="$(top_builddir)/include" --library-dirs="$(DESTDIR)$(libdir)" --user
 	$(PYTHON) $(top_srcdir)/bindings/python/setup.py install --prefix="$(DESTDIR)$(prefix)"
 

--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -3,16 +3,18 @@
 from pmix import *
 
 def main():
-    try:
-        foo = PMIxClient()
-    except:
-        print("FAILED TO CREATE CLIENT")
+    foo = PMIxClient()
+    print("Testing PMIx ", foo.get_version())
+    info = {PMIX_PROGRAMMING_MODEL: 'TEST', PMIX_MODEL_LIBRARY_NAME: "PMIX"}
+    my_result = foo.init(info)
+    print("Init result ", my_result)
+    if 0 != my_result:
+        print("FAILED TO INIT")
         exit(1)
-    print("MYVERS ", foo.get_version())
-    print("INITD ", foo.initialized())
-    dict = {'FOOBAR': 'VAR', 'BLAST': 7}
-    my_result = foo.init(dict)
-    print("MYRES ", my_result)
+    # try getting something
 
+    # finalize
+    info = {}
+    foo.finalize(info)
 if __name__ == '__main__':
     main()

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -1,0 +1,480 @@
+#!/opt/local/bin/python
+
+import os, os.path, sys, shutil, signal
+from optparse import OptionParser, OptionGroup
+
+takeconst = False
+takeapis = False
+takedtypes = False
+
+def signal_handler(signal, frame):
+    print("Ctrl-C received")
+    sys.exit(0)
+
+def harvest_constants(options, src, constants, definitions):
+    global takeconst, takeapis, takedtypes
+    path = os.path.join(options.src, src)
+    # open the file
+    try:
+        inputfile = open(path, "r")
+    except:
+        print("File", path, "could not be opened")
+        return
+    # read the file - these files aren't too large
+    # so ingest the whole thing at one gulp
+    lines = inputfile.readlines()
+    # cache the string constants, numeric, and typedef constants
+    # in separate lists
+    strconsts = []
+    strconstlen = 0
+    errconsts = []
+    nconsts = []
+    nconstlen = 0
+    typedefs = []
+    apis = []
+    # loop over the lines
+    for n in range(len(lines)):
+        line = lines[n]
+        # remove white space at front and back
+        myline = line.strip()
+        # remove comment lines
+        if "/*" in myline or "*/" in myline or myline.startswith("*"):
+            n += 1
+            continue
+        # if the line starts with #define, then we want it
+        if takeconst and myline.startswith("#define"):
+            value = myline[8:]
+            # skip some well-known unwanted values
+            if value.startswith("PMIx"):
+                continue
+            if value.startswith("PMIX_HAVE_VISIB"):
+                continue
+            tokens = value.split()
+            if len(tokens) >= 2:
+                if tokens[1][0] == '"':
+                    strconsts.append(tokens[0])
+                    if len(tokens[0]) > strconstlen:
+                        strconstlen = len(tokens[0])
+                elif "PMIX_ERR_" in value:
+                    # numerical constant that looks just like a
+                    # string constant - i.e., PMIX_ERR_FOO...1
+                    # we output them in a separate section, but
+                    # consider them string constants
+                    errconsts.append(tokens[0])
+                    if len(tokens[0]) > strconstlen:
+                        strconstlen = len(tokens[0])
+                elif tokens[1].isdigit() or tokens[1].startswith("UINT") or tokens[1].startswith("0x"):
+                    # values that were defined as UINT32_MAX need to be converted
+                    # to hex values as Python otherwise gets confused
+                    if tokens[1] == "UINT32_MAX":
+                        tokens[1] = "0xffffffff"
+                    elif "UINT32_MAX-1" in tokens[1]:
+                        tokens[1] = "0xfffffffe"
+                    elif "UINT32_MAX-2" in tokens[1]:
+                        tokens[1] = "0xfffffffd"
+                    elif "UINT32_MAX-3" in tokens[1]:
+                        tokens[1] = "0xfffffffc"
+                    elif "UINT8_MAX" in tokens[1]:
+                        tokens[1] = "0xff"
+                    nconsts.append([tokens[0], tokens[1]])
+                    if len(tokens[0]) > nconstlen:
+                        nconstlen = len(tokens[0])
+        elif takeapis and myline.startswith("PMIX_EXPORT"):
+            value = myline[12:].strip()
+            # this is the name of an API - these
+            # are frequently multi-line, so collect
+            # all of them
+            if ";" in value:
+                value = value[:-1]
+                # check for bool type - must be converted to bint
+                if "bool" in value:
+                    value.replace("bool ", "bint ")
+                # a single-line API might have a "void" arg
+                # Python doesn't accept "void" as an arg, so
+                # we have to "snip" it out
+                start = value.find("(") + 1
+                end = value.find(")")
+                snip = value[start:end]
+                if snip == "void":
+                    value = value[0:start] + value[end:]
+                newapi = [value]
+                apis.append(newapi)
+            else:
+                newapi = [value]
+                apirunning = True
+                while apirunning:
+                    n += 1
+                    value = lines[n].strip()
+                    # check for bool type - must be converted to bint
+                    if "bool" in value:
+                        value.replace("bool ", "bint ")
+                    if ";" in value:
+                        apirunning = False
+                        value = value[:-1]
+                    newapi.append(value)
+                apis.append(newapi)
+        elif takedtypes and myline.startswith("typedef"):
+            # there are three types of typedef's in PMIx:
+            #
+            # 1. simple one-line typedef - e.g., "typedef int foo"
+            #
+            # 2. multi-line struct types
+            #
+            # 3. function definitions - by PMIx convention, these
+            #    always have an "fn_t" in the name
+            #
+            # Start by addressing the first - detectable by
+            # having a semi-colon at the end of the line and
+            # no "fn_t" or "cbfunc_t" in it
+            if ";" in myline and not "fn_t" in myline and not "cbfunc_t" in myline:
+                value = myline[:-1]
+                # check for bool type - must be converted to bint
+                if "bool" in value:
+                    value.replace("bool ", "bint ")
+                # check for pre-declaration statements of form
+                # typedef struct foo foo
+                ck = value.split()
+                if len(ck) == 4 and ck[1] == "struct" and ck[2] == ck[3]:
+                    n += 1
+                    continue
+                else:
+                    typedefs.append([value])
+            # now check the third option by looking for
+            # "fn_t" or "cbfunc_t" in it
+            elif "fn_t" in myline or "cbfunc_t" in myline:
+                if ";" in myline:
+                    # this is a one-line function definition
+                    value = myline[:-1]
+                    # check for bool type - must be converted to bint
+                    if "bool" in value:
+                        value.replace("bool ", "bint ")
+                    typedefs.append([value])
+                else:
+                    # this is a multi-line function definition
+                    # check for bool type - must be converted to bint
+                    if "bool" in myline:
+                        myline.replace("bool ", "bint ")
+                    newdef = [myline]
+                    defrunning = True
+                    while defrunning:
+                        n += 1
+                        value = lines[n].strip()
+                        # check for bool type - must be converted to bint
+                        if "bool" in value:
+                            value.replace("bool ", "bint ")
+                        if ";" in value:
+                            defrunning = False
+                            value = value[:-1]
+                        newdef.append(value)
+                    typedefs.append(newdef)
+            # must be a multi-line struct type definition
+            # we capture these in the typedef list
+            # so we output their type definition
+            else:
+                # check for pre-declaration statements of form
+                # typedef struct foo foo
+                value = myline
+                ck = value.split()
+                if len(ck) == 4 and ck[1] == "struct" and ck[2] == ck[3]:
+                    n += 1
+                    continue
+                else:
+                    newdef = []
+                    n += 1
+                    value = lines[n].strip()
+                    nbrk = 1
+                    while nbrk > 0:
+                        # avoid comments
+                        if "/*" in value or "*/" in value or value.startswith("*"):
+                            n += 1
+                            value = lines[n].strip()
+                            continue
+                        if "}" in value:
+                            nbrk -= 1
+                            if nbrk > 0:
+                                n += 1
+                                value = lines[n].strip()
+                            continue
+                        if  "union" in value:
+                            # we have to create another definition that contains
+                            # just the union and then add that back into the
+                            # current typedef
+                            uniondef = []
+                            n += 1
+                            value = lines[n].strip()
+                            while "}" not in value:
+                                # terminate at the semi-colon
+                                idx = value.rfind(';')
+                                value = "    " + value[:idx]
+                                # check for bool type - must be converted to bint
+                                if "bool" in value:
+                                    value = value.replace("bool ", "bint ")
+                                elif "struct timeval " in value:
+                                    value = value.replace("struct timeval", "timeval")
+                                # add it to the union def
+                                uniondef.append(value)
+                                n += 1
+                                value = lines[n].strip()
+                            # terminate at the semi-colon
+                            idx = value.rfind(';')
+                            value = value[:idx]
+                            # extract the name of the union
+                            idx = value.rfind(' ')
+                            value = value[idx+1:]
+                            # save this name
+                            lowname = value
+                            # capitalize the first letter
+                            value = value.title()
+                            # create the union definition - the output
+                            # routine will prepend a 'c'
+                            myvalue = "def union " + value + ":"
+                            uniondef.insert(0, myvalue)
+                            typedefs.append(uniondef)
+                            # add the union to the struct
+                            value = "    " + value + " " + lowname
+                            newdef.append(value)
+                            nbrk -= 1
+                            n += 1
+                            value = lines[n].strip()
+                            continue
+                        # terminate at the semi-colon
+                        idx = value.rfind(';')
+                        value = "    " + value[:idx]
+                        # check for bool type - must be converted to bint
+                        if "bool" in value:
+                            value = value.replace("bool ", "bint ")
+                        elif "struct timeval " in value:
+                            value = value.replace("struct timeval", "timeval")
+                        # we don't want any dimensions - if given, convert
+                        # to the corresponding value
+                        idx = value.find('[')
+                        if idx >= 0:
+                            # find the end of the dimension
+                            dim = value.rfind(']')
+                            dimstr = value[idx+1:dim]
+                            # have to do this manually
+                            if "MAX_KEYLEN" in dimstr:
+                                value = value[:idx] + "[512]" + value[dim+1:]
+                            elif "MAX_NSLEN" in dimstr:
+                                value = value[:idx] + "[256]" + value[dim+1:]
+                            else:
+                                print("BAD DIMENSION " + dimstr)
+                                exit(1)
+                        newdef.append(value)
+                        n += 1
+                        value = lines[n].strip()
+                    # we need to extract the type name
+                    value = "typedef struct " + value[2:]
+                    value = value[:-1] + ":"
+                    newdef.insert(0, value)
+                    typedefs.append(newdef)
+    # only write the data sources once per file
+    defsrc = False
+    constsrc = False
+
+    # start by pretty-printing the string constants
+    # prepended with an underscore to avoid conflicts
+    # with the Python version of the name
+    if takeconst and len(strconsts) > 0:
+        if not defsrc:
+            definitions.write("cdef extern from \"" + src + "\":\n")
+            defsrc = True
+        if not constsrc:
+            constants.write("# " + src + "\n")
+            constsrc = True
+        definitions.write("\n    # STRING CONSTANTS\n")
+        for const in strconsts:
+            defname = "_" + const
+            definitions.write("    cdef const char* " + defname)
+            for i in range (4 + strconstlen - len(const)):
+                definitions.write(" ")
+            definitions.write("\"" + const + "\"\n")
+            # now output it into the constants file
+            constants.write(const)
+            for i in range (4 + strconstlen - len(const)):
+                constants.write(" ")
+            constants.write("= " + defname + "\n")
+        # add some space
+        definitions.write("\n")
+        constants.write("\n")
+
+    if takeconst and len(errconsts) > 0:
+        if not defsrc:
+            definitions.write("cdef extern from \"" + src + "\":\n")
+            defsrc = True
+        if not constsrc:
+            constants.write("# " + src + "\n")
+            constsrc = True
+        definitions.write("\n    # ERROR CONSTANTS\n")
+        for const in errconsts:
+            defname = "_" + const
+            definitions.write("    cdef int " + defname)
+            for i in range (4 + strconstlen - len(const)):
+                definitions.write(" ")
+            definitions.write("\"" + const + "\"\n")
+            # now output it into the constants file
+            constants.write(const)
+            for i in range (4 + strconstlen - len(const)):
+                constants.write(" ")
+            constants.write("= " + defname + "\n")
+        # add some space
+        definitions.write("\n")
+        constants.write("\n")
+
+    if takeconst and len(nconsts) > 0:
+        if not constsrc:
+            constants.write("# " + src + "\n")
+            constsrc = True
+        # pretty-print the numeric constants
+        for num in nconsts:
+            constants.write(num[0])
+            for i in range (4 + strconstlen - len(num[0])):
+                constants.write(" ")
+            constants.write("= " + num[1] + "\n")
+        # add some space
+        constants.write("\n")
+
+    # pretty-print any typedefs
+    if takedtypes and len(typedefs) > 0:
+        if not defsrc:
+            definitions.write("cdef extern from \"" + src + "\":\n")
+            defsrc = True
+        definitions.write("\n    # TYPEDEFS\n")
+        for t in typedefs:
+            if len(t) > 1:
+                definitions.write("\n")
+            definitions.write("    c" + t[0] + "\n")
+            if len(t) > 1:
+                # find the 2nd opening paren
+                idx = t[0].find("(") + 1
+                idx = t[0].find("(", idx) + 2
+                for n in range(1, len(t)):
+                    definitions.write("    ")
+                    for m in range(idx):
+                        definitions.write(" ")
+                    definitions.write(t[n] + "\n")
+        # add some space
+        definitions.write("\n")
+
+    # pretty-print any APIs
+    if takeapis and len(apis) > 0:
+        if not defsrc:
+            definitions.write("cdef extern from \"" + src + "\":\n")
+            defsrc = True
+        definitions.write("\n    # APIS\n")
+        for api in apis:
+            definitions.write("    " + api[0] + "\n")
+            if len(api) > 1:
+                # find the opening paren
+                idx = api[0].find("(") + 1
+                for n in range(1, len(api)):
+                    definitions.write("    ")
+                    for m in range(idx):
+                        definitions.write(" ")
+                    definitions.write(api[n] + "\n")
+            definitions.write("\n")
+    return
+
+def main():
+    global takeconst, takeapis, takedtypes
+    signal.signal(signal.SIGINT, signal_handler)
+
+    parser = OptionParser("usage: %prog [options]")
+    debugGroup = OptionGroup(parser, "Debug Options")
+    debugGroup.add_option("--debug",
+                          action="store_true", dest="debug", default=False,
+                          help="Output lots of debug messages while processing")
+    debugGroup.add_option("--dryrun",
+                          action="store_true", dest="dryrun", default=False,
+                          help="Show commands, but do not execute them")
+    parser.add_option_group(debugGroup)
+
+    execGroup = OptionGroup(parser, "Execution Options")
+    execGroup.add_option("--src", dest="src",
+                         help="The directory where the PMIx header files will be found")
+    execGroup.add_option("--constants",
+                         action="store_true", dest="constants", default=False,
+                         help="Translate constants")
+    execGroup.add_option("--apis",
+                         action="store_true", dest="apis", default=False,
+                         help="Translate APIs")
+    execGroup.add_option("--datatypes",
+                         action="store_true", dest="datatypes", default=False,
+                         help="Translate datatypes")
+    parser.add_option_group(execGroup)
+
+    (options, args) = parser.parse_args()
+
+    if not options.constants and not options.apis and not options.datatypes:
+        takeconst = True
+        takeapis = True
+        takedtypes = True
+
+    if options.constants:
+        takeconst = True
+    if options.apis:
+        takeapis = True
+    if options.datatypes:
+        takedtypes = True
+
+    if options.dryrun or options.debug:
+        debug = True
+    else:
+        debug = False
+
+    if options.src:
+        # see if the source directory exists
+        if not os.path.exists(options.src):
+            print("SOURCE directory",options.src,"does not exist")
+            sys.exit(1)
+
+    if options.dryrun:
+        constants = sys.stdout
+        definitions = sys.stdout
+    else:
+        # open the .pxd file for the definitions
+        # if the output file exists, remove it
+        if os.path.exists("pmix_constants.pxd"):
+            if debug:
+                print("Remove pmix_constants.pxd")
+            if not options.dryrun:
+                os.remove("pmix_constants.pxd")
+        elif debug:
+            print("File pmix_constants.pxd not found")
+        definitions = open("pmix_constants.pxd", "w+")
+        # add the necessary imports
+        definitions.write("from posix.types cimport *\n")
+        definitions.write("from posix.time cimport *\n")
+        definitions.write("from libc.stdint cimport *\n\n")
+
+        # open the .pxi file for the Python-level constants
+        if os.path.exists("pmix_constants.pxi"):
+            if debug:
+                print("Remove pmix_constants.pxi")
+            if not options.dryrun:
+                os.remove("pmix_constants.pxi")
+        elif debug:
+            print("File pmix_constants.pxi not found")
+        constants = open("pmix_constants.pxi", "w+")
+        # add the necessary import and provide a little space for neatness
+        constants.write("from pmix_constants cimport *\n\n")
+
+    # scan across the header files in the src directory
+    # looking for constants and typedefs
+    # add some space
+    harvest_constants(options, "pmix_common.h", constants, definitions)
+    definitions.write("\n\n")
+    constants.write("\n\n")
+    harvest_constants(options, "pmix.h", constants, definitions)
+    # add some space
+    definitions.write("\n\n")
+    constants.write("\n\n")
+    harvest_constants(options, "pmix_server.h", constants, definitions)
+    # add some space
+    definitions.write("\n\n")
+    constants.write("\n\n")
+    harvest_constants(options, "pmix_tool.h", constants, definitions)
+
+if __name__ == '__main__':
+    main()
+

--- a/bindings/python/cpmix.pxd
+++ b/bindings/python/cpmix.pxd
@@ -1,50 +1,12 @@
-from posix.types cimport pid_t, uid_t, gid_t
-from posix.time cimport timeval
-
-cdef extern from "time.h" nogil:
-    ctypedef int time_t
-    time_t time(time_t*)
-
-cdef extern from "<stdint.h>" nogil:
-
-    # 7.18.1 Integer types
-    # 7.18.1.1 Exact-width integer types
-    ctypedef   signed char  int8_t
-    ctypedef   signed short int16_t
-    ctypedef   signed int   int32_t
-    ctypedef   signed long  int64_t
-    ctypedef unsigned char  uint8_t
-    ctypedef unsigned short uint16_t
-    ctypedef unsigned int   uint32_t
-    ctypedef unsigned long long uint64_t
-    # 7.18.1.4 Integer types capable of holding object pointers
-    ctypedef ssize_t intptr_t
-    ctypedef  size_t uintptr_t
-
-    # 7.18.2 Limits of specified-width integer types
-    # 7.18.2.1 Limits of exact-width integer types
-    int8_t   INT8_MIN
-    int16_t  INT16_MIN
-    int32_t  INT32_MIN
-    int64_t  INT64_MIN
-    int8_t   INT8_MAX
-    int16_t  INT16_MAX
-    int32_t  INT32_MAX
-    int64_t  INT64_MAX
-    uint8_t  UINT8_MAX
-    uint16_t UINT16_MAX
-    uint32_t UINT32_MAX
-    uint64_t UINT64_MAX
-    # size_t
-    size_t SIZE_MAX
+from posix.types cimport *
+from posix.time cimport *
+from libc.stdint cimport *
 
 #file: cpmix.pxd
 
 cdef extern from "pmix_common.h":
-    cdef int PMIX_MAX_KEYLEN "PMIX_MAX_KEYLEN"
-    cdef int PMIX_MAX_NSLEN "PMIX_MAX_NSLEN"
-    const int CPMIX_MAX_NSLEN = 256
-    const int CPMIX_MAX_KEYLEN = 512
+    cdef int _PMIX_MAX_KEYLEN "PMIX_MAX_KEYLEN"
+    cdef int _PMIX_MAX_NSLEN "PMIX_MAX_NSLEN"
 
     ctypedef unsigned int pmix_rank_t
 
@@ -54,220 +16,220 @@ cdef extern from "pmix_common.h":
     cdef pmix_rank_t PMIX_RANK_INVALID "PMIX_RANK_INVALID"
 
     # Attributes
-    cdef const char* PMIX_EVENT_BASE "PMIX_EVENT_BASE"
-    cdef const char* PMIX_SERVER_TOOL_SUPPORT "PMIX_SERVER_TOOL_SUPPORT"
-    cdef const char* PMIX_SERVER_REMOTE_CONNECTIONS "PMIX_SERVER_REMOTE_CONNECTIONS"
-    cdef const char* PMIX_SERVER_SYSTEM_SUPPORT "PMIX_SERVER_SYSTEM_SUPPORT"
-    cdef const char* PMIX_SERVER_TMPDIR "PMIX_SERVER_TMPDIR"
-    cdef const char* PMIX_SYSTEM_TMPDIR "PMIX_SYSTEM_TMPDIR"
-    cdef const char* PMIX_SERVER_ENABLE_MONITORING "PMIX_SERVER_ENABLE_MONITORING"
-    cdef const char* PMIX_SERVER_NSPACE "PMIX_SERVER_NSPACE"
-    cdef const char* PMIX_SERVER_RANK "PMIX_SERVER_RANK"
-    cdef const char* PMIX_SERVER_GATEWAY "PMIX_SERVER_GATEWAY"
+    cdef const char* PMIX_EVENT_BASE_DEFINE "PMIX_EVENT_BASE"
+    cdef const char* PMIX_SERVER_TOOL_SUPPORT_DEFINE "PMIX_SERVER_TOOL_SUPPORT"
+    cdef const char* PMIX_SERVER_REMOTE_CONNECTIONS_DEFINE "PMIX_SERVER_REMOTE_CONNECTIONS"
+    cdef const char* PMIX_SERVER_SYSTEM_SUPPORT_DEFINE "PMIX_SERVER_SYSTEM_SUPPORT"
+    cdef const char* PMIX_SERVER_TMPDIR_DEFINE "PMIX_SERVER_TMPDIR"
+    cdef const char* PMIX_SYSTEM_TMPDIR_DEFINE "PMIX_SYSTEM_TMPDIR"
+    cdef const char* PMIX_SERVER_ENABLE_MONITORING_DEFINE "PMIX_SERVER_ENABLE_MONITORING"
+    cdef const char* PMIX_SERVER_NSPACE_DEFINE "PMIX_SERVER_NSPACE"
+    cdef const char* PMIX_SERVER_RANK_DEFINE "PMIX_SERVER_RANK"
+    cdef const char* PMIX_SERVER_GATEWAY_DEFINE "PMIX_SERVER_GATEWAY"
 
-    cdef const char* PMIX_TOOL_NSPACE "PMIX_TOOL_NSPACE"
-    cdef const char* PMIX_TOOL_RANK "PMIX_TOOL_RANK"
-    cdef const char* PMIX_SERVER_PIDINFO "PMIX_SERVER_PIDINFO"
-    cdef const char* PMIX_CONNECT_TO_SYSTEM "PMIX_CONNECT_TO_SYSTEM"
-    cdef const char* PMIX_CONNECT_SYSTEM_FIRST "PMIX_CONNECT_SYSTEM_FIRST"
-    cdef const char* PMIX_SERVER_URI "PMIX_SERVER_URI"
-    cdef const char* PMIX_SERVER_HOSTNAME "PMIX_SERVER_HOSTNAME"
-    cdef const char* PMIX_CONNECT_MAX_RETRIES "PMIX_CONNECT_MAX_RETRIES"
-    cdef const char* PMIX_CONNECT_RETRY_DELAY "PMIX_CONNECT_RETRY_DELAY"
-    cdef const char* PMIX_TOOL_DO_NOT_CONNECT "PMIX_TOOL_DO_NOT_CONNECT"
-    cdef const char* PMIX_RECONNECT_SERVER "PMIX_RECONNECT_SERVER"
-    cdef const char* PMIX_LAUNCHER "PMIX_LAUNCHER"
+    cdef const char* PMIX_TOOL_NSPACE_DEFINE "PMIX_TOOL_NSPACE"
+    cdef const char* PMIX_TOOL_RANK_DEFINE "PMIX_TOOL_RANK"
+    cdef const char* PMIX_SERVER_PIDINFO_DEFINE "PMIX_SERVER_PIDINFO"
+    cdef const char* PMIX_CONNECT_TO_SYSTEM_DEFINE "PMIX_CONNECT_TO_SYSTEM"
+    cdef const char* PMIX_CONNECT_SYSTEM_FIRST_DEFINE "PMIX_CONNECT_SYSTEM_FIRST"
+    cdef const char* PMIX_SERVER_URI_DEFINE "PMIX_SERVER_URI"
+    cdef const char* PMIX_SERVER_HOSTNAME_DEFINE "PMIX_SERVER_HOSTNAME"
+    cdef const char* PMIX_CONNECT_MAX_RETRIES_DEFINE "PMIX_CONNECT_MAX_RETRIES"
+    cdef const char* PMIX_CONNECT_RETRY_DELAY_DEFINE "PMIX_CONNECT_RETRY_DELAY"
+    cdef const char* PMIX_TOOL_DO_NOT_CONNECT_DEFINE "PMIX_TOOL_DO_NOT_CONNECT"
+    cdef const char* PMIX_RECONNECT_SERVER_DEFINE "PMIX_RECONNECT_SERVER"
+    cdef const char* PMIX_LAUNCHER_DEFINE "PMIX_LAUNCHER"
 
-    cdef const char* PMIX_USERID "PMIX_USERID"
-    cdef const char* PMIX_GRPID "PMIX_GRPID"
-    cdef const char* PMIX_DSTPATH "PMIX_DSTPATH"
-    cdef const char* PMIX_VERSION_INFO "PMIX_VERSION_INFO"
-    cdef const char* PMIX_REQUESTOR_IS_TOOL "PMIX_REQUESTOR_IS_TOOL"
-    cdef const char* PMIX_REQUESTOR_IS_CLIENT "PMIX_REQUESTOR_IS_CLIENT"
+    cdef const char* PMIX_USERID_DEFINE "PMIX_USERID"
+    cdef const char* PMIX_GRPID_DEFINE "PMIX_GRPID"
+    cdef const char* PMIX_DSTPATH_DEFINE "PMIX_DSTPATH"
+    cdef const char* PMIX_VERSION_INFO_DEFINE "PMIX_VERSION_INFO"
+    cdef const char* PMIX_REQUESTOR_IS_TOOL_DEFINE "PMIX_REQUESTOR_IS_TOOL"
+    cdef const char* PMIX_REQUESTOR_IS_CLIENT_DEFINE "PMIX_REQUESTOR_IS_CLIENT"
 
-    cdef const char* PMIX_PROGRAMMING_MODEL "PMIX_PROGRAMMING_MODEL"
-    cdef const char* PMIX_MODEL_LIBRARY_NAME "PMIX_MODEL_LIBRARY_NAME"
-    cdef const char* PMIX_MODEL_LIBRARY_VERSION "PMIX_MODEL_LIBRARY_VERSION"
-    cdef const char* PMIX_THREADING_MODEL "PMIX_THREADING_MODEL"
-    cdef const char* PMIX_MODEL_NUM_THREADS "PMIX_MODEL_NUM_THREADS"
-    cdef const char* PMIX_MODEL_NUM_CPUS "PMIX_MODEL_NUM_CPUS"
-    cdef const char* PMIX_MODEL_CPU_TYPE "PMIX_MODEL_CPU_TYPE"
-    cdef const char* PMIX_MODEL_PHASE_NAME "PMIX_MODEL_PHASE_NAME"
-    cdef const char* PMIX_MODEL_PHASE_TYPE "PMIX_MODEL_PHASE_TYPE"
-    cdef const char* PMIX_MODEL_AFFINITY_POLICY "PMIX_MODEL_AFFINITY_POLICY"
+    cdef const char* PMIX_PROGRAMMING_MODEL_DEFINE "PMIX_PROGRAMMING_MODEL"
+    cdef const char* PMIX_MODEL_LIBRARY_NAME_DEFINE "PMIX_MODEL_LIBRARY_NAME"
+    cdef const char* PMIX_MODEL_LIBRARY_VERSION_DEFINE "PMIX_MODEL_LIBRARY_VERSION"
+    cdef const char* PMIX_THREADING_MODEL_DEFINE "PMIX_THREADING_MODEL"
+    cdef const char* PMIX_MODEL_NUM_THREADS_DEFINE "PMIX_MODEL_NUM_THREADS"
+    cdef const char* PMIX_MODEL_NUM_CPUS_DEFINE "PMIX_MODEL_NUM_CPUS"
+    cdef const char* PMIX_MODEL_CPU_TYPE_DEFINE "PMIX_MODEL_CPU_TYPE"
+    cdef const char* PMIX_MODEL_PHASE_NAME_DEFINE "PMIX_MODEL_PHASE_NAME"
+    cdef const char* PMIX_MODEL_PHASE_TYPE_DEFINE "PMIX_MODEL_PHASE_TYPE"
+    cdef const char* PMIX_MODEL_AFFINITY_POLICY_DEFINE "PMIX_MODEL_AFFINITY_POLICY"
 
-    cdef const char* PMIX_USOCK_DISABLE "PMIX_USOCK_DISABLE"
-    cdef const char* PMIX_SOCKET_MODE "PMIX_SOCKET_MODE"
-    cdef const char* PMIX_SINGLE_LISTENER "PMIX_SINGLE_LISTENER"
+    cdef const char* PMIX_USOCK_DISABLE_DEFINE "PMIX_USOCK_DISABLE"
+    cdef const char* PMIX_SOCKET_MODE_DEFINE "PMIX_SOCKET_MODE"
+    cdef const char* PMIX_SINGLE_LISTENER_DEFINE "PMIX_SINGLE_LISTENER"
 
-    cdef const char* PMIX_TCP_REPORT_URI "PMIX_TCP_REPORT_URI"
-    cdef const char* PMIX_TCP_URI "PMIX_TCP_URI"
-    cdef const char* PMIX_TCP_IF_INCLUDE "PMIX_TCP_IF_INCLUDE"
-    cdef const char* PMIX_TCP_IF_EXCLUDE "PMIX_TCP_IF_EXCLUDE"
-    cdef const char* PMIX_TCP_IPV4_PORT "PMIX_TCP_IPV4_PORT"
-    cdef const char* PMIX_TCP_IPV6_PORT "PMIX_TCP_IPV6_PORT"
-    cdef const char* PMIX_TCP_DISABLE_IPV4 "PMIX_TCP_DISABLE_IPV4"
-    cdef const char* PMIX_TCP_DISABLE_IPV6 "PMIX_TCP_DISABLE_IPV6"
+    cdef const char* PMIX_TCP_REPORT_URI_DEFINE "PMIX_TCP_REPORT_URI"
+    cdef const char* PMIX_TCP_URI_DEFINE "PMIX_TCP_URI"
+    cdef const char* PMIX_TCP_IF_INCLUDE_DEFINE "PMIX_TCP_IF_INCLUDE"
+    cdef const char* PMIX_TCP_IF_EXCLUDE_DEFINE "PMIX_TCP_IF_EXCLUDE"
+    cdef const char* PMIX_TCP_IPV4_PORT_DEFINE "PMIX_TCP_IPV4_PORT"
+    cdef const char* PMIX_TCP_IPV6_PORT_DEFINE "PMIX_TCP_IPV6_PORT"
+    cdef const char* PMIX_TCP_DISABLE_IPV4_DEFINE "PMIX_TCP_DISABLE_IPV4"
+    cdef const char* PMIX_TCP_DISABLE_IPV6_DEFINE "PMIX_TCP_DISABLE_IPV6"
 
-    cdef const char* PMIX_GDS_MODULE "PMIX_GDS_MODULE"
+    cdef const char* PMIX_GDS_MODULE_DEFINE "PMIX_GDS_MODULE"
 
-    cdef const char* PMIX_CPUSET "PMIX_CPUSET"
-    cdef const char* PMIX_CREDENTIAL "PMIX_CREDENTIAL"
-    cdef const char* PMIX_SPAWNED "PMIX_SPAWNED"
-    cdef const char* PMIX_ARCH "PMIX_ARCH"
+    cdef const char* PMIX_CPUSET_DEFINE "PMIX_CPUSET"
+    cdef const char* PMIX_CREDENTIAL_DEFINE "PMIX_CREDENTIAL"
+    cdef const char* PMIX_SPAWNED_DEFINE "PMIX_SPAWNED"
+    cdef const char* PMIX_ARCH_DEFINE "PMIX_ARCH"
 
-    cdef const char* PMIX_TMPDIR "PMIX_TMPDIR"
-    cdef const char* PMIX_NSDIR "PMIX_NSDIR"
-    cdef const char* PMIX_PROCDIR "PMIX_PROCDIR"
-    cdef const char* PMIX_TDIR_RMCLEAN "PMIX_TDIR_RMCLEAN"
+    cdef const char* PMIX_TMPDIR_DEFINE "PMIX_TMPDIR"
+    cdef const char* PMIX_NSDIR_DEFINE "PMIX_NSDIR"
+    cdef const char* PMIX_PROCDIR_DEFINE "PMIX_PROCDIR"
+    cdef const char* PMIX_TDIR_RMCLEAN_DEFINE "PMIX_TDIR_RMCLEAN"
 
-    cdef const char* PMIX_CLUSTER_ID "PMIX_CLUSTER_ID"
-    cdef const char* PMIX_PROCID "PMIX_PROCID"
-    cdef const char* PMIX_NSPACE "PMIX_NSPACE"
-    cdef const char* PMIX_JOBID "PMIX_JOBID"
-    cdef const char* PMIX_APPNUM "PMIX_APPNUM"
-    cdef const char* PMIX_RANK "PMIX_RANK"
-    cdef const char* PMIX_GLOBAL_RANK "PMIX_GLOBAL_RANK"
-    cdef const char* PMIX_APP_RANK "PMIX_APP_RANK"
-    cdef const char* PMIX_NPROC_OFFSET "PMIX_NPROC_OFFSET"
-    cdef const char* PMIX_LOCAL_RANK "PMIX_LOCAL_RANK"
-    cdef const char* PMIX_NODE_RANK "PMIX_NODE_RANK"
-    cdef const char* PMIX_LOCALLDR "PMIX_LOCALLDR"
-    cdef const char* PMIX_APPLDR "PMIX_APPLDR"
-    cdef const char* PMIX_PROC_PID "PMIX_PROC_PID"
-    cdef const char* PMIX_SESSION_ID "PMIX_SESSION_ID"
-    cdef const char* PMIX_NODE_LIST "PMIX_NODE_LIST"
-    cdef const char* PMIX_ALLOCATED_NODELIST "PMIX_ALLOCATED_NODELIST"
-    cdef const char* PMIX_HOSTNAME "PMIX_HOSTNAME"
-    cdef const char* PMIX_NODEID "PMIX_NODEID"
-    cdef const char* PMIX_LOCAL_PEERS "PMIX_LOCAL_PEERS"
-    cdef const char* PMIX_LOCAL_PROCS "PMIX_LOCAL_PROCS"
-    cdef const char* PMIX_LOCAL_CPUSETS "PMIX_LOCAL_CPUSETS"
-    cdef const char* PMIX_PROC_URI "PMIX_PROC_URI"
-    cdef const char* PMIX_LOCALITY "PMIX_LOCALITY"
-    cdef const char* PMIX_PARENT_ID "PMIX_PARENT_ID"
-    cdef const char* PMIX_EXIT_CODE "PMIX_EXIT_CODE"
+    cdef const char* PMIX_CLUSTER_ID_DEFINE "PMIX_CLUSTER_ID"
+    cdef const char* PMIX_PROCID_DEFINE "PMIX_PROCID"
+    cdef const char* PMIX_NSPACE_DEFINE "PMIX_NSPACE"
+    cdef const char* PMIX_JOBID_DEFINE "PMIX_JOBID"
+    cdef const char* PMIX_APPNUM_DEFINE "PMIX_APPNUM"
+    cdef const char* PMIX_RANK_DEFINE "PMIX_RANK"
+    cdef const char* PMIX_GLOBAL_RANK_DEFINE "PMIX_GLOBAL_RANK"
+    cdef const char* PMIX_APP_RANK_DEFINE "PMIX_APP_RANK"
+    cdef const char* PMIX_NPROC_OFFSET_DEFINE "PMIX_NPROC_OFFSET"
+    cdef const char* PMIX_LOCAL_RANK_DEFINE "PMIX_LOCAL_RANK"
+    cdef const char* PMIX_NODE_RANK_DEFINE "PMIX_NODE_RANK"
+    cdef const char* PMIX_LOCALLDR_DEFINE "PMIX_LOCALLDR"
+    cdef const char* PMIX_APPLDR_DEFINE "PMIX_APPLDR"
+    cdef const char* PMIX_PROC_PID_DEFINE "PMIX_PROC_PID"
+    cdef const char* PMIX_SESSION_ID_DEFINE "PMIX_SESSION_ID"
+    cdef const char* PMIX_NODE_LIST_DEFINE "PMIX_NODE_LIST"
+    cdef const char* PMIX_ALLOCATED_NODELIST_DEFINE "PMIX_ALLOCATED_NODELIST"
+    cdef const char* PMIX_HOSTNAME_DEFINE "PMIX_HOSTNAME"
+    cdef const char* PMIX_NODEID_DEFINE "PMIX_NODEID"
+    cdef const char* PMIX_LOCAL_PEERS_DEFINE "PMIX_LOCAL_PEERS"
+    cdef const char* PMIX_LOCAL_PROCS_DEFINE "PMIX_LOCAL_PROCS"
+    cdef const char* PMIX_LOCAL_CPUSETS_DEFINE "PMIX_LOCAL_CPUSETS"
+    cdef const char* PMIX_PROC_URI_DEFINE "PMIX_PROC_URI"
+    cdef const char* PMIX_LOCALITY_DEFINE "PMIX_LOCALITY"
+    cdef const char* PMIX_PARENT_ID_DEFINE "PMIX_PARENT_ID"
+    cdef const char* PMIX_EXIT_CODE_DEFINE "PMIX_EXIT_CODE"
 
-    cdef const char* PMIX_UNIV_SIZE "PMIX_UNIV_SIZE"
-    cdef const char* PMIX_JOB_SIZE "PMIX_JOB_SIZE"
-    cdef const char* PMIX_JOB_NUM_APPS "PMIX_JOB_NUM_APPS"
-    cdef const char* PMIX_APP_SIZE "PMIX_APP_SIZE"
-    cdef const char* PMIX_LOCAL_SIZE "PMIX_LOCAL_SIZE"
-    cdef const char* PMIX_NODE_SIZE "PMIX_NODE_SIZE"
-    cdef const char* PMIX_MAX_PROCS "PMIX_MAX_PROCS"
-    cdef const char* PMIX_NUM_NODES "PMIX_NUM_NODES"
+    cdef const char* PMIX_UNIV_SIZE_DEFINE "PMIX_UNIV_SIZE"
+    cdef const char* PMIX_JOB_SIZE_DEFINE "PMIX_JOB_SIZE"
+    cdef const char* PMIX_JOB_NUM_APPS_DEFINE "PMIX_JOB_NUM_APPS"
+    cdef const char* PMIX_APP_SIZE_DEFINE "PMIX_APP_SIZE"
+    cdef const char* PMIX_LOCAL_SIZE_DEFINE "PMIX_LOCAL_SIZE"
+    cdef const char* PMIX_NODE_SIZE_DEFINE "PMIX_NODE_SIZE"
+    cdef const char* PMIX_MAX_PROCS_DEFINE "PMIX_MAX_PROCS"
+    cdef const char* PMIX_NUM_NODES_DEFINE "PMIX_NUM_NODES"
 
-    cdef const char* PMIX_AVAIL_PHYS_MEMORY "PMIX_AVAIL_PHYS_MEMORY"
-    cdef const char* PMIX_DAEMON_MEMORY "PMIX_DAEMON_MEMORY"
-    cdef const char* PMIX_CLIENT_AVG_MEMORY "PMIX_CLIENT_AVG_MEMORY"
+    cdef const char* PMIX_AVAIL_PHYS_MEMORY_DEFINE "PMIX_AVAIL_PHYS_MEMORY"
+    cdef const char* PMIX_DAEMON_MEMORY_DEFINE "PMIX_DAEMON_MEMORY"
+    cdef const char* PMIX_CLIENT_AVG_MEMORY_DEFINE "PMIX_CLIENT_AVG_MEMORY"
 
-    cdef const char* PMIX_NET_TOPO "PMIX_NET_TOPO"
-    cdef const char* PMIX_LOCAL_TOPO "PMIX_LOCAL_TOPO"
-    cdef const char* PMIX_TOPOLOGY "PMIX_TOPOLOGY"
-    cdef const char* PMIX_TOPOLOGY_XML "PMIX_TOPOLOGY_XML"
-    cdef const char* PMIX_TOPOLOGY_FILE "PMIX_TOPOLOGY_FILE"
-    cdef const char* PMIX_TOPOLOGY_SIGNATURE "PMIX_TOPOLOGY_SIGNATURE"
-    cdef const char* PMIX_LOCALITY_STRING "PMIX_LOCALITY_STRING"
-    cdef const char* PMIX_HWLOC_SHMEM_ADDR "PMIX_HWLOC_SHMEM_ADDR"
-    cdef const char* PMIX_HWLOC_SHMEM_SIZE "PMIX_HWLOC_SHMEM_SIZE"
-    cdef const char* PMIX_HWLOC_SHMEM_FILE "PMIX_HWLOC_SHMEM_FILE"
-    cdef const char* PMIX_HWLOC_XML_V1 "PMIX_HWLOC_XML_V1"
-    cdef const char* PMIX_HWLOC_XML_V2 "PMIX_HWLOC_XML_V2"
-    cdef const char* PMIX_HWLOC_SHARE_TOPO "PMIX_HWLOC_SHARE_TOPO"
-    cdef const char* PMIX_HWLOC_HOLE_KIND "PMIX_HWLOC_HOLE_KIND"
+    cdef const char* PMIX_NET_TOPO_DEFINE "PMIX_NET_TOPO"
+    cdef const char* PMIX_LOCAL_TOPO_DEFINE "PMIX_LOCAL_TOPO"
+    cdef const char* PMIX_TOPOLOGY_DEFINE "PMIX_TOPOLOGY"
+    cdef const char* PMIX_TOPOLOGY_XML_DEFINE "PMIX_TOPOLOGY_XML"
+    cdef const char* PMIX_TOPOLOGY_FILE_DEFINE "PMIX_TOPOLOGY_FILE"
+    cdef const char* PMIX_TOPOLOGY_SIGNATURE_DEFINE "PMIX_TOPOLOGY_SIGNATURE"
+    cdef const char* PMIX_LOCALITY_STRING_DEFINE "PMIX_LOCALITY_STRING"
+    cdef const char* PMIX_HWLOC_SHMEM_ADDR_DEFINE "PMIX_HWLOC_SHMEM_ADDR"
+    cdef const char* PMIX_HWLOC_SHMEM_SIZE_DEFINE "PMIX_HWLOC_SHMEM_SIZE"
+    cdef const char* PMIX_HWLOC_SHMEM_FILE_DEFINE "PMIX_HWLOC_SHMEM_FILE"
+    cdef const char* PMIX_HWLOC_XML_V1_DEFINE "PMIX_HWLOC_XML_V1"
+    cdef const char* PMIX_HWLOC_XML_V2_DEFINE "PMIX_HWLOC_XML_V2"
+    cdef const char* PMIX_HWLOC_SHARE_TOPO_DEFINE "PMIX_HWLOC_SHARE_TOPO"
+    cdef const char* PMIX_HWLOC_HOLE_KIND_DEFINE "PMIX_HWLOC_HOLE_KIND"
 
-    cdef const char* PMIX_COLLECT_DATA "PMIX_COLLECT_DATA"
-    cdef const char* PMIX_TIMEOUT "PMIX_TIMEOUT"
-    cdef const char* PMIX_IMMEDIATE "PMIX_IMMEDIATE"
-    cdef const char* PMIX_WAIT "PMIX_WAIT"
-    cdef const char* PMIX_COLLECTIVE_ALGO "PMIX_COLLECTIVE_ALGO"
-    cdef const char* PMIX_COLLECTIVE_ALGO_REQD "PMIX_COLLECTIVE_ALGO_REQD"
-    cdef const char* PMIX_NOTIFY_COMPLETION "PMIX_NOTIFY_COMPLETION"
-    cdef const char* PMIX_RANGE "PMIX_RANGE"
-    cdef const char* PMIX_PERSISTENCE "PMIX_PERSISTENCE"
-    cdef const char* PMIX_DATA_SCOPE "PMIX_DATA_SCOPE"
-    cdef const char* PMIX_OPTIONAL "PMIX_OPTIONAL"
-    cdef const char* PMIX_EMBED_BARRIER "PMIX_EMBED_BARRIER"
-    cdef const char* PMIX_JOB_TERM_STATUS "PMIX_JOB_TERM_STATUS"
-    cdef const char* PMIX_PROC_STATE_STATUS "PMIX_PROC_STATE_STATUS"
+    cdef const char* PMIX_COLLECT_DATA_DEFINE "PMIX_COLLECT_DATA"
+    cdef const char* PMIX_TIMEOUT_DEFINE "PMIX_TIMEOUT"
+    cdef const char* PMIX_IMMEDIATE_DEFINE "PMIX_IMMEDIATE"
+    cdef const char* PMIX_WAIT_DEFINE "PMIX_WAIT"
+    cdef const char* PMIX_COLLECTIVE_ALGO_DEFINE "PMIX_COLLECTIVE_ALGO"
+    cdef const char* PMIX_COLLECTIVE_ALGO_REQD_DEFINE "PMIX_COLLECTIVE_ALGO_REQD"
+    cdef const char* PMIX_NOTIFY_COMPLETION_DEFINE "PMIX_NOTIFY_COMPLETION"
+    cdef const char* PMIX_RANGE_DEFINE "PMIX_RANGE"
+    cdef const char* PMIX_PERSISTENCE_DEFINE "PMIX_PERSISTENCE"
+    cdef const char* PMIX_DATA_SCOPE_DEFINE "PMIX_DATA_SCOPE"
+    cdef const char* PMIX_OPTIONAL_DEFINE "PMIX_OPTIONAL"
+    cdef const char* PMIX_EMBED_BARRIER_DEFINE "PMIX_EMBED_BARRIER"
+    cdef const char* PMIX_JOB_TERM_STATUS_DEFINE "PMIX_JOB_TERM_STATUS"
+    cdef const char* PMIX_PROC_STATE_STATUS_DEFINE "PMIX_PROC_STATE_STATUS"
 
     # internal attributes
-    cdef const char* PMIX_REGISTER_NODATA "PMIX_REGISTER_NODATA"
-    cdef const char* PMIX_PROC_DATA "PMIX_PROC_DATA"
-    cdef const char* PMIX_NODE_MAP "PMIX_NODE_MAP"
-    cdef const char* PMIX_PROC_MAP "PMIX_PROC_MAP"
-    cdef const char* PMIX_ANL_MAP "PMIX_ANL_MAP"
-    cdef const char* PMIX_APP_MAP_TYPE "PMIX_APP_MAP_TYPE"
-    cdef const char* PMIX_APP_MAP_REGEX "PMIX_APP_MAP_REGEX"
-    cdef const char* PMIX_PROC_BLOB "PMIX_PROC_BLOB"
-    cdef const char* PMIX_MAP_BLOB "PMIX_MAP_BLOB"
+    cdef const char* PMIX_REGISTER_NODATA_DEFINE "PMIX_REGISTER_NODATA"
+    cdef const char* PMIX_PROC_DATA_DEFINE "PMIX_PROC_DATA"
+    cdef const char* PMIX_NODE_MAP_DEFINE "PMIX_NODE_MAP"
+    cdef const char* PMIX_PROC_MAP_DEFINE "PMIX_PROC_MAP"
+    cdef const char* PMIX_ANL_MAP_DEFINE "PMIX_ANL_MAP"
+    cdef const char* PMIX_APP_MAP_TYPE_DEFINE "PMIX_APP_MAP_TYPE"
+    cdef const char* PMIX_APP_MAP_REGEX_DEFINE "PMIX_APP_MAP_REGEX"
+    cdef const char* PMIX_PROC_BLOB_DEFINE "PMIX_PROC_BLOB"
+    cdef const char* PMIX_MAP_BLOB_DEFINE "PMIX_MAP_BLOB"
 
     # event handler registration and notification
-    cdef const char* PMIX_EVENT_HDLR_NAME "PMIX_EVENT_HDLR_NAME"
-    cdef const char* PMIX_EVENT_JOB_LEVEL "PMIX_EVENT_JOB_LEVEL"
-    cdef const char* PMIX_EVENT_ENVIRO_LEVEL "PMIX_EVENT_ENVIRO_LEVEL"
-    cdef const char* PMIX_EVENT_HDLR_FIRST "PMIX_EVENT_HDLR_FIRST"
-    cdef const char* PMIX_EVENT_HDLR_LAST "PMIX_EVENT_HDLR_LAST"
-    cdef const char* PMIX_EVENT_HDLR_FIRST_IN_CATEGORY "PMIX_EVENT_HDLR_FIRST_IN_CATEGORY"
-    cdef const char* PMIX_EVENT_HDLR_LAST_IN_CATEGORY "PMIX_EVENT_HDLR_LAST_IN_CATEGORY"
-    cdef const char* PMIX_EVENT_HDLR_BEFORE "PMIX_EVENT_HDLR_BEFORE"
-    cdef const char* PMIX_EVENT_HDLR_AFTER "PMIX_EVENT_HDLR_AFTER"
-    cdef const char* PMIX_EVENT_HDLR_PREPEND "PMIX_EVENT_HDLR_PREPEND"
-    cdef const char* PMIX_EVENT_HDLR_APPEND "PMIX_EVENT_HDLR_APPEND"
-    cdef const char* PMIX_EVENT_CUSTOM_RANGE "PMIX_EVENT_CUSTOM_RANGE"
-    cdef const char* PMIX_EVENT_AFFECTED_PROC "PMIX_EVENT_AFFECTED_PROC"
-    cdef const char* PMIX_EVENT_AFFECTED_PROCS "PMIX_EVENT_AFFECTED_PROCS"
-    cdef const char* PMIX_EVENT_NON_DEFAULT "PMIX_EVENT_NON_DEFAULT"
-    cdef const char* PMIX_EVENT_RETURN_OBJECT "PMIX_EVENT_RETURN_OBJECT"
-    cdef const char* PMIX_EVENT_DO_NOT_CACHE "PMIX_EVENT_DO_NOT_CACHE"
-    cdef const char* PMIX_EVENT_SILENT_TERMINATION "PMIX_EVENT_SILENT_TERMINATION"
+    cdef const char* PMIX_EVENT_HDLR_NAME_DEFINE "PMIX_EVENT_HDLR_NAME"
+    cdef const char* PMIX_EVENT_JOB_LEVEL_DEFINE "PMIX_EVENT_JOB_LEVEL"
+    cdef const char* PMIX_EVENT_ENVIRO_LEVEL_DEFINE "PMIX_EVENT_ENVIRO_LEVEL"
+    cdef const char* PMIX_EVENT_HDLR_FIRST_DEFINE "PMIX_EVENT_HDLR_FIRST"
+    cdef const char* PMIX_EVENT_HDLR_LAST_DEFINE "PMIX_EVENT_HDLR_LAST"
+    cdef const char* PMIX_EVENT_HDLR_FIRST_IN_CATEGORY_DEFINE "PMIX_EVENT_HDLR_FIRST_IN_CATEGORY"
+    cdef const char* PMIX_EVENT_HDLR_LAST_IN_CATEGORY_DEFINE "PMIX_EVENT_HDLR_LAST_IN_CATEGORY"
+    cdef const char* PMIX_EVENT_HDLR_BEFORE_DEFINE "PMIX_EVENT_HDLR_BEFORE"
+    cdef const char* PMIX_EVENT_HDLR_AFTER_DEFINE "PMIX_EVENT_HDLR_AFTER"
+    cdef const char* PMIX_EVENT_HDLR_PREPEND_DEFINE "PMIX_EVENT_HDLR_PREPEND"
+    cdef const char* PMIX_EVENT_HDLR_APPEND_DEFINE "PMIX_EVENT_HDLR_APPEND"
+    cdef const char* PMIX_EVENT_CUSTOM_RANGE_DEFINE "PMIX_EVENT_CUSTOM_RANGE"
+    cdef const char* PMIX_EVENT_AFFECTED_PROC_DEFINE "PMIX_EVENT_AFFECTED_PROC"
+    cdef const char* PMIX_EVENT_AFFECTED_PROCS_DEFINE "PMIX_EVENT_AFFECTED_PROCS"
+    cdef const char* PMIX_EVENT_NON_DEFAULT_DEFINE "PMIX_EVENT_NON_DEFAULT"
+    cdef const char* PMIX_EVENT_RETURN_OBJECT_DEFINE "PMIX_EVENT_RETURN_OBJECT"
+    cdef const char* PMIX_EVENT_DO_NOT_CACHE_DEFINE "PMIX_EVENT_DO_NOT_CACHE"
+    cdef const char* PMIX_EVENT_SILENT_TERMINATION_DEFINE "PMIX_EVENT_SILENT_TERMINATION"
 
     # fault tolerance events
-    cdef const char* PMIX_EVENT_TERMINATE_SESSION "PMIX_EVENT_TERMINATE_SESSION"
-    cdef const char* PMIX_EVENT_TERMINATE_JOB "PMIX_EVENT_TERMINATE_JOB"
-    cdef const char* PMIX_EVENT_TERMINATE_NODE "PMIX_EVENT_TERMINATE_NODE"
-    cdef const char* PMIX_EVENT_TERMINATE_PROC "PMIX_EVENT_TERMINATE_PROC"
-    cdef const char* PMIX_EVENT_ACTION_TIMEOUT "PMIX_EVENT_ACTION_TIMEOUT"
-    cdef const char* PMIX_EVENT_NO_TERMINATION "PMIX_EVENT_NO_TERMINATION"
-    cdef const char* PMIX_EVENT_WANT_TERMINATION "PMIX_EVENT_WANT_TERMINATION"
+    cdef const char* PMIX_EVENT_TERMINATE_SESSION_DEFINE "PMIX_EVENT_TERMINATE_SESSION"
+    cdef const char* PMIX_EVENT_TERMINATE_JOB_DEFINE "PMIX_EVENT_TERMINATE_JOB"
+    cdef const char* PMIX_EVENT_TERMINATE_NODE_DEFINE "PMIX_EVENT_TERMINATE_NODE"
+    cdef const char* PMIX_EVENT_TERMINATE_PROC_DEFINE "PMIX_EVENT_TERMINATE_PROC"
+    cdef const char* PMIX_EVENT_ACTION_TIMEOUT_DEFINE "PMIX_EVENT_ACTION_TIMEOUT"
+    cdef const char* PMIX_EVENT_NO_TERMINATION_DEFINE "PMIX_EVENT_NO_TERMINATION"
+    cdef const char* PMIX_EVENT_WANT_TERMINATION_DEFINE "PMIX_EVENT_WANT_TERMINATION"
 
     # attributes used to describe "spawn" directives
-    cdef const char* PMIX_PERSONALITY "PMIX_PERSONALITY"
-    cdef const char* PMIX_HOST "PMIX_HOST"
-    cdef const char* PMIX_HOSTFILE "PMIX_HOSTFILE"
-    cdef const char* PMIX_ADD_HOST "PMIX_ADD_HOST"
-    cdef const char* PMIX_ADD_HOSTFILE "PMIX_ADD_HOSTFILE"
-    cdef const char* PMIX_PREFIX "PMIX_PREFIX"
-    cdef const char* PMIX_WDIR "PMIX_WDIR"
-    cdef const char* PMIX_MAPPER "PMIX_MAPPER"
-    cdef const char* PMIX_DISPLAY_MAP "PMIX_DISPLAY_MAP"
-    cdef const char* PMIX_PPR "PMIX_PPR"
-    cdef const char* PMIX_MAPBY "PMIX_MAPBY"
-    cdef const char* PMIX_RANKBY "PMIX_RANKBY"
-    cdef const char* PMIX_BINDTO "PMIX_BINDTO"
-    cdef const char* PMIX_PRELOAD_BIN "PMIX_PRELOAD_BIN"
-    cdef const char* PMIX_PRELOAD_FILES "PMIX_PRELOAD_FILES"
-    cdef const char* PMIX_NON_PMI "PMIX_NON_PMI"
-    cdef const char* PMIX_STDIN_TGT "PMIX_STDIN_TGT"
-    cdef const char* PMIX_DEBUGGER_DAEMONS "PMIX_DEBUGGER_DAEMONS"
-    cdef const char* PMIX_COSPAWN_APP "PMIX_COSPAWN_APP"
-    cdef const char* PMIX_SET_SESSION_CWD "PMIX_SET_SESSION_CWD"
-    cdef const char* PMIX_TAG_OUTPUT "PMIX_TAG_OUTPUT"
-    cdef const char* PMIX_TIMESTAMP_OUTPUT "PMIX_TIMESTAMP_OUTPUT"
-    cdef const char* PMIX_MERGE_STDERR_STDOUT "PMIX_MERGE_STDERR_STDOUT"
-    cdef const char* PMIX_OUTPUT_TO_FILE "PMIX_OUTPUT_TO_FILE"
-    cdef const char* PMIX_INDEX_ARGV "PMIX_INDEX_ARGV"
-    cdef const char* PMIX_CPUS_PER_PROC "PMIX_CPUS_PER_PROC"
-    cdef const char* PMIX_NO_PROCS_ON_HEAD "PMIX_NO_PROCS_ON_HEAD"
-    cdef const char* PMIX_NO_OVERSUBSCRIBE "PMIX_NO_OVERSUBSCRIBE"
-    cdef const char* PMIX_REPORT_BINDINGS "PMIX_REPORT_BINDINGS"
-    cdef const char* PMIX_CPU_LIST "PMIX_CPU_LIST"
-    cdef const char* PMIX_JOB_RECOVERABLE "PMIX_JOB_RECOVERABLE"
-    cdef const char* PMIX_MAX_RESTARTS "PMIX_MAX_RESTARTS"
-    cdef const char* PMIX_FWD_STDIN "PMIX_FWD_STDIN"
-    cdef const char* PMIX_FWD_STDOUT "PMIX_FWD_STDOUT"
-    cdef const char* PMIX_FWD_STDERR "PMIX_FWD_STDERR"
-    cdef const char* PMIX_FWD_STDDIAG "PMIX_FWD_STDDIAG"
+    cdef const char* PMIX_PERSONALITY_DEFINE "PMIX_PERSONALITY"
+    cdef const char* PMIX_HOST_DEFINE "PMIX_HOST"
+    cdef const char* PMIX_HOSTFILE_DEFINE "PMIX_HOSTFILE"
+    cdef const char* PMIX_ADD_HOST_DEFINE "PMIX_ADD_HOST"
+    cdef const char* PMIX_ADD_HOSTFILE_DEFINE "PMIX_ADD_HOSTFILE"
+    cdef const char* PMIX_PREFIX_DEFINE "PMIX_PREFIX"
+    cdef const char* PMIX_WDIR_DEFINE "PMIX_WDIR"
+    cdef const char* PMIX_MAPPER_DEFINE "PMIX_MAPPER"
+    cdef const char* PMIX_DISPLAY_MAP_DEFINE "PMIX_DISPLAY_MAP"
+    cdef const char* PMIX_PPR_DEFINE "PMIX_PPR"
+    cdef const char* PMIX_MAPBY_DEFINE "PMIX_MAPBY"
+    cdef const char* PMIX_RANKBY_DEFINE "PMIX_RANKBY"
+    cdef const char* PMIX_BINDTO_DEFINE "PMIX_BINDTO"
+    cdef const char* PMIX_PRELOAD_BIN_DEFINE "PMIX_PRELOAD_BIN"
+    cdef const char* PMIX_PRELOAD_FILES_DEFINE "PMIX_PRELOAD_FILES"
+    cdef const char* PMIX_NON_PMI_DEFINE "PMIX_NON_PMI"
+    cdef const char* PMIX_STDIN_TGT_DEFINE "PMIX_STDIN_TGT"
+    cdef const char* PMIX_DEBUGGER_DAEMONS_DEFINE "PMIX_DEBUGGER_DAEMONS"
+    cdef const char* PMIX_COSPAWN_APP_DEFINE "PMIX_COSPAWN_APP"
+    cdef const char* PMIX_SET_SESSION_CWD_DEFINE "PMIX_SET_SESSION_CWD"
+    cdef const char* PMIX_TAG_OUTPUT_DEFINE "PMIX_TAG_OUTPUT"
+    cdef const char* PMIX_TIMESTAMP_OUTPUT_DEFINE "PMIX_TIMESTAMP_OUTPUT"
+    cdef const char* PMIX_MERGE_STDERR_STDOUT_DEFINE "PMIX_MERGE_STDERR_STDOUT"
+    cdef const char* PMIX_OUTPUT_TO_FILE_DEFINE "PMIX_OUTPUT_TO_FILE"
+    cdef const char* PMIX_INDEX_ARGV_DEFINE "PMIX_INDEX_ARGV"
+    cdef const char* PMIX_CPUS_PER_PROC_DEFINE "PMIX_CPUS_PER_PROC"
+    cdef const char* PMIX_NO_PROCS_ON_HEAD_DEFINE "PMIX_NO_PROCS_ON_HEAD"
+    cdef const char* PMIX_NO_OVERSUBSCRIBE_DEFINE "PMIX_NO_OVERSUBSCRIBE"
+    cdef const char* PMIX_REPORT_BINDINGS_DEFINE "PMIX_REPORT_BINDINGS"
+    cdef const char* PMIX_CPU_LIST_DEFINE "PMIX_CPU_LIST"
+    cdef const char* PMIX_JOB_RECOVERABLE_DEFINE "PMIX_JOB_RECOVERABLE"
+    cdef const char* PMIX_MAX_RESTARTS_DEFINE "PMIX_MAX_RESTARTS"
+    cdef const char* PMIX_FWD_STDIN_DEFINE "PMIX_FWD_STDIN"
+    cdef const char* PMIX_FWD_STDOUT_DEFINE "PMIX_FWD_STDOUT"
+    cdef const char* PMIX_FWD_STDERR_DEFINE "PMIX_FWD_STDERR"
+    cdef const char* PMIX_FWD_STDDIAG_DEFINE "PMIX_FWD_STDDIAG"
 
     # query attributes
     cdef const char* PMIX_QUERY_NAMESPACES "PMIX_QUERY_NAMESPACES"
@@ -661,7 +623,7 @@ cdef extern from "pmix_common.h":
         size_t bytes_used
 
     ctypedef struct pmix_proc_t:
-        char nspace[CPMIX_MAX_NSLEN]
+        char nspace[256]
         pmix_rank_t rank
 
     ctypedef struct pmix_proc_info_t:
@@ -717,13 +679,13 @@ cdef extern from "pmix_common.h":
         pmix_info_array_t *array
 
     ctypedef struct pmix_info_t:
-        char key[CPMIX_MAX_KEYLEN]
+        char key[512]
         pmix_info_directives_t flags
         pmix_value_t value
 
     ctypedef struct pmix_pdata_t:
         pmix_proc_t proc
-        char key[CPMIX_MAX_KEYLEN]
+        char key[512]
         pmix_value_t value
 
     ctypedef struct pmix_app_t:
@@ -741,7 +703,7 @@ cdef extern from "pmix_common.h":
         size_t nqual
 
     ctypedef struct pmix_modex_data:
-        char nspace[CPMIX_MAX_NSLEN]
+        char nspace[256]
         int rank
         uint8_t *blob
         size_t size
@@ -831,12 +793,11 @@ cdef extern from "pmix_common.h":
     pmix_status_t PMIx_Data_copy_payload(pmix_data_buffer_t *dest,
                                          pmix_data_buffer_t *src)
 
-
 cdef extern from "pmix.h":
     int PMIx_Initialized()
     const char* PMIx_Get_version()
     pmix_status_t PMIx_Init(pmix_proc_t* myproc, pmix_info_t* info, size_t ninfo)
-
+    pmix_status_t PMIx_Finalize(pmix_info_t* info, size_t ninfo)
 
 cdef extern from "pmix_server.h":
     # Callback function definitions

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -1,0 +1,58 @@
+from libc.string cimport memset,strncpy, strdup
+from libc.stdlib cimport malloc, free
+from libc.string cimport memcpy
+from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
+
+# pull in all the constant definitions - we
+# store them in a separate file for neatness
+include "pmix_constants.pxi"
+
+# provide conversion programs that translate incoming
+# PMIx structures into Python dictionaries, and incoming
+# arrays into Python lists of objects
+
+
+cdef class PMIxInfoArray:
+    cdef pmix_info_t* array
+    cdef size_t ninfo
+
+    def __cinit__(self, size_t number):
+        # allocate some memory (uninitialised, may contain arbitrary data)
+        self.array = <pmix_info_t*> PyMem_Malloc(number * sizeof(pmix_info_t))
+        if not self.array:
+            raise MemoryError()
+        self.ninfo = number
+
+    def load(self, keyvals:dict):
+        kvkeys = list(keyvals.keys())
+        if len(kvkeys) > <int>self.ninfo:
+            raise IndexError()
+        n = 0
+        for key in kvkeys:
+            klen = len(key)
+            if isinstance(key, str):
+                pykey = key.encode('ascii')
+            else:
+                pykey = key
+            pykeyptr = <const char *>(pykey)
+            memset(self.array[n].key, 0, PMIX_MAX_KEYLEN+1)
+            memcpy(self.array[n].key, pykeyptr, klen)
+            # the value also needs to be transferred
+            if (isinstance(keyvals[key], str)):
+                self.array[n].value.type = PMIX_STRING
+                if isinstance(keyvals[key], str):
+                    pykey = keyvals[key].encode('ascii')
+                else:
+                    pykey = keyvals[key]
+                self.array[n].value.data.string = strdup(pykey)
+            n += 1
+
+    def unload(self, infoarray:list):
+        for n in range(self.ninfo):
+            pyin = {}
+            pyin['key'] = self.array[n].key
+            pyin['value'] = "foo"
+            infoarray.append(pyin)
+
+    def __dealloc__(self):
+        PyMem_Free(self.array)

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1146,18 +1146,24 @@ fi
 AM_CONDITIONAL([WANT_PYTHON_BINDINGS], [test $WANT_PYTHON_BINDINGS -eq 1])
 
 if test "$WANT_PYTHON_BINDINGS" = "1"; then
-    AM_PATH_PYTHON([2.7], [python_happy=1], [python_happy=0])
+    AM_PATH_PYTHON([3.4], [python_happy=1], [python_happy=0])
     if test "$python_happy" = "0"; then
         AC_MSG_WARN([Python bindings were enabled, but no suitable])
         AC_MSG_WARN([interpreter was found. PMIx requires at least])
-        AC_MSG_WARN([Python v2.7 to provide Python bindings])
+        AC_MSG_WARN([Python v3.4 to provide Python bindings])
         AC_MSG_ERROR([Cannot continue])
     fi
+    python_version=`python --version 2>&1`
+    PMIX_SUMMARY_ADD([[Bindings]],[[Python]], [pmix_python], [yes ($python_version)])
 
     AC_MSG_CHECKING([if Cython package installed])
     have_cython=`$srcdir/config/pmix_check_cython.py 2> /dev/null`
     if test "$have_cython" = "0"; then
         AC_MSG_RESULT([yes])
+        AC_MSG_CHECKING([Cython version])
+        cython_version=`cython --version 2>&1`
+        AC_MSG_RESULT([$cython_version])
+        PMIX_SUMMARY_ADD([[Bindings]],[[Cython]], [pmix_cython], [yes ($cython_version)])
     else
         AC_MSG_RESULT([no])
         AC_MSG_WARN([Python bindings were enabled, but the Cython])

--- a/config/pmix_summary.m4
+++ b/config/pmix_summary.m4
@@ -1,0 +1,79 @@
+dnl -*- shell-script -*-
+dnl
+dnl Copyright (c) 2016      Los Alamos National Security, LLC. All rights
+dnl                         reserved.
+dnl Copyright (c) 2016-2018 Cisco Systems, Inc.  All rights reserved
+dnl Copyright (c) 2016      Research Organization for Information Science
+dnl                         and Technology (RIST). All rights reserved.
+dnl Copyright (c) 2018      Intel, Inc.  All rights reserved.
+dnl $COPYRIGHT$
+dnl
+dnl Additional copyrights may follow
+dnl
+dnl $HEADER$
+dnl
+AC_DEFUN([PMIX_SUMMARY_ADD],[
+    PMIX_VAR_SCOPE_PUSH([pmix_summary_section pmix_summary_line pmix_summary_section_current])
+
+    dnl need to replace spaces in the section name with somethis else. _ seems like a reasonable
+    dnl choice. if this changes remember to change PMIX_PRINT_SUMMARY as well.
+    pmix_summary_section=$(echo $1 | tr ' ' '_')
+    pmix_summary_line="$2: $4"
+    pmix_summary_section_current=$(eval echo \$pmix_summary_values_$pmix_summary_section)
+
+    if test -z "$pmix_summary_section_current" ; then
+        if test -z "$pmix_summary_sections" ; then
+            pmix_summary_sections=$pmix_summary_section
+        else
+            pmix_summary_sections="$pmix_summary_sections $pmix_summary_section"
+        fi
+        eval pmix_summary_values_$pmix_summary_section=\"$pmix_summary_line\"
+    else
+        eval pmix_summary_values_$pmix_summary_section=\"$pmix_summary_section_current,$pmix_summary_line\"
+    fi
+
+    PMIX_VAR_SCOPE_POP
+])
+
+AC_DEFUN([PMIX_SUMMARY_PRINT],[
+    PMIX_VAR_SCOPE_PUSH([pmix_summary_section pmix_summary_section_name])
+    cat <<EOF
+
+PMIx configuration:
+-----------------------
+Version: $PMIX_MAJOR_VERSION.$PMIX_MINOR_VERSION.$PMIX_RELEASE_VERSION$PMIX_GREEK_VERSION
+EOF
+
+    if test $WANT_DEBUG = 0 ; then
+        echo "Debug build: no"
+    else
+        echo "Debug build: yes"
+    fi
+
+    if test ! -z $with_platform ; then
+        echo "Platform file: $with_platform"
+    else
+        echo "Platform file: (none)"
+    fi
+
+    echo
+
+    for pmix_summary_section in $(echo $pmix_summary_sections) ; do
+        pmix_summary_section_name=$(echo $pmix_summary_section | tr '_' ' ')
+        echo "$pmix_summary_section_name"
+        echo "-----------------------"
+        echo "$(eval echo \$pmix_summary_values_$pmix_summary_section)" | tr ',' $'\n' | sort -f
+        echo " "
+    done
+
+    if test $WANT_DEBUG = 1 ; then
+        cat <<EOF
+*****************************************************************************
+ THIS IS A DEBUG BUILD!  DO NOT USE THIS BUILD FOR PERFORMANCE MEASUREMENTS!
+*****************************************************************************
+
+EOF
+    fi
+
+    PMIX_VAR_SCOPE_POP
+])

--- a/configure.ac
+++ b/configure.ac
@@ -19,7 +19,7 @@
 # Copyright (c) 2012      Oracle and/or its affiliates.  All rights reserved.
 # Copyright (c) 2013      Mellanox Technologies, Inc.
 #                         All rights reserved.
-# Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+# Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
 # Copyright (c) 2016      IBM Corporation.  All rights reserved.
 # Copyright (c) 2016-2018 Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -255,3 +255,5 @@ AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
 pmix_show_title "Configuration complete"
 
 AC_OUTPUT
+
+PMIX_SUMMARY_PRINT

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -140,7 +140,6 @@ typedef uint32_t pmix_rank_t;
                                                                     //        client rendezvous points and contact info
 #define PMIX_SYSTEM_TMPDIR                  "pmix.sys.tmpdir"       // (char*) temp directory for this system, where PMIx
                                                                     //        server will place tool rendezvous points and contact info
-#define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_SERVER_ENABLE_MONITORING       "pmix.srv.monitor"      // (bool) Enable PMIx internal monitoring by server
 #define PMIX_SERVER_NSPACE                  "pmix.srv.nspace"       // (char*) Name of the nspace to use for this server
 #define PMIX_SERVER_RANK                    "pmix.srv.rank"         // (pmix_rank_t) Rank of this server
@@ -274,7 +273,6 @@ typedef uint32_t pmix_rank_t;
 /* topology info */
 #define PMIX_NET_TOPO                       "pmix.ntopo"            // (char*) xml-representation of network topology
 #define PMIX_LOCAL_TOPO                     "pmix.ltopo"            // (char*) xml-representation of local node topology
-#define PMIX_NODE_LIST                      "pmix.nlist"            // (char*) comma-delimited list of nodes running procs for this job
 #define PMIX_TOPOLOGY                       "pmix.topo"             // (hwloc_topology_t) pointer to the PMIx client's internal topology object
 #define PMIX_TOPOLOGY_XML                   "pmix.topo.xml"         // (char*) XML-based description of topology
 #define PMIX_TOPOLOGY_FILE                  "pmix.topo.file"        // (char*) full path to file containing XML topology description
@@ -1226,7 +1224,6 @@ typedef struct pmix_proc_info {
 
 
 /****    PMIX VALUE STRUCT    ****/
-typedef struct pmix_info_t pmix_info_t;
 
 typedef struct pmix_data_array {
     pmix_data_type_t type;
@@ -1244,15 +1241,11 @@ typedef struct pmix_data_array {
         PMIX_DATA_ARRAY_CONSTRUCT((m), (n), (t));                         \
     } while(0)
 
-typedef struct pmix_info_array {
-    size_t size;
-    pmix_info_t *array;
-} pmix_info_array_t;
 /********************/
 
 /* NOTE: operations can supply a collection of values under
- * a single key by passing a pmix_value_t containing an
- * array of type PMIX_INFO_ARRAY, with each array element
+ * a single key by passing a pmix_value_t containing a
+ * data array of type PMIX_INFO, with each array element
  * containing its own pmix_info_t object */
 
 typedef struct pmix_value {
@@ -1290,9 +1283,6 @@ typedef struct pmix_value {
         void *ptr;
         pmix_alloc_directive_t adir;
         pmix_envar_t envar;
-        /**** DEPRECATED ****/
-        pmix_info_array_t *array;
-        /********************/
     } data;
 } pmix_value_t;
 /* allocate and initialize a specified number of value structs */
@@ -1412,11 +1402,11 @@ pmix_status_t pmix_setenv(const char *name, const char *value,
     (r) = pmix_setenv((a), (b), true, (c))
 
 /****    PMIX INFO STRUCT    ****/
-struct pmix_info_t {
+typedef struct pmix_info {
     char key[PMIX_MAX_KEYLEN+1];    // ensure room for the NULL terminator
     pmix_info_directives_t flags;   // bit-mask of flags
     pmix_value_t value;
-};
+} pmix_info_t;
 
 /* utility macros for working with pmix_info_t structs */
 #define PMIX_INFO_CREATE(m, n)                                  \
@@ -2443,24 +2433,6 @@ static inline void pmix_value_destruct(pmix_value_t * m) {
             free((m)->data.darray);
             (m)->data.darray = NULL;
         }
-    /**** DEPRECATED ****/
-    } else if (PMIX_INFO_ARRAY == (m)->type) {
-        pmix_info_t *_p = (pmix_info_t*)((m)->data.array->array);
-        for (_n=0; _n < (m)->data.array->size; _n++) {
-            if (PMIX_STRING == _p[_n].value.type) {
-                if (NULL != _p[_n].value.data.string) {
-                    free(_p[_n].value.data.string);
-                }
-            } else if (PMIX_BYTE_OBJECT == _p[_n].value.type) {
-                if (NULL != _p[_n].value.data.bo.bytes) {
-                    free(_p[_n].value.data.bo.bytes);
-                }
-            } else if (PMIX_PROC_INFO == _p[_n].value.type) {
-                PMIX_PROC_INFO_DESTRUCT(_p[_n].value.data.pinfo);
-            }
-        }
-        free(_p);
-    /********************/
     } else if (PMIX_ENVAR == (m)->type) {
         PMIX_ENVAR_DESTRUCT(&(m)->data.envar);
     }

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -205,6 +205,12 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
         free(tmpbuf);                                                       \
     } while (0)
 
+/* for backwards compatibility */
+typedef struct pmix_info_array {
+    size_t size;
+    pmix_info_t *array;
+} pmix_info_array_t;
+
 
 /**
  * Internal struct used for holding registered bfrop functions
@@ -496,9 +502,6 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_string(char **dest, char *src,
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_value(pmix_value_t **dest,
                                                       pmix_value_t *src,
                                                       pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_array(pmix_info_array_t **dest,
-                                                      pmix_info_array_t *src,
-                                                      pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_proc(pmix_proc_t **dest,
                                                      pmix_proc_t *src,
                                                      pmix_data_type_t type);
@@ -537,10 +540,6 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_query(pmix_query_t **dest,
                                                       pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_envar(pmix_envar_t **dest,
                                                       pmix_envar_t *src,
-                                                      pmix_data_type_t type);
-/**** DEPRECATED ****/
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_array(pmix_info_array_t **dest,
-                                                      pmix_info_array_t *src,
                                                       pmix_data_type_t type);
 
 /*
@@ -596,8 +595,6 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_status(char **output, char *pre
 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_value(char **output, char *prefix,
                                                        pmix_value_t *src, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_array(char **output, char *prefix,
-                                                       pmix_info_array_t *src, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_proc(char **output, char *prefix,
                                                       pmix_proc_t *src, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_print_app(char **output, char *prefix,

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -876,32 +876,6 @@ pmix_status_t pmix_bfrops_base_copy_query(pmix_query_t **dest,
     return PMIX_SUCCESS;
 }
 
-/**** DEPRECATED ****/
-pmix_status_t pmix_bfrops_base_copy_array(pmix_info_array_t **dest,
-                                          pmix_info_array_t *src,
-                                          pmix_data_type_t type)
-{
-    pmix_info_t *d1, *s1;
-
-    *dest = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
-    if (NULL == (*dest)) {
-        return PMIX_ERR_NOMEM;
-        }
-    (*dest)->size = src->size;
-    if (0 < src->size) {
-        (*dest)->array = (pmix_info_t*)malloc(src->size * sizeof(pmix_info_t));
-        if (NULL == (*dest)->array) {
-            free(*dest);
-            return PMIX_ERR_NOMEM;
-        }
-        d1 = (pmix_info_t*)(*dest)->array;
-        s1 = (pmix_info_t*)src->array;
-        memcpy(d1, s1, src->size * sizeof(pmix_info_t));
-    }
-    return PMIX_SUCCESS;
-}
-/*******************/
-
 pmix_status_t pmix_bfrops_base_copy_envar(pmix_envar_t **dest,
                                           pmix_envar_t *src,
                                           pmix_data_type_t type)

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -511,9 +511,6 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
 pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
                                           pmix_value_t *src)
 {
-    size_t n;
-    pmix_info_t *p1, *s1;
-
     /* copy the right field */
     p->type = src->type;
     switch (src->type) {
@@ -643,22 +640,6 @@ pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
         p->data.envar.separator = src->data.envar.separator;
         break;
 
-    /**** DEPRECATED ****/
-    case PMIX_INFO_ARRAY:
-        p->data.array->size = src->data.array->size;
-        if (0 < src->data.array->size) {
-            p->data.array->array = (pmix_info_t*)malloc(src->data.array->size * sizeof(pmix_info_t));
-            if (NULL == p->data.array->array) {
-                return PMIX_ERR_NOMEM;
-            }
-            p1 = (pmix_info_t*)p->data.array->array;
-            s1 = (pmix_info_t*)src->data.array->array;
-            for (n=0; n < src->data.darray->size; n++) {
-                PMIX_INFO_XFER(&p1[n], &s1[n]);
-            }
-        }
-        break;
-    /********************/
     default:
         pmix_output(0, "PMIX-XFER-VALUE: UNSUPPORTED TYPE %d", (int)src->type);
         return PMIX_ERROR;

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1007,13 +1007,6 @@ pmix_status_t pmix_bfrops_base_pack_darray(pmix_buffer_t *buffer, const void *sr
                 }
                 break;
 
-            /**** DEPRECATED ****/
-            case PMIX_INFO_ARRAY:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_array(buffer, p[i].array, p[i].size, PMIX_INFO_ARRAY))) {
-                    return ret;
-                }
-                break;
-            /********************/
             default:
                 pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
                             __FILE__, __LINE__, (int)p[i].type);
@@ -1236,17 +1229,10 @@ pmix_status_t pmix_bfrops_base_pack_val(pmix_buffer_t *buffer,
             }
             break;
 
-        /**** DEPRECATED ****/
-        case PMIX_INFO_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_array(buffer, p->data.array, 1, PMIX_INFO_ARRAY))) {
-                return ret;
-            }
-            break;
-        /********************/
         default:
-        pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
-                    __FILE__, __LINE__, (int)p->type);
-        return PMIX_ERROR;
+            pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
+                        __FILE__, __LINE__, (int)p->type);
+            return PMIX_ERROR;
     }
     return PMIX_SUCCESS;
 }
@@ -1255,33 +1241,6 @@ pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_buffer_t *buffer, const
                                                     int32_t num_vals, pmix_data_type_t type)
 {
     return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
-}
-
-
-/**** DEPRECATED ****/
-pmix_status_t pmix_bfrops_base_pack_array(pmix_buffer_t *buffer, const void *src,
-                                          int32_t num_vals, pmix_data_type_t type)
-{
-    pmix_info_array_t *ptr;
-    int32_t i;
-    pmix_status_t ret;
-
-    ptr = (pmix_info_array_t *) src;
-
-    for (i = 0; i < num_vals; ++i) {
-        /* pack the size */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
-            return ret;
-        }
-        if (0 < ptr[i].size) {
-            /* pack the values */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
-                return ret;
-            }
-        }
-    }
-
-    return PMIX_SUCCESS;
 }
 
 pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_buffer_t *buffer, const void *src,

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -1021,12 +1021,6 @@ int pmix_bfrops_base_print_status(char **output, char *prefix,
                           src->data.envar.separator);
             break;
 
-        /**** DEPRECATED ****/
-        case PMIX_INFO_ARRAY:
-            rc = asprintf(output, "%sPMIX_VALUE: Data type: INFO_ARRAY\tARRAY SIZE: %ld",
-                          prefx, (long)src->data.array->size);
-            break;
-        /********************/
         default:
             rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
             break;
@@ -1702,37 +1696,3 @@ pmix_status_t pmix_bfrops_base_print_envar(char **output, char *prefix,
         return PMIX_SUCCESS;
     }
 }
-
-
-/**** DEPRECATED ****/
-pmix_status_t pmix_bfrops_base_print_array(char **output, char *prefix,
-                                           pmix_info_array_t *src, pmix_data_type_t type)
-{
-    size_t j;
-    char *tmp, *tmp2, *tmp3, *pfx;
-    pmix_info_t *s1;
-
-    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size)) {
-        return PMIX_ERR_NOMEM;
-    }
-    if (0 > asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix)) {
-        free(tmp);
-        return PMIX_ERR_NOMEM;
-    }
-    s1 = (pmix_info_t*)src->array;
-
-    for (j=0; j < src->size; j++) {
-        pmix_bfrops_base_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
-        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
-            free(tmp);
-            free(tmp2);
-            return PMIX_ERR_NOMEM;
-        }
-        free(tmp);
-        free(tmp2);
-        tmp = tmp3;
-    }
-    *output = tmp;
-    return PMIX_SUCCESS;
-}
-/********************/

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -764,21 +764,9 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_buffer_t *buffer,
                 return ret;
             }
             break;
-        /**** DEPRECATED ****/
-        case PMIX_INFO_ARRAY:
-            /* this field is now a pointer, so we must allocate storage for it */
-            val->data.array = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
-            if (NULL == val->data.array) {
-                return PMIX_ERR_NOMEM;
-            }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_array(buffer, val->data.array, &m, PMIX_INFO_ARRAY))) {
-                return ret;
-            }
-            break;
-            /********************/
         default:
-        pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
-        return PMIX_ERROR;
+            pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
+            return PMIX_ERROR;
     }
 
     return PMIX_SUCCESS;
@@ -1539,17 +1527,6 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
                     return ret;
                 }
                 break;
-            /**** DEPRECATED ****/
-            case PMIX_INFO_ARRAY:
-                ptr[i].array = (pmix_info_array_t*)malloc(m * sizeof(pmix_info_array_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_array(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            /********************/
             default:
                 return PMIX_ERR_NOT_SUPPORTED;
         }
@@ -1653,40 +1630,6 @@ pmix_status_t pmix_bfrops_base_unpack_envar(pmix_buffer_t *buffer, void *dest,
         m=1;
         if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &ptr[i].separator, &m, PMIX_BYTE))) {
             return ret;
-        }
-    }
-    return PMIX_SUCCESS;
-}
-
-/**** DEPRECATED ****/
-pmix_status_t pmix_bfrops_base_unpack_array(pmix_buffer_t *buffer, void *dest,
-                                            int32_t *num_vals, pmix_data_type_t type)
-{
-    pmix_info_array_t *ptr;
-    int32_t i, n, m;
-    pmix_status_t ret;
-
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
-                        "pmix_bfrop_unpack: %d info arrays", *num_vals);
-
-    ptr = (pmix_info_array_t*) dest;
-    n = *num_vals;
-
-    for (i = 0; i < n; ++i) {
-        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
-                            "pmix_bfrop_unpack: init array[%d]", i);
-        memset(&ptr[i], 0, sizeof(pmix_info_array_t));
-        /* unpack the size of this array */
-        m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
-            return ret;
-        }
-        if (0 < ptr[i].size) {
-            ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
-            m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
-                return ret;
-            }
         }
     }
     return PMIX_SUCCESS;

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -227,8 +227,6 @@ pmix_value_cmp_t pmix12_bfrop_value_cmp(pmix_value_t *p, pmix_value_t *p1)
 /* COPY FUNCTIONS FOR GENERIC PMIX TYPES */
 pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
 {
-    pmix_info_t *p1, *s1;
-
     /* copy the right field */
     p->type = src->type;
     switch (src->type) {
@@ -300,22 +298,7 @@ pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
         p->data.tv.tv_usec = src->data.tv.tv_usec;
         break;
     case PMIX_INFO_ARRAY:
-        p->data.array = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
-        if (NULL == p->data.array) {
-            return PMIX_ERR_NOMEM;
-        }
-        p->data.array->size = src->data.array->size;
-        if (0 < src->data.array->size) {
-            p->data.array->array = (pmix_info_t*)malloc(src->data.array->size * sizeof(pmix_info_t));
-            if (NULL == p->data.array->array) {
-                free(p->data.array);
-                return PMIX_ERR_NOMEM;
-            }
-            p1 = (pmix_info_t*)p->data.array->array;
-            s1 = (pmix_info_t*)src->data.array->array;
-            memcpy(p1, s1, src->data.array->size * sizeof(pmix_info_t));
-        }
-        break;
+        return PMIX_ERR_NOT_SUPPORTED;
     case PMIX_BYTE_OBJECT:
         if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
             p->data.bo.bytes = malloc(src->data.bo.size);

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -534,11 +534,6 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
         break;
     case PMIX_TIMEVAL:
         if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
-            return ret;
-        }
-        break;
-    case PMIX_INFO_ARRAY:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.array, 1, PMIX_INFO_ARRAY))) {
             return ret;
         }
         break;

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -670,7 +670,11 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
         }
         break;
     case PMIX_INFO_ARRAY:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.array, &m, PMIX_INFO_ARRAY))) {
+        /* we don't know anything about info array's so we
+         * have to convert this to a data array */
+        PMIX_DATA_ARRAY_CREATE(val->data.darray, m, PMIX_INFO);
+        /* unpack into it */
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
             return ret;
         }
         break;

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -356,518 +356,506 @@ pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
     /* copy the right field */
     p->type = src->type;
     switch (src->type) {
-    case PMIX_UNDEF:
-    break;
-    case PMIX_BOOL:
-        p->data.flag = src->data.flag;
-        break;
-    case PMIX_BYTE:
-        p->data.byte = src->data.byte;
-        break;
-    case PMIX_STRING:
-        if (NULL != src->data.string) {
-            p->data.string = strdup(src->data.string);
-        } else {
-            p->data.string = NULL;
-        }
-        break;
-    case PMIX_SIZE:
-        p->data.size = src->data.size;
-        break;
-    case PMIX_PID:
-        p->data.pid = src->data.pid;
-        break;
-    case PMIX_INT:
-        /* to avoid alignment issues */
-        memcpy(&p->data.integer, &src->data.integer, sizeof(int));
-        break;
-    case PMIX_INT8:
-        p->data.int8 = src->data.int8;
-        break;
-    case PMIX_INT16:
-        /* to avoid alignment issues */
-        memcpy(&p->data.int16, &src->data.int16, 2);
-        break;
-    case PMIX_INT32:
-        /* to avoid alignment issues */
-        memcpy(&p->data.int32, &src->data.int32, 4);
-        break;
-    case PMIX_INT64:
-        /* to avoid alignment issues */
-        memcpy(&p->data.int64, &src->data.int64, 8);
-        break;
-    case PMIX_UINT:
-        /* to avoid alignment issues */
-        memcpy(&p->data.uint, &src->data.uint, sizeof(unsigned int));
-        break;
-    case PMIX_UINT8:
-        p->data.uint8 = src->data.uint8;
-        break;
-    case PMIX_UINT16:
-        /* to avoid alignment issues */
-        memcpy(&p->data.uint16, &src->data.uint16, 2);
-        break;
-    case PMIX_UINT32:
-        /* to avoid alignment issues */
-        memcpy(&p->data.uint32, &src->data.uint32, 4);
-        break;
-    case PMIX_UINT64:
-        /* to avoid alignment issues */
-        memcpy(&p->data.uint64, &src->data.uint64, 8);
-        break;
-    case PMIX_FLOAT:
-        p->data.fval = src->data.fval;
-        break;
-    case PMIX_DOUBLE:
-        p->data.dval = src->data.dval;
-        break;
-    case PMIX_TIMEVAL:
-        memcpy(&p->data.tv, &src->data.tv, sizeof(struct timeval));
-        break;
-    case PMIX_TIME:
-        memcpy(&p->data.time, &src->data.time, sizeof(time_t));
-        break;
-    case PMIX_STATUS:
-        memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
-        break;
-    case PMIX_PROC:
-        memcpy(&p->data.proc, &src->data.proc, sizeof(pmix_proc_t));
-        break;
-    case PMIX_PROC_RANK:
-        memcpy(&p->data.proc, &src->data.rank, sizeof(pmix_rank_t));
-        break;
-    case PMIX_BYTE_OBJECT:
-    case PMIX_COMPRESSED_STRING:
-        memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
-        if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
-            p->data.bo.bytes = malloc(src->data.bo.size);
-            memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
-            p->data.bo.size = src->data.bo.size;
-        } else {
-            p->data.bo.bytes = NULL;
-            p->data.bo.size = 0;
-        }
-        break;
-    case PMIX_PERSIST:
-        memcpy(&p->data.persist, &src->data.persist, sizeof(pmix_persistence_t));
-        break;
-    case PMIX_SCOPE:
-        memcpy(&p->data.scope, &src->data.scope, sizeof(pmix_scope_t));
-        break;
-    case PMIX_DATA_RANGE:
-        memcpy(&p->data.range, &src->data.range, sizeof(pmix_data_range_t));
-        break;
-    case PMIX_PROC_STATE:
-        memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
-        break;
-    case PMIX_PROC_INFO:
-        PMIX_PROC_INFO_CREATE(p->data.pinfo, 1);
-        if (NULL != src->data.pinfo->hostname) {
-            p->data.pinfo->hostname = strdup(src->data.pinfo->hostname);
-        }
-        if (NULL != src->data.pinfo->executable_name) {
-            p->data.pinfo->executable_name = strdup(src->data.pinfo->executable_name);
-        }
-        memcpy(&p->data.pinfo->pid, &src->data.pinfo->pid, sizeof(pid_t));
-        memcpy(&p->data.pinfo->exit_code, &src->data.pinfo->exit_code, sizeof(int));
-        memcpy(&p->data.pinfo->state, &src->data.pinfo->state, sizeof(pmix_proc_state_t));
-        break;
-    case PMIX_DATA_ARRAY:
-        p->data.darray = (pmix_data_array_t*)calloc(1, sizeof(pmix_data_array_t));
-        p->data.darray->type = src->data.darray->type;
-        p->data.darray->size = src->data.darray->size;
-        if (0 == p->data.darray->size || NULL == src->data.darray->array) {
-            p->data.darray->array = NULL;
-            p->data.darray->size = 0;
+        case PMIX_UNDEF:
             break;
-        }
-        /* allocate space and do the copy */
-        switch (src->data.darray->type) {
-            case PMIX_UINT8:
-            case PMIX_INT8:
-            case PMIX_BYTE:
-                p->data.darray->array = (char*)malloc(src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size);
+        case PMIX_BOOL:
+            p->data.flag = src->data.flag;
+            break;
+        case PMIX_BYTE:
+            p->data.byte = src->data.byte;
+            break;
+        case PMIX_STRING:
+            if (NULL != src->data.string) {
+                p->data.string = strdup(src->data.string);
+            } else {
+                p->data.string = NULL;
+            }
+            break;
+        case PMIX_SIZE:
+            p->data.size = src->data.size;
+            break;
+        case PMIX_PID:
+            p->data.pid = src->data.pid;
+            break;
+        case PMIX_INT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.integer, &src->data.integer, sizeof(int));
+            break;
+        case PMIX_INT8:
+            p->data.int8 = src->data.int8;
+            break;
+        case PMIX_INT16:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int16, &src->data.int16, 2);
+            break;
+        case PMIX_INT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int32, &src->data.int32, 4);
+            break;
+        case PMIX_INT64:
+            /* to avoid alignment issues */
+            memcpy(&p->data.int64, &src->data.int64, 8);
+            break;
+        case PMIX_UINT:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint, &src->data.uint, sizeof(unsigned int));
+            break;
+        case PMIX_UINT8:
+            p->data.uint8 = src->data.uint8;
+            break;
+        case PMIX_UINT16:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint16, &src->data.uint16, 2);
+            break;
+        case PMIX_UINT32:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint32, &src->data.uint32, 4);
+            break;
+        case PMIX_UINT64:
+            /* to avoid alignment issues */
+            memcpy(&p->data.uint64, &src->data.uint64, 8);
+            break;
+        case PMIX_FLOAT:
+            p->data.fval = src->data.fval;
+            break;
+        case PMIX_DOUBLE:
+            p->data.dval = src->data.dval;
+            break;
+        case PMIX_TIMEVAL:
+            memcpy(&p->data.tv, &src->data.tv, sizeof(struct timeval));
+            break;
+        case PMIX_TIME:
+            memcpy(&p->data.time, &src->data.time, sizeof(time_t));
+            break;
+        case PMIX_STATUS:
+            memcpy(&p->data.status, &src->data.status, sizeof(pmix_status_t));
+            break;
+        case PMIX_PROC:
+            memcpy(&p->data.proc, &src->data.proc, sizeof(pmix_proc_t));
+            break;
+        case PMIX_PROC_RANK:
+            memcpy(&p->data.proc, &src->data.rank, sizeof(pmix_rank_t));
+            break;
+        case PMIX_BYTE_OBJECT:
+        case PMIX_COMPRESSED_STRING:
+            memset(&p->data.bo, 0, sizeof(pmix_byte_object_t));
+            if (NULL != src->data.bo.bytes && 0 < src->data.bo.size) {
+                p->data.bo.bytes = malloc(src->data.bo.size);
+                memcpy(p->data.bo.bytes, src->data.bo.bytes, src->data.bo.size);
+                p->data.bo.size = src->data.bo.size;
+            } else {
+                p->data.bo.bytes = NULL;
+                p->data.bo.size = 0;
+            }
+            break;
+        case PMIX_PERSIST:
+            memcpy(&p->data.persist, &src->data.persist, sizeof(pmix_persistence_t));
+            break;
+        case PMIX_SCOPE:
+            memcpy(&p->data.scope, &src->data.scope, sizeof(pmix_scope_t));
+            break;
+        case PMIX_DATA_RANGE:
+            memcpy(&p->data.range, &src->data.range, sizeof(pmix_data_range_t));
+            break;
+        case PMIX_PROC_STATE:
+            memcpy(&p->data.state, &src->data.state, sizeof(pmix_proc_state_t));
+            break;
+        case PMIX_PROC_INFO:
+            PMIX_PROC_INFO_CREATE(p->data.pinfo, 1);
+            if (NULL != src->data.pinfo->hostname) {
+                p->data.pinfo->hostname = strdup(src->data.pinfo->hostname);
+            }
+            if (NULL != src->data.pinfo->executable_name) {
+                p->data.pinfo->executable_name = strdup(src->data.pinfo->executable_name);
+            }
+            memcpy(&p->data.pinfo->pid, &src->data.pinfo->pid, sizeof(pid_t));
+            memcpy(&p->data.pinfo->exit_code, &src->data.pinfo->exit_code, sizeof(int));
+            memcpy(&p->data.pinfo->state, &src->data.pinfo->state, sizeof(pmix_proc_state_t));
+            break;
+        case PMIX_DATA_ARRAY:
+            p->data.darray = (pmix_data_array_t*)calloc(1, sizeof(pmix_data_array_t));
+            p->data.darray->type = src->data.darray->type;
+            p->data.darray->size = src->data.darray->size;
+            if (0 == p->data.darray->size || NULL == src->data.darray->array) {
+                p->data.darray->array = NULL;
+                p->data.darray->size = 0;
                 break;
-            case PMIX_UINT16:
-            case PMIX_INT16:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint16_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint16_t));
-                break;
-            case PMIX_UINT32:
-            case PMIX_INT32:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint32_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint32_t));
-                break;
-            case PMIX_UINT64:
-            case PMIX_INT64:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint64_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint64_t));
-                break;
-            case PMIX_BOOL:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(bool));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(bool));
-                break;
-            case PMIX_SIZE:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(size_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(size_t));
-                break;
-            case PMIX_PID:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(pid_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pid_t));
-                break;
-            case PMIX_STRING:
-                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                prarray = (char**)p->data.darray->array;
-                strarray = (char**)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (NULL != strarray[n]) {
-                        prarray[n] = strdup(strarray[n]);
+            }
+            /* allocate space and do the copy */
+            switch (src->data.darray->type) {
+                case PMIX_UINT8:
+                case PMIX_INT8:
+                case PMIX_BYTE:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                }
-                break;
-            case PMIX_INT:
-            case PMIX_UINT:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(int));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(int));
-                break;
-            case PMIX_FLOAT:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(float));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(float));
-                break;
-            case PMIX_DOUBLE:
-                p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(double));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(double));
-                break;
-            case PMIX_TIMEVAL:
-                p->data.darray->array = (struct timeval*)malloc(src->data.darray->size * sizeof(struct timeval));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(struct timeval));
-                break;
-            case PMIX_TIME:
-                p->data.darray->array = (time_t*)malloc(src->data.darray->size * sizeof(time_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(time_t));
-                break;
-            case PMIX_STATUS:
-                p->data.darray->array = (pmix_status_t*)malloc(src->data.darray->size * sizeof(pmix_status_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_status_t));
-                break;
-            case PMIX_VALUE:
-                PMIX_VALUE_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pv = (pmix_value_t*)p->data.darray->array;
-                sv = (pmix_value_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(&pv[n], &sv[n]))) {
-                        PMIX_VALUE_FREE(pv, src->data.darray->size);
-                        return rc;
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size);
+                    break;
+                case PMIX_UINT16:
+                case PMIX_INT16:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint16_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                }
-                break;
-            case PMIX_PROC:
-                PMIX_PROC_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_proc_t));
-                break;
-            case PMIX_APP:
-                PMIX_APP_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pa = (pmix_app_t*)p->data.darray->array;
-                sa = (pmix_app_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (NULL != sa[n].cmd) {
-                        pa[n].cmd = strdup(sa[n].cmd);
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint16_t));
+                    break;
+                case PMIX_UINT32:
+                case PMIX_INT32:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint32_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                    if (NULL != sa[n].argv) {
-                        pa[n].argv = pmix_argv_copy(sa[n].argv);
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint32_t));
+                    break;
+                case PMIX_UINT64:
+                case PMIX_INT64:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(uint64_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                    if (NULL != sa[n].env) {
-                        pa[n].env = pmix_argv_copy(sa[n].env);
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(uint64_t));
+                    break;
+                case PMIX_BOOL:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(bool));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                    if (NULL != sa[n].cwd) {
-                        pa[n].cwd = strdup(sa[n].cwd);
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(bool));
+                    break;
+                case PMIX_SIZE:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(size_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                    pa[n].maxprocs = sa[n].maxprocs;
-                    if (0 < sa[n].ninfo && NULL != sa[n].info) {
-                        PMIX_INFO_CREATE(pa[n].info, sa[n].ninfo);
-                        if (NULL == pa[n].info) {
-                            PMIX_APP_FREE(pa, src->data.darray->size);
-                            return PMIX_ERR_NOMEM;
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(size_t));
+                    break;
+                case PMIX_PID:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(pid_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pid_t));
+                    break;
+                case PMIX_STRING:
+                    p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    prarray = (char**)p->data.darray->array;
+                    strarray = (char**)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (NULL != strarray[n]) {
+                            prarray[n] = strdup(strarray[n]);
                         }
-                        pa[n].ninfo = sa[n].ninfo;
-                        for (m=0; m < pa[n].ninfo; m++) {
-                            PMIX_INFO_XFER(&pa[n].info[m], &sa[n].info[m]);
-                        }
                     }
-                }
-                break;
-            case PMIX_INFO:
-                PMIX_INFO_CREATE(p->data.darray->array, src->data.darray->size);
-                p1 = (pmix_info_t*)p->data.darray->array;
-                s1 = (pmix_info_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
-                }
-                break;
-            case PMIX_PDATA:
-                PMIX_PDATA_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pd = (pmix_pdata_t*)p->data.darray->array;
-                sd = (pmix_pdata_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data.flag, sd[n].value.type);
-                }
-                break;
-            case PMIX_BUFFER:
-                p->data.darray->array = (pmix_buffer_t*)malloc(src->data.darray->size * sizeof(pmix_buffer_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pb = (pmix_buffer_t*)p->data.darray->array;
-                sb = (pmix_buffer_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    PMIX_CONSTRUCT(&pb[n], pmix_buffer_t);
-                    pmix20_bfrop_copy_payload(&pb[n], &sb[n]);
-                }
-                break;
-            case PMIX_BYTE_OBJECT:
-            case PMIX_COMPRESSED_STRING:
-                p->data.darray->array = (pmix_byte_object_t*)malloc(src->data.darray->size * sizeof(pmix_byte_object_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pbo = (pmix_byte_object_t*)p->data.darray->array;
-                sbo = (pmix_byte_object_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
-                        pbo[n].size = sbo[n].size;
-                        pbo[n].bytes = (char*)malloc(pbo[n].size);
-                        memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
-                    } else {
-                        pbo[n].bytes = NULL;
-                        pbo[n].size = 0;
+                    break;
+                case PMIX_INT:
+                case PMIX_UINT:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(int));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                }
-                break;
-            case PMIX_KVAL:
-                p->data.darray->array = (pmix_kval_t*)calloc(src->data.darray->size , sizeof(pmix_kval_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pk = (pmix_kval_t*)p->data.darray->array;
-                sk = (pmix_kval_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (NULL != sk[n].key) {
-                        pk[n].key = strdup(sk[n].key);
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(int));
+                    break;
+                case PMIX_FLOAT:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(float));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
                     }
-                    if (NULL != sk[n].value) {
-                        PMIX_VALUE_CREATE(pk[n].value, 1);
-                        if (NULL == pk[n].value) {
-                            free(p->data.darray->array);
-                            return PMIX_ERR_NOMEM;
-                        }
-                        if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(pk[n].value, sk[n].value))) {
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(float));
+                    break;
+                case PMIX_DOUBLE:
+                    p->data.darray->array = (char*)malloc(src->data.darray->size * sizeof(double));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(double));
+                    break;
+                case PMIX_TIMEVAL:
+                    p->data.darray->array = (struct timeval*)malloc(src->data.darray->size * sizeof(struct timeval));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(struct timeval));
+                    break;
+                case PMIX_TIME:
+                    p->data.darray->array = (time_t*)malloc(src->data.darray->size * sizeof(time_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(time_t));
+                    break;
+                case PMIX_STATUS:
+                    p->data.darray->array = (pmix_status_t*)malloc(src->data.darray->size * sizeof(pmix_status_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_status_t));
+                    break;
+                case PMIX_VALUE:
+                    PMIX_VALUE_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pv = (pmix_value_t*)p->data.darray->array;
+                    sv = (pmix_value_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(&pv[n], &sv[n]))) {
+                            PMIX_VALUE_FREE(pv, src->data.darray->size);
                             return rc;
                         }
                     }
-                }
-                break;
-            case PMIX_MODEX:
-                PMIX_MODEX_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pm = (pmix_modex_data_t*)p->data.darray->array;
-                sm = (pmix_modex_data_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    memcpy(&pm[n], &sm[n], sizeof(pmix_modex_data_t));
-                    if (NULL != sm[n].blob && 0 < sm[n].size) {
-                        pm[n].blob = (uint8_t*)malloc(sm[n].size);
-                        if (NULL == pm[n].blob) {
-                            return PMIX_ERR_NOMEM;
+                    break;
+                case PMIX_PROC:
+                    PMIX_PROC_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_proc_t));
+                    break;
+                case PMIX_APP:
+                    PMIX_APP_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pa = (pmix_app_t*)p->data.darray->array;
+                    sa = (pmix_app_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (NULL != sa[n].cmd) {
+                            pa[n].cmd = strdup(sa[n].cmd);
                         }
-                        memcpy(pm[n].blob, sm[n].blob, sm[n].size);
-                        pm[n].size = sm[n].size;
-                    } else {
-                        pm[n].blob = NULL;
-                        pm[n].size = 0;
-                    }
-                }
-                break;
-            case PMIX_PERSIST:
-                p->data.darray->array = (pmix_persistence_t*)malloc(src->data.darray->size * sizeof(pmix_persistence_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_persistence_t));
-                break;
-            case PMIX_POINTER:
-                p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                prarray = (char**)p->data.darray->array;
-                strarray = (char**)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    prarray[n] = strarray[n];
-                }
-                break;
-            case PMIX_SCOPE:
-                p->data.darray->array = (pmix_scope_t*)malloc(src->data.darray->size * sizeof(pmix_scope_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_scope_t));
-                break;
-            case PMIX_DATA_RANGE:
-                p->data.darray->array = (pmix_data_range_t*)malloc(src->data.darray->size * sizeof(pmix_data_range_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_data_range_t));
-                break;
-            case PMIX_COMMAND:
-                p->data.darray->array = (pmix_cmd_t*)malloc(src->data.darray->size * sizeof(pmix_cmd_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_cmd_t));
-                break;
-            case PMIX_INFO_DIRECTIVES:
-                p->data.darray->array = (pmix_info_directives_t*)malloc(src->data.darray->size * sizeof(pmix_info_directives_t));
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_info_directives_t));
-                break;
-            case PMIX_PROC_INFO:
-                PMIX_PROC_INFO_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pi = (pmix_proc_info_t*)p->data.darray->array;
-                si = (pmix_proc_info_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    memcpy(&pi[n].proc, &si[n].proc, sizeof(pmix_proc_t));
-                    if (NULL != si[n].hostname) {
-                        pi[n].hostname = strdup(si[n].hostname);
-                    } else {
-                        pi[n].hostname = NULL;
-                    }
-                    if (NULL != si[n].executable_name) {
-                        pi[n].executable_name = strdup(si[n].executable_name);
-                    } else {
-                        pi[n].executable_name = NULL;
-                    }
-                    pi[n].pid = si[n].pid;
-                    pi[n].exit_code = si[n].exit_code;
-                    pi[n].state = si[n].state;
-                }
-                break;
-            case PMIX_DATA_ARRAY:
-                return PMIX_ERR_NOT_SUPPORTED;  // don't support iterative arrays
-            case PMIX_QUERY:
-                PMIX_QUERY_CREATE(p->data.darray->array, src->data.darray->size);
-                if (NULL == p->data.darray->array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                pq = (pmix_query_t*)p->data.darray->array;
-                sq = (pmix_query_t*)src->data.darray->array;
-                for (n=0; n < src->data.darray->size; n++) {
-                    if (NULL != sq[n].keys) {
-                        pq[n].keys = pmix_argv_copy(sq[n].keys);
-                    }
-                    if (NULL != sq[n].qualifiers && 0 < sq[n].nqual) {
-                        PMIX_INFO_CREATE(pq[n].qualifiers, sq[n].nqual);
-                        if (NULL == pq[n].qualifiers) {
-                            PMIX_QUERY_FREE(pq, src->data.darray->size);
-                            return PMIX_ERR_NOMEM;
+                        if (NULL != sa[n].argv) {
+                            pa[n].argv = pmix_argv_copy(sa[n].argv);
                         }
-                        for (m=0; m < sq[n].nqual; m++) {
-                            PMIX_INFO_XFER(&pq[n].qualifiers[m], &sq[n].qualifiers[m]);
+                        if (NULL != sa[n].env) {
+                            pa[n].env = pmix_argv_copy(sa[n].env);
                         }
-                        pq[n].nqual = sq[n].nqual;
-                    } else {
-                        pq[n].qualifiers = NULL;
-                        pq[n].nqual = 0;
+                        if (NULL != sa[n].cwd) {
+                            pa[n].cwd = strdup(sa[n].cwd);
+                        }
+                        pa[n].maxprocs = sa[n].maxprocs;
+                        if (0 < sa[n].ninfo && NULL != sa[n].info) {
+                            PMIX_INFO_CREATE(pa[n].info, sa[n].ninfo);
+                            if (NULL == pa[n].info) {
+                                PMIX_APP_FREE(pa, src->data.darray->size);
+                                return PMIX_ERR_NOMEM;
+                            }
+                            pa[n].ninfo = sa[n].ninfo;
+                            for (m=0; m < pa[n].ninfo; m++) {
+                                PMIX_INFO_XFER(&pa[n].info[m], &sa[n].info[m]);
+                            }
+                        }
                     }
-                }
-                break;
-            default:
-                return PMIX_ERR_UNKNOWN_DATA_TYPE;
-        }
-        break;
-    case PMIX_POINTER:
-        memcpy(&p->data.ptr, &src->data.ptr, sizeof(void*));
-        break;
-    /**** DEPRECATED ****/
-    case PMIX_INFO_ARRAY:
-        p->data.array->size = src->data.array->size;
-        if (0 < src->data.array->size) {
-            p->data.array->array = (pmix_info_t*)malloc(src->data.array->size * sizeof(pmix_info_t));
-            if (NULL == p->data.array->array) {
-                return PMIX_ERR_NOMEM;
+                    break;
+                case PMIX_INFO:
+                    PMIX_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                    p1 = (pmix_info_t*)p->data.darray->array;
+                    s1 = (pmix_info_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
+                    }
+                    break;
+                case PMIX_PDATA:
+                    PMIX_PDATA_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pd = (pmix_pdata_t*)p->data.darray->array;
+                    sd = (pmix_pdata_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        PMIX_PDATA_LOAD(&pd[n], &sd[n].proc, sd[n].key, &sd[n].value.data.flag, sd[n].value.type);
+                    }
+                    break;
+                case PMIX_BUFFER:
+                    p->data.darray->array = (pmix_buffer_t*)malloc(src->data.darray->size * sizeof(pmix_buffer_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pb = (pmix_buffer_t*)p->data.darray->array;
+                    sb = (pmix_buffer_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        PMIX_CONSTRUCT(&pb[n], pmix_buffer_t);
+                        pmix20_bfrop_copy_payload(&pb[n], &sb[n]);
+                    }
+                    break;
+                case PMIX_BYTE_OBJECT:
+                case PMIX_COMPRESSED_STRING:
+                    p->data.darray->array = (pmix_byte_object_t*)malloc(src->data.darray->size * sizeof(pmix_byte_object_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pbo = (pmix_byte_object_t*)p->data.darray->array;
+                    sbo = (pmix_byte_object_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (NULL != sbo[n].bytes && 0 < sbo[n].size) {
+                            pbo[n].size = sbo[n].size;
+                            pbo[n].bytes = (char*)malloc(pbo[n].size);
+                            memcpy(pbo[n].bytes, sbo[n].bytes, pbo[n].size);
+                        } else {
+                            pbo[n].bytes = NULL;
+                            pbo[n].size = 0;
+                        }
+                    }
+                    break;
+                case PMIX_KVAL:
+                    p->data.darray->array = (pmix_kval_t*)calloc(src->data.darray->size , sizeof(pmix_kval_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pk = (pmix_kval_t*)p->data.darray->array;
+                    sk = (pmix_kval_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (NULL != sk[n].key) {
+                            pk[n].key = strdup(sk[n].key);
+                        }
+                        if (NULL != sk[n].value) {
+                            PMIX_VALUE_CREATE(pk[n].value, 1);
+                            if (NULL == pk[n].value) {
+                                free(p->data.darray->array);
+                                return PMIX_ERR_NOMEM;
+                            }
+                            if (PMIX_SUCCESS != (rc = pmix20_bfrop_value_xfer(pk[n].value, sk[n].value))) {
+                                return rc;
+                            }
+                        }
+                    }
+                    break;
+                case PMIX_MODEX:
+                    PMIX_MODEX_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pm = (pmix_modex_data_t*)p->data.darray->array;
+                    sm = (pmix_modex_data_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        memcpy(&pm[n], &sm[n], sizeof(pmix_modex_data_t));
+                        if (NULL != sm[n].blob && 0 < sm[n].size) {
+                            pm[n].blob = (uint8_t*)malloc(sm[n].size);
+                            if (NULL == pm[n].blob) {
+                                return PMIX_ERR_NOMEM;
+                            }
+                            memcpy(pm[n].blob, sm[n].blob, sm[n].size);
+                            pm[n].size = sm[n].size;
+                        } else {
+                            pm[n].blob = NULL;
+                            pm[n].size = 0;
+                        }
+                    }
+                    break;
+                case PMIX_PERSIST:
+                    p->data.darray->array = (pmix_persistence_t*)malloc(src->data.darray->size * sizeof(pmix_persistence_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_persistence_t));
+                    break;
+                case PMIX_POINTER:
+                    p->data.darray->array = (char**)malloc(src->data.darray->size * sizeof(char*));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    prarray = (char**)p->data.darray->array;
+                    strarray = (char**)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        prarray[n] = strarray[n];
+                    }
+                    break;
+                case PMIX_SCOPE:
+                    p->data.darray->array = (pmix_scope_t*)malloc(src->data.darray->size * sizeof(pmix_scope_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_scope_t));
+                    break;
+                case PMIX_DATA_RANGE:
+                    p->data.darray->array = (pmix_data_range_t*)malloc(src->data.darray->size * sizeof(pmix_data_range_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_data_range_t));
+                    break;
+                case PMIX_COMMAND:
+                    p->data.darray->array = (pmix_cmd_t*)malloc(src->data.darray->size * sizeof(pmix_cmd_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_cmd_t));
+                    break;
+                case PMIX_INFO_DIRECTIVES:
+                    p->data.darray->array = (pmix_info_directives_t*)malloc(src->data.darray->size * sizeof(pmix_info_directives_t));
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(p->data.darray->array, src->data.darray->array, src->data.darray->size * sizeof(pmix_info_directives_t));
+                    break;
+                case PMIX_PROC_INFO:
+                    PMIX_PROC_INFO_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pi = (pmix_proc_info_t*)p->data.darray->array;
+                    si = (pmix_proc_info_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        memcpy(&pi[n].proc, &si[n].proc, sizeof(pmix_proc_t));
+                        if (NULL != si[n].hostname) {
+                            pi[n].hostname = strdup(si[n].hostname);
+                        } else {
+                            pi[n].hostname = NULL;
+                        }
+                        if (NULL != si[n].executable_name) {
+                            pi[n].executable_name = strdup(si[n].executable_name);
+                        } else {
+                            pi[n].executable_name = NULL;
+                        }
+                        pi[n].pid = si[n].pid;
+                        pi[n].exit_code = si[n].exit_code;
+                        pi[n].state = si[n].state;
+                    }
+                    break;
+                case PMIX_DATA_ARRAY:
+                    return PMIX_ERR_NOT_SUPPORTED;  // don't support iterative arrays
+                case PMIX_QUERY:
+                    PMIX_QUERY_CREATE(p->data.darray->array, src->data.darray->size);
+                    if (NULL == p->data.darray->array) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    pq = (pmix_query_t*)p->data.darray->array;
+                    sq = (pmix_query_t*)src->data.darray->array;
+                    for (n=0; n < src->data.darray->size; n++) {
+                        if (NULL != sq[n].keys) {
+                            pq[n].keys = pmix_argv_copy(sq[n].keys);
+                        }
+                        if (NULL != sq[n].qualifiers && 0 < sq[n].nqual) {
+                            PMIX_INFO_CREATE(pq[n].qualifiers, sq[n].nqual);
+                            if (NULL == pq[n].qualifiers) {
+                                PMIX_QUERY_FREE(pq, src->data.darray->size);
+                                return PMIX_ERR_NOMEM;
+                            }
+                            for (m=0; m < sq[n].nqual; m++) {
+                                PMIX_INFO_XFER(&pq[n].qualifiers[m], &sq[n].qualifiers[m]);
+                            }
+                            pq[n].nqual = sq[n].nqual;
+                        } else {
+                            pq[n].qualifiers = NULL;
+                            pq[n].nqual = 0;
+                        }
+                    }
+                    break;
+                default:
+                    return PMIX_ERR_UNKNOWN_DATA_TYPE;
             }
-            p1 = (pmix_info_t*)p->data.array->array;
-            s1 = (pmix_info_t*)src->data.array->array;
-            for (n=0; n < src->data.darray->size; n++) {
-                PMIX_INFO_LOAD(&p1[n], s1[n].key, &s1[n].value.data.flag, s1[n].value.type);
-            }
-        }
-        break;
-    /********************/
-    default:
-        pmix_output(0, "COPY-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)src->type);
-        return PMIX_ERROR;
+            break;
+        case PMIX_POINTER:
+            memcpy(&p->data.ptr, &src->data.ptr, sizeof(void*));
+            break;
+        /**** DEPRECATED ****/
+        case PMIX_INFO_ARRAY:
+            return PMIX_ERR_NOT_SUPPORTED;
+        /********************/
+        default:
+            pmix_output(0, "COPY-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)src->type);
+            return PMIX_ERROR;
     }
     return PMIX_SUCCESS;
 }

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2011-2013 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -613,13 +613,6 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
                 return ret;
             }
             break;
-        /**** DEPRECATED ****/
-        case PMIX_INFO_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.array, 1, PMIX_INFO_ARRAY))) {
-                return ret;
-            }
-            break;
-        /********************/
         default:
         pmix_output(0, "PACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)p->type);
         return PMIX_ERROR;
@@ -1035,10 +1028,9 @@ pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_buffer_t *buffer, const voi
     return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
 }
 
-
 /**** DEPRECATED ****/
 pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
-                          int32_t num_vals, pmix_data_type_t type)
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i;
@@ -1048,12 +1040,12 @@ pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             /* pack the values */
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -1062,3 +1054,4 @@ pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 /********************/
+

--- a/src/mca/bfrops/v20/print.c
+++ b/src/mca/bfrops/v20/print.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -761,7 +761,7 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix,
  * PMIX_VALUE
  */
  pmix_status_t pmix20_bfrop_print_value(char **output, char *prefix,
-                                      pmix_value_t *src, pmix_data_type_t type)
+                                        pmix_value_t *src, pmix_data_type_t type)
  {
     char *prefx;
     int rc;
@@ -904,12 +904,6 @@ pmix_status_t pmix20_bfrop_print_status(char **output, char *prefix,
         rc = asprintf(output, "%sPMIX_VALUE: Data type: DATA_ARRAY\tARRAY SIZE: %ld",
                       prefx, (long)src->data.darray->size);
         break;
-        /**** DEPRECATED ****/
-        case PMIX_INFO_ARRAY:
-        rc = asprintf(output, "%sPMIX_VALUE: Data type: INFO_ARRAY\tARRAY SIZE: %ld",
-                      prefx, (long)src->data.array->size);
-        break;
-        /********************/
         default:
         rc = asprintf(output, "%sPMIX_VALUE: Data type: UNKNOWN\tValue: UNPRINTABLE", prefx);
         break;

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -756,12 +756,11 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             break;
         /**** DEPRECATED ****/
         case PMIX_INFO_ARRAY:
-            /* this field is now a pointer, so we must allocate storage for it */
-            val->data.array = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
-            if (NULL == val->data.array) {
-                return PMIX_ERR_NOMEM;
-            }
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.array, &m, PMIX_INFO_ARRAY))) {
+            /* we don't know anything about info array's so we
+             * have to convert this to a data array */
+            PMIX_DATA_ARRAY_CREATE(val->data.darray, m, PMIX_INFO);
+            /* unpack into it */
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
                 return ret;
             }
             break;

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -62,6 +62,17 @@ pmix_bfrops_module_t pmix_bfrops_pmix21_module = {
     .register_type = register_type,
     .data_type_string = data_type_string
 };
+
+static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                             int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                               int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest,
+                                             pmix_info_array_t *src,
+                                             pmix_data_type_t type);
+static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix,
+                                              pmix_info_array_t *src, pmix_data_type_t type);
+
 
 static pmix_status_t init(void)
 {
@@ -374,10 +385,10 @@ static pmix_status_t init(void)
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY,
-                       pmix_bfrops_base_pack_array,
-                       pmix_bfrops_base_unpack_array,
-                       pmix_bfrops_base_copy_array,
-                       pmix_bfrops_base_print_array,
+                       pmix21_bfrop_pack_array,
+                       pmix21_bfrop_unpack_array,
+                       pmix21_bfrop_copy_array,
+                       pmix21_bfrop_print_array,
                        &mca_bfrops_v21_component.types);
     /********************/
 
@@ -446,3 +457,115 @@ static const char* data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v21_component.types, type);
 }
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                             int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_info_array_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the size */
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            /* pack the values */
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+/********************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                               int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix21_bfrop_unpack: %d info arrays", *num_vals);
+
+    ptr = (pmix_info_array_t*) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix21_bfrop_unpack: init array[%d]", i);
+        memset(&ptr[i], 0, sizeof(pmix_info_array_t));
+        /* unpack the size of this array */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
+            m=ptr[i].size;
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+/********************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest,
+                                             pmix_info_array_t *src,
+                                             pmix_data_type_t type)
+{
+    pmix_info_t *d1, *s1;
+
+    *dest = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
+    (*dest)->size = src->size;
+    (*dest)->array = (pmix_info_t*)malloc(src->size * sizeof(pmix_info_t));
+    d1 = (pmix_info_t*)(*dest)->array;
+    s1 = (pmix_info_t*)src->array;
+    memcpy(d1, s1, src->size * sizeof(pmix_info_t));
+    return PMIX_SUCCESS;
+}
+/*******************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix,
+                                              pmix_info_array_t *src, pmix_data_type_t type)
+{
+    size_t j;
+    char *tmp, *tmp2, *tmp3, *pfx;
+    pmix_info_t *s1;
+
+    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (0 > asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix)) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
+    s1 = (pmix_info_t*)src->array;
+
+    for (j=0; j < src->size; j++) {
+        pmix_bfrops_base_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
+        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+            free(tmp);
+            free(tmp2);
+            return PMIX_ERR_NOMEM;
+        }
+        free(tmp);
+        free(tmp2);
+        tmp = tmp3;
+    }
+    *output = tmp;
+    return PMIX_SUCCESS;
+}
+/********************/

--- a/src/mca/bfrops/v21/internal.h
+++ b/src/mca/bfrops/v21/internal.h
@@ -1,0 +1,122 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+#ifndef PMIX21_BFROP_INTERNAL_H_
+#define PMIX21_BFROP_INTERNAL_H_
+
+#include <src/include/pmix_config.h>
+
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h> /* for struct timeval */
+#endif
+
+#include "src/class/pmix_pointer_array.h"
+
+#include "src/mca/bfrops/base/base.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+ BEGIN_C_DECLS
+
+/*
+ * Implementations of API functions
+ */
+
+pmix_status_t pmix21_bfrop_pack(pmix_buffer_t *buffer, const void *src,
+                                int32_t num_vals,
+                                pmix_data_type_t type);
+pmix_status_t pmix21_bfrop_unpack(pmix_buffer_t *buffer, void *dest,
+                                  int32_t *max_num_vals,
+                                  pmix_data_type_t type);
+
+pmix_status_t pmix21_bfrop_copy(void **dest, void *src, pmix_data_type_t type);
+
+pmix_status_t pmix21_bfrop_print(char **output, char *prefix, void *src, pmix_data_type_t type);
+
+pmix_status_t pmix21_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
+
+pmix_status_t pmix21_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src);
+
+void pmix21_bfrop_value_load(pmix_value_t *v, const void *data,
+                            pmix_data_type_t type);
+
+pmix_status_t pmix21_bfrop_value_unload(pmix_value_t *kv,
+                                       void **data,
+                                       size_t *sz);
+
+pmix_value_cmp_t pmix21_bfrop_value_cmp(pmix_value_t *p,
+                                       pmix_value_t *p1);
+
+/*
+ * Specialized functions
+ */
+pmix_status_t pmix21_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix21_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
+                                         int32_t *num_vals, pmix_data_type_t type);
+
+/*
+ * Internal pack functions
+ */
+
+/**** DEPRECATED ****/
+pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+/********************/
+
+/*
+ * Internal unpack functions
+ */
+/**** DEPRECATED ****/
+pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+/********************/
+
+/*
+ * Internal copy functions
+ */
+
+/**** DEPRECATED ****/
+pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest,
+                                    pmix_info_array_t *src,
+                                    pmix_data_type_t type);
+
+/********************/
+
+/*
+ * Internal print functions
+ */
+/**** DEPRECATED ****/
+pmix_status_t pmix21_bfrop_print_array(char **output, char *prefix,
+                                     pmix_info_array_t *src,
+                                     pmix_data_type_t type);
+/********************/
+
+END_C_DECLS
+
+#endif

--- a/src/mca/bfrops/v3/bfrop_pmix3.c
+++ b/src/mca/bfrops/v3/bfrop_pmix3.c
@@ -63,6 +63,17 @@ pmix_bfrops_module_t pmix_bfrops_pmix3_module = {
     .data_type_string = data_type_string
 };
 
+static pmix_status_t pmix3_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                            int32_t num_vals, pmix_data_type_t type);
+static pmix_status_t pmix3_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                              int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t pmix3_bfrop_copy_array(pmix_info_array_t **dest,
+                                            pmix_info_array_t *src,
+                                            pmix_data_type_t type);
+static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix,
+                                             pmix_info_array_t *src, pmix_data_type_t type);
+
+
 static pmix_status_t init(void)
 {
     /* some standard types don't require anything special */
@@ -390,10 +401,10 @@ static pmix_status_t init(void)
 
     /**** DEPRECATED ****/
     PMIX_REGISTER_TYPE("PMIX_INFO_ARRAY", PMIX_INFO_ARRAY,
-                       pmix_bfrops_base_pack_array,
-                       pmix_bfrops_base_unpack_array,
-                       pmix_bfrops_base_copy_array,
-                       pmix_bfrops_base_print_array,
+                       pmix3_bfrop_pack_array,
+                       pmix3_bfrop_unpack_array,
+                       pmix3_bfrop_copy_array,
+                       pmix3_bfrop_print_array,
                        &mca_bfrops_v3_component.types);
     /********************/
 
@@ -462,3 +473,115 @@ static const char* data_type_string(pmix_data_type_t type)
 {
     return pmix_bfrops_base_data_type_string(&mca_bfrops_v3_component.types, type);
 }
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix3_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+                                            int32_t num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i;
+    pmix_status_t ret;
+
+    ptr = (pmix_info_array_t *) src;
+
+    for (i = 0; i < num_vals; ++i) {
+        /* pack the size */
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            /* pack the values */
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+/********************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix3_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+                                              int32_t *num_vals, pmix_data_type_t type)
+{
+    pmix_info_array_t *ptr;
+    int32_t i, n, m;
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix3_bfrop_unpack: %d info arrays", *num_vals);
+
+    ptr = (pmix_info_array_t*) dest;
+    n = *num_vals;
+
+    for (i = 0; i < n; ++i) {
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix3_bfrop_unpack: init array[%d]", i);
+        memset(&ptr[i], 0, sizeof(pmix_info_array_t));
+        /* unpack the size of this array */
+        m=1;
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+            return ret;
+        }
+        if (0 < ptr[i].size) {
+            ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
+            m=ptr[i].size;
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+                return ret;
+            }
+        }
+    }
+    return PMIX_SUCCESS;
+}
+/********************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix3_bfrop_copy_array(pmix_info_array_t **dest,
+                                            pmix_info_array_t *src,
+                                            pmix_data_type_t type)
+{
+    pmix_info_t *d1, *s1;
+
+    *dest = (pmix_info_array_t*)malloc(sizeof(pmix_info_array_t));
+    (*dest)->size = src->size;
+    (*dest)->array = (pmix_info_t*)malloc(src->size * sizeof(pmix_info_t));
+    d1 = (pmix_info_t*)(*dest)->array;
+    s1 = (pmix_info_t*)src->array;
+    memcpy(d1, s1, src->size * sizeof(pmix_info_t));
+    return PMIX_SUCCESS;
+}
+/*******************/
+
+/**** DEPRECATED ****/
+static pmix_status_t pmix3_bfrop_print_array(char **output, char *prefix,
+                                             pmix_info_array_t *src, pmix_data_type_t type)
+{
+    size_t j;
+    char *tmp, *tmp2, *tmp3, *pfx;
+    pmix_info_t *s1;
+
+    if (0 > asprintf(&tmp, "%sARRAY SIZE: %ld", prefix, (long)src->size)) {
+        return PMIX_ERR_NOMEM;
+    }
+    if (0 > asprintf(&pfx, "\n%s\t",  (NULL == prefix) ? "" : prefix)) {
+        free(tmp);
+        return PMIX_ERR_NOMEM;
+    }
+    s1 = (pmix_info_t*)src->array;
+
+    for (j=0; j < src->size; j++) {
+        pmix_bfrops_base_print_info(&tmp2, pfx, &s1[j], PMIX_INFO);
+        if (0 > asprintf(&tmp3, "%s%s", tmp, tmp2)) {
+            free(tmp);
+            free(tmp2);
+            return PMIX_ERR_NOMEM;
+        }
+        free(tmp);
+        free(tmp2);
+        tmp = tmp3;
+    }
+    *output = tmp;
+    return PMIX_SUCCESS;
+}
+/********************/

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -2920,7 +2920,7 @@ static pmix_status_t dstore_del_nspace(const char* nspace)
                              __FILE__, __LINE__, __func__, session_tbl[session_tbl_idx].jobuid));
         size = pmix_value_array_get_size(_ns_track_array);
         if (size && (dstor_track_idx >= 0)) {
-            if((dstor_track_idx + 1) > size) {
+            if((dstor_track_idx + 1) > (int)size) {
                 rc = PMIX_ERR_VALUE_OUT_OF_BOUNDS;
                 PMIX_ERROR_LOG(rc);
                 goto exit;


### PR DESCRIPTION
Require Python 3 for bindings

Output configuration summary report. Show Python and Cython version info

Create a python script to automatically generate Cython input files from
PMIx headers. This gets executed during "make install" as part of
generating the bindings. The conversion routines to shift information
between C and Python need to be manually written for now. Fortunately,
these don't change as we move across PMIx versions and so they should
only be modified when something gets added, which is rare.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>