### PR TITLE
Implement job control and sensor APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ test/simple/simptimeout
 test/simple/stability
 test/simple/gwclient
 test/simple/gwtest
+test/simple/simpjctrl
 
 # coverity
 cov-int

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -779,6 +779,7 @@ typedef int pmix_status_t;
 #define PMIX_LAUNCH_DIRECTIVE                   (PMIX_ERR_OP_BASE - 24)
 #define PMIX_LAUNCHER_READY                     (PMIX_ERR_OP_BASE - 25)
 #define PMIX_OPERATION_IN_PROGRESS              (PMIX_ERR_OP_BASE - 26)
+#define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
 
 
 /* define a starting point for system error constants so

--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -85,7 +85,7 @@ static void query_cbfunc(struct pmix_peer_t *peer,
     /* unpack any returned data */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, peer, buf, &results->ninfo, &cnt, PMIX_SIZE);
-    if (PMIX_SUCCESS != rc) {
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
         PMIX_ERROR_LOG(rc);
         goto complete;
     }
@@ -332,6 +332,11 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
         return PMIX_ERR_INIT;
     }
 
+    /* sanity check */
+    if (NULL == monitor) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
     /* if we are the server, then we just issue the request and
      * return the response */
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
@@ -354,6 +359,19 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
         return PMIX_ERR_UNREACH;
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* if the monitor is PMIX_SEND_HEARTBEAT, then send it */
+    if (0 == strncmp(monitor->key, PMIX_SEND_HEARTBEAT, PMIX_MAX_KEYLEN)) {
+        msg = PMIX_NEW(pmix_buffer_t);
+        if (NULL == msg) {
+            return PMIX_ERR_NOMEM;
+        }
+        PMIX_PTL_SEND_ONEWAY(rc, pmix_client_globals.myserver, msg, PMIX_PTL_TAG_HEARTBEAT);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE(msg);
+        }
+        return rc;
+    }
 
     /* if we are a client, then relay this request to the server */
     msg = PMIX_NEW(pmix_buffer_t);

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.  All rights
  *                         reserved.
   *
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,7 +30,7 @@
 #include "src/util/output.h"
 #include "src/util/show_help.h"
 #include "src/include/pmix_globals.h"
-#include "src/mca/ptl/ptl.h"
+#include "src/mca/ptl/base/base.h"
 
 #include "src/mca/psensor/base/base.h"
 #include "psensor_heartbeat.h"
@@ -158,6 +158,7 @@ static void add_tracker(int sd, short flags, void *cbdata)
     /* setup the timer event */
     pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev,
                            check_heartbeat, ft);
+    pmix_output(0, "SETTING TIMER FOR %d SEC", ft->tv.tv_sec);
     pmix_event_evtimer_add(&ft->ev, &ft->tv);
     ft->event_active = true;
 }
