### PR TITLE
Update sensor support

### DIFF
--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -6,7 +6,7 @@
  * Copyright (c) 2011-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
  *
- * Copyright (c) 2017      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -258,7 +258,9 @@ static pmix_status_t stop(pmix_peer_t *requestor, char *id)
     cd = PMIX_NEW(file_caddy_t);
     PMIX_RETAIN(requestor);
     cd->requestor = requestor;
-    cd->id = strdup(id);
+    if (NULL != id) {
+        cd->id = strdup(id);
+    }
 
     /* need to push into our event base to add this to our trackers */
     pmix_event_assign(&cd->ev, pmix_psensor_base.evbase, -1,

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -63,6 +63,7 @@ typedef struct {
     pmix_data_range_t range;
     pmix_info_t *info;
     size_t ninfo;
+    bool stopped;
 } pmix_heartbeat_trkr_t;
 
 static void ft_constructor(pmix_heartbeat_trkr_t *ft)
@@ -79,6 +80,7 @@ static void ft_constructor(pmix_heartbeat_trkr_t *ft)
     ft->range = PMIX_RANGE_NAMESPACE;
     ft->info = NULL;
     ft->ninfo = 0;
+    ft->stopped = false;
 }
 static void ft_destructor(pmix_heartbeat_trkr_t *ft)
 {
@@ -251,7 +253,9 @@ static pmix_status_t heartbeat_stop(pmix_peer_t *requestor, char *id)
     cd = PMIX_NEW(heartbeat_caddy_t);
     PMIX_RETAIN(requestor);
     cd->requestor = requestor;
-    cd->id = strdup(id);
+    if (NULL != id) {
+        cd->id = strdup(id);
+    }
 
     /* need to push into our event base to remove this from our trackers */
     pmix_event_assign(&cd->ev, pmix_psensor_base.evbase, -1,
@@ -266,7 +270,7 @@ static void opcbfunc(pmix_status_t status, void *cbdata)
 {
     pmix_heartbeat_trkr_t *ft = (pmix_heartbeat_trkr_t*)cbdata;
 
-    PMIX_RELEASE(ft);
+    PMIX_RELEASE(ft);  // maintain accounting
 }
 
 /* this function automatically gets periodically called
@@ -286,17 +290,20 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
                          pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank));
 
-    if (0 == ft->nbeats) {
+    if (0 == ft->nbeats && !ft->stopped) {
         /* no heartbeat recvd in last window */
         PMIX_OUTPUT_VERBOSE((1, pmix_psensor_base_framework.framework_output,
                              "[%s:%d] sensor:check_heartbeat failed for proc %s:%d",
                              pmix_globals.myid.nspace, pmix_globals.myid.rank,
                              ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank));
-        /* stop monitoring this client */
-        pmix_list_remove_item(&mca_psensor_heartbeat_component.trackers, &ft->super);
         /* generate an event */
         (void)strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         source.rank = ft->requestor->info->pname.rank;
+        /* ensure the tracker remains throughout the process */
+        PMIX_RETAIN(ft);
+        /* mark that the process appears stopped so we don't
+         * continue to report it */
+        ft->stopped = true;
         rc = PMIx_Notify_event(PMIX_MONITOR_HEARTBEAT_ALERT, &source,
                                ft->range, ft->info, ft->ninfo, opcbfunc, ft);
         if (PMIX_SUCCESS != rc) {
@@ -328,6 +335,8 @@ static void add_beat(int sd, short args, void *cbdata)
         if (ft->requestor == b->peer) {
             /* increment the beat count */
             ++ft->nbeats;
+            /* ensure we know that the proc is alive */
+            ft->stopped = false;
             break;
         }
     }

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -45,6 +45,7 @@
 #include "src/server/pmix_server_ops.h"
 #include "src/util/error.h"
 #include "src/util/show_help.h"
+#include "src/mca/psensor/psensor.h"
 
 #include "src/mca/ptl/base/base.h"
 
@@ -148,6 +149,9 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 }
             }
         }
+        /* cleanup any sensors that are monitoring them */
+        pmix_psensor.stop(peer, NULL);
+
         if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer)) {
             /* if this peer already called finalize, then
              * we are just seeing their connection go away

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1071,6 +1071,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
                  * for tools, so don't clean them up */
                 if (!PMIX_PROC_IS_TOOL(peer)) {
                     pmix_pnet.child_finalized(&cd->proc);
+                    pmix_psensor.stop(peer, NULL);
                 }
             }
             if (nptr->nlocalprocs == nptr->nfinalized) {


### PR DESCRIPTION
Ensure we cleanup any active sensors when a peer departs. Allow the
heartbeat monitor to "reset" if a process stops beating and subsequently
returns

Fixes #819

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 95d2fbb6e53c00274b81afbfadb2a5b168383fb5)