### PR TITLE
Update the job_ctrl return code

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2537,7 +2537,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
         PMIX_LIST_DESTRUCT(&cachefiles);
         if (cnt == (int)cd->ninfo) {
             /* nothing more to do */
-            rc = PMIX_SUCCESS;
+            rc = PMIX_OPERATION_SUCCEEDED;
             goto exit;
         }
     }


### PR DESCRIPTION
Return OPERATION_SUCCEEDED for cleanup registrations

Signed-off-by: Ralph Castain <rhc@open-mpi.org>