@@ -168,6 +169,7 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
 {
     pmix_heartbeat_trkr_t *ft;
     size_t n;
+    pmix_ptl_posted_recv_t *rcv;
 
     PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
                          "[%s:%d] checking heartbeat monitoring for requestor %s:%d",
@@ -200,6 +202,17 @@ static pmix_status_t heartbeat_start(pmix_peer_t *requestor, pmix_status_t error
         /* didn't specify a sample rate, or what should be sampled */
         PMIX_RELEASE(ft);
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* if the recv hasn't been posted, so so now */
+    if (!mca_psensor_heartbeat_component.recv_active) {
+        /* setup to receive heartbeats */
+        rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
+        rcv->tag = PMIX_PTL_TAG_HEARTBEAT;
+        rcv->cbfunc = pmix_psensor_heartbeat_recv_beats;
+        /* add it to the beginning of the list of recvs */
+        pmix_list_prepend(&pmix_ptl_globals.posted_recvs, &rcv->super);
+        mca_psensor_heartbeat_component.recv_active = true;
     }
 
     /* need to push into our event base to add this to our trackers */
@@ -241,7 +254,7 @@ static pmix_status_t heartbeat_stop(pmix_peer_t *requestor, char *id)
     cd->requestor = requestor;
     cd->id = strdup(id);
 
-    /* need to push into our event base to add this to our trackers */
+    /* need to push into our event base to remove this from our trackers */
     pmix_event_assign(&cd->ev, pmix_psensor_base.evbase, -1,
                       EV_WRITE, del_tracker, cd);
     PMIX_POST_OBJECT(cd);

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -158,7 +158,6 @@ static void add_tracker(int sd, short flags, void *cbdata)
     /* setup the timer event */
     pmix_event_evtimer_set(pmix_psensor_base.evbase, &ft->ev,
                            check_heartbeat, ft);
-    pmix_output(0, "SETTING TIMER FOR %d SEC", ft->tv.tv_sec);
     pmix_event_evtimer_add(&ft->ev, &ft->tv);
     ft->event_active = true;
 }

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.h
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.h
@@ -2,7 +2,7 @@
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
  *
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -28,6 +28,7 @@ BEGIN_C_DECLS
 
 typedef struct {
     pmix_psensor_base_component_t super;
+    bool recv_active;
     pmix_list_t trackers;
 } pmix_psensor_heartbeat_component_t;
 

--- a/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat_component.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -50,14 +50,9 @@ pmix_psensor_heartbeat_component_t mca_psensor_heartbeat_component = {
   */
 static int heartbeat_open(void)
 {
-    pmix_status_t rc;
-
     PMIX_CONSTRUCT(&mca_psensor_heartbeat_component.trackers, pmix_list_t);
 
-    /* setup to receive heartbeats */
-    PMIX_PTL_RECV(rc, pmix_globals.mypeer, pmix_psensor_heartbeat_recv_beats, PMIX_PTL_TAG_HEARTBEAT);
-
-    return rc;
+    return PMIX_SUCCESS;
 }
 
 
@@ -74,12 +69,7 @@ static int heartbeat_query(pmix_mca_base_module_t **module, int *priority)
 
 static int heartbeat_close(void)
 {
-    pmix_status_t rc;
-
-    /* cancel our persistent recv */
-    PMIX_PTL_CANCEL(rc, pmix_globals.mypeer, PMIX_PTL_TAG_HEARTBEAT);
-
     PMIX_LIST_DESTRUCT(&mca_psensor_heartbeat_component.trackers);
 
-    return rc;
+    return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -67,6 +67,7 @@
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
 #include "src/mca/preg/preg.h"
+#include "src/mca/psensor/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/hwloc/hwloc-internal.h"
 
@@ -407,6 +408,16 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         }
     }
 
+    /* open the psensor framework */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_psensor_base_framework, 0))) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return rc;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_psensor_base_select())) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return rc;
+    }
+
     /* setup the wildcard recv for inbound messages from clients */
     req = PMIX_NEW(pmix_ptl_posted_recv_t);
     req->tag = UINT32_MAX;
@@ -521,6 +532,8 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     if (NULL != pmix_server_globals.tmpdir) {
         free(pmix_server_globals.tmpdir);
     }
+    /* close the psensor framework */
+    (void)pmix_mca_base_framework_close(&pmix_psensor_base_framework);
     /* close the pnet framework */
     (void)pmix_mca_base_framework_close(&pmix_pnet_base_framework);
 
@@ -3237,6 +3250,9 @@ void pmix_server_message_handler(struct pmix_peer_t *pr,
         if (NULL == reply) {
             PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
             return;
+        }
+        if (PMIX_OPERATION_SUCCEEDED == ret) {
+            ret = PMIX_SUCCESS;
         }
         PMIX_BFROPS_PACK(rc, pr, reply, &ret, 1, PMIX_STATUS);
         if (PMIX_SUCCESS != rc) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -52,6 +52,7 @@
 #include "src/class/pmix_list.h"
 #include "src/mca/bfrops/bfrops.h"
 #include "src/mca/plog/plog.h"
+#include "src/mca/psensor/psensor.h"
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/output.h"
@@ -2537,7 +2538,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
         if (cnt == (int)cd->ninfo) {
             /* nothing more to do */
             if (NULL != cbfunc) {
-                cbfunc(PMIX_SUCCESS, NULL, 0, cd, NULL, NULL);
+                cbfunc(PMIX_SUCCESS, NULL, 0, cd->cbdata, NULL, NULL);
             }
             return PMIX_SUCCESS;
         }
@@ -2575,9 +2576,6 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer,
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "recvd monitor request from client");
 
-    if (NULL == pmix_host_server.monitor) {
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
 
     cd = PMIX_NEW(pmix_query_caddy_t);
     if (NULL == cd) {
@@ -2618,6 +2616,24 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer,
             PMIX_ERROR_LOG(rc);
             goto exit;
         }
+    }
+
+    /* see if they are requesting one of the monitoring
+     * methods we internally support */
+    rc = pmix_psensor.start(peer, error, &monitor, cd->info, cd->ninfo);
+    if (PMIX_SUCCESS == rc) {
+        rc = PMIX_OPERATION_SUCCEEDED;
+        goto exit;
+    }
+    if (PMIX_ERR_NOT_SUPPORTED != rc) {
+        goto exit;
+    }
+
+    /* if we don't internally support it, see if
+     * our host does */
+    if (NULL == pmix_host_server.monitor) {
+        rc = PMIX_ERR_NOT_SUPPORTED;
+        goto exit;
     }
 
     /* setup the requesting peer name */

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -25,7 +25,7 @@ headers = simptest.h
 
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simplegacy simptimeout \
-                  gwtest gwclient stability quietclient
+                  gwtest gwclient stability quietclient simpjctrl
 
 simptest_SOURCES = \
         simptest.c
@@ -115,4 +115,10 @@ quietclient_SOURCES = \
         quietclient.c
 quietclient_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 quietclient_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpjctrl_SOURCES = \
+        simpjctrl.c
+simpjctrl_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpjctrl_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/simpjctrl.c
+++ b/test/simple/simpjctrl.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <signal.h>
+
+#include <pmix.h>
+#include "simptest.h"
+
+static pmix_proc_t myproc;
+
+/* this is the event notification function we pass down below
+ * when registering for general events - i.e.,, the default
+ * handler. We don't technically need to register one, but it
+ * is usually good practice to catch any events that occur */
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lk = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lk->status = status;
+    DEBUG_WAKEUP_THREAD(lk);
+}
+
+static void infocbfunc(pmix_status_t status,
+                       pmix_info_t *info, size_t ninfo,
+                       void *cbdata,
+                       pmix_release_cbfunc_t release_fn,
+                       void *release_cbdata)
+{
+    mylock_t *lk = (mylock_t*)cbdata;
+
+    fprintf(stderr, "Callback recvd with status %d\n", status);
+
+    /* release the caller */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    lk->status = status;
+    DEBUG_WAKEUP_THREAD(lk);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc;
+    uint32_t nprocs, n;
+    pmix_info_t *info, *iptr;
+    bool flag;
+    mylock_t mylock;
+    pmix_data_array_t *dptr;
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+
+    /* register our default event handler - again, this isn't strictly
+     * required, but is generally good practice */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (0 != mylock.status) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace, myproc.rank);
+        exit(mylock.status);
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    /* job-related info is found in our nspace, assigned to the
+     * wildcard rank as it doesn't relate to a specific rank. Setup
+     * a name to retrieve such values */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* get our universe size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* inform the RM that we are preemptible, and that our checkpoint methods are
+     * "signal" on SIGUSR2 and event on PMIX_JCTRL_CHECKPOINT */
+    PMIX_INFO_CREATE(info, 2);
+    flag = true;
+    PMIX_INFO_LOAD(&info[0], PMIX_JOB_CTRL_PREEMPTIBLE, (void*)&flag, PMIX_BOOL);
+    /* can't use "load" to load a pmix_data_array_t */
+    (void)strncpy(info[1].key, PMIX_JOB_CTRL_CHECKPOINT_METHOD, PMIX_MAX_KEYLEN);
+    info[1].value.type = PMIX_DATA_ARRAY;
+    dptr = (pmix_data_array_t*)malloc(sizeof(pmix_data_array_t));
+    info[1].value.data.darray = dptr;
+    dptr->type = PMIX_INFO;
+    dptr->size = 2;
+    PMIX_INFO_CREATE(dptr->array, dptr->size);
+    rc = SIGUSR2;
+    iptr = (pmix_info_t*)dptr->array;
+    PMIX_INFO_LOAD(&iptr[0], PMIX_JOB_CTRL_CHECKPOINT_SIGNAL, &rc, PMIX_INT);
+    rc = PMIX_JCTRL_CHECKPOINT;
+    PMIX_INFO_LOAD(&iptr[1], PMIX_JOB_CTRL_CHECKPOINT_EVENT, &rc, PMIX_STATUS);
+
+    /* since this is informational and not a requested operation, the target parameter
+     * doesn't mean anything and can be ignored */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != (rc = PMIx_Job_control_nb(NULL, 0, info, 2, infocbfunc, (void*)&mylock))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Job_control_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&mylock);
+    PMIX_INFO_FREE(info, 2);
+    if (0 != mylock.status) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Job_control_nb failed: %d\n", myproc.nspace, myproc.rank, mylock.status);
+        exit(mylock.status);
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    /* now request that this process be monitored using heartbeats */
+    PMIX_INFO_CREATE(iptr, 1);
+    PMIX_INFO_LOAD(&iptr[0], PMIX_MONITOR_HEARTBEAT, NULL, PMIX_POINTER);
+
+    PMIX_INFO_CREATE(info, 3);
+    PMIX_INFO_LOAD(&info[0], PMIX_MONITOR_ID, "MONITOR1", PMIX_STRING);
+    n = 5;  // require a heartbeat every 5 seconds
+    PMIX_INFO_LOAD(&info[1], PMIX_MONITOR_HEARTBEAT_TIME, &n, PMIX_UINT32);
+    n = 2;  // two heartbeats can be missed before declaring us "stalled"
+    PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_HEARTBEAT_DROPS, &n, PMIX_UINT32);
+
+    /* make the request */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != (rc = PMIx_Process_monitor_nb(iptr, PMIX_MONITOR_HEARTBEAT_ALERT,
+                                                      info, 3, infocbfunc, (void*)&mylock))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&mylock);
+    PMIX_INFO_FREE(iptr, 1);
+    PMIX_INFO_FREE(info, 3);
+    if (0 != mylock.status) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %d\n", myproc.nspace, myproc.rank, mylock.status);
+        exit(mylock.status);
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+    /* send a heartbeat */
+    PMIx_Heartbeat();
+
+    /* call fence to synchronize with our peers - no need to
+     * collect any info as we didn't "put" anything */
+    PMIX_INFO_CREATE(info, 1);
+    flag = false;
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    PMIX_INFO_FREE(info, 1);
+
+
+  done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -107,6 +107,18 @@ static void log_fn(const pmix_proc_t *client,
                    const pmix_info_t data[], size_t ndata,
                    const pmix_info_t directives[], size_t ndirs,
                    pmix_op_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t alloc_fn(const pmix_proc_t *client,
+                              pmix_alloc_directive_t directive,
+                              const pmix_info_t data[], size_t ndata,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t jctrl_fn(const pmix_proc_t *requestor,
+                              const pmix_proc_t targets[], size_t ntargets,
+                              const pmix_info_t directives[], size_t ndirs,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+static pmix_status_t mon_fn(const pmix_proc_t *requestor,
+                            const pmix_info_t *monitor, pmix_status_t error,
+                            const pmix_info_t directives[], size_t ndirs,
+                            pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 static pmix_server_module_t mymodule = {
     .client_connected = connected,
@@ -125,7 +137,10 @@ static pmix_server_module_t mymodule = {
     .notify_event = notify_event,
     .query = query_fn,
     .tool_connected = tool_connect_fn,
-    .log = log_fn
+    .log = log_fn,
+    .allocate = alloc_fn,
+    .job_control = jctrl_fn,
+    .monitor = mon_fn
 };
 
 typedef struct {
@@ -1096,6 +1111,31 @@ static void log_fn(const pmix_proc_t *client,
         cbfunc(PMIX_SUCCESS, cbdata);
     }
 }
+
+static pmix_status_t alloc_fn(const pmix_proc_t *client,
+                              pmix_alloc_directive_t directive,
+                              const pmix_info_t data[], size_t ndata,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t jctrl_fn(const pmix_proc_t *requestor,
+                              const pmix_proc_t targets[], size_t ntargets,
+                              const pmix_info_t directives[], size_t ndirs,
+                              pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_OPERATION_SUCCEEDED;
+}
+
+static pmix_status_t mon_fn(const pmix_proc_t *requestor,
+                            const pmix_info_t *monitor, pmix_status_t error,
+                            const pmix_info_t directives[], size_t ndirs,
+                            pmix_info_cbfunc_t cbfunc, void *cbdata)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
 
 static void wait_signal_callback(int fd, short event, void *arg)
 {


### PR DESCRIPTION
Somehow, we missed fully implementing these APIs in the PMIx library.
Fix that by properly handling monitoring requests and by fixing the
heartbeat component. Also ensure that we have a way for a host to
indicate they atomically handled the request for those cases where they
cannot thread shift to call the callback function.

Fixes #806 

Signed-off-by: Ralph Castain <rhc@open-mpi.org>