### PR TITLE
Implement PMIx group collective APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ examples/pub
 examples/pubi
 examples/server
 examples/tool
+examples/group
+examples/asyncgroup
 
 include/pmix_version.h
 include/pmix_rename.h

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -21,7 +21,7 @@
 
 AM_CPPFLAGS = -I$(top_builddir)/src -I$(top_builddir)/src/include -I$(top_builddir)/include -I$(top_builddir)/include/pmix
 
-noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl
+noinst_PROGRAMS = client client2 dmodex dynamic fault pub pubi tool debugger debuggerd alloc jctrl group asyncgroup
 if !WANT_HIDDEN
 # these examples use internal symbols
 # use --disable-visibility
@@ -75,6 +75,14 @@ pubi_LDADD = $(top_builddir)/src/libpmix.la
 tool_SOURCES = tool.c
 tool_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 tool_LDADD = $(top_builddir)/src/libpmix.la
+
+group_SOURCES = group.c
+group_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+group_LDADD = $(top_builddir)/src/libpmix.la
+
+asyncgroup_SOURCES = asyncgroup.c
+asyncgroup_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+asyncgroup_LDADD = $(top_builddir)/src/libpmix.la
 
 if !WANT_HIDDEN
 server_SOURCES = server.c

--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <pmix.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
+
+
+static pmix_proc_t myproc;
+static mylock_t invitedlock;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+static void op_callbk(pmix_status_t status,
+                      void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void errhandler_reg_callbk(pmix_status_t status,
+                                  size_t errhandler_ref,
+                                  void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void grpcomplete(pmix_status_t status,
+                        void *cbdata)
+{
+    fprintf(stderr, "%s:%d GRPCOMPLETE\n", myproc.nspace, myproc.rank);
+    DEBUG_WAKEUP_THREAD(&invitedlock);
+}
+
+static void invitefn(size_t evhdlr_registration_id,
+                     pmix_status_t status,
+                     const pmix_proc_t *source,
+                     pmix_info_t info[], size_t ninfo,
+                     pmix_info_t results[], size_t nresults,
+                     pmix_event_notification_cbfunc_fn_t cbfunc,
+                     void *cbdata)
+{
+    size_t n;
+    char *grp;
+    pmix_status_t rc;
+
+    /* if I am the leader, I can ignore this event */
+    if (PMIX_CHECK_PROCID(source, &myproc)) {
+        fprintf(stderr, "%s:%d INVITED, BUT LEADER\n", myproc.nspace, myproc.rank);
+        /* mark the event chain as complete */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    /* search for grp id */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_GROUP_ID)) {
+            grp = info[n].value.data.string;
+            break;
+        }
+    }
+    fprintf(stderr, "Client %s:%d INVITED by source %s:%d\n",
+            myproc.nspace, myproc.rank,
+            source->nspace, source->rank);
+    invitedlock.status = status;
+    fprintf(stderr, "%s:%d ACCEPTING INVITE\n", myproc.nspace, myproc.rank);
+    rc = PMIx_Group_join_nb(grp, source, PMIX_GROUP_ACCEPT, NULL, 0, grpcomplete, NULL);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "%s:%d Error in Group_join_nb: %sn", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    }
+
+    /* mark the event chain as complete */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+}
+
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs;
+    mylock_t lock;
+    pmix_status_t code;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "[%d] Client ns %s rank %d: Running\n", (int)getpid(), myproc.nspace, myproc.rank);
+
+    DEBUG_CONSTRUCT_LOCK(&invitedlock);
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* get our universe size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (4 < nprocs) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        goto done;
+    }
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* register our default errhandler */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, errhandler_reg_callbk, (void*)&lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    /* we need to register handlers for invitations */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    code = PMIX_GROUP_INVITED;
+    PMIx_Register_event_handler(&code, 1, NULL, 0,
+                                invitefn, errhandler_reg_callbk, (void*)&lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+
+    /* rank=0 constructs a new group */
+    if (0 == myproc.rank) {
+        fprintf(stderr, "%d executing Group_invite\n", myproc.rank);
+        nprocs = 3;
+        PMIX_PROC_CREATE(procs, nprocs);
+        PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
+        PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
+        PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
+        rc = PMIx_Group_invite("ourgroup", procs, nprocs, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_invite failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        PMIX_PROC_FREE(procs, nprocs);
+        fprintf(stderr, "%s:%d Execute fence across group\n", myproc.nspace, myproc.rank);
+        PMIX_PROC_LOAD(&proc, "ourgroup", PMIX_RANK_WILDCARD);
+        rc = PMIx_Fence(&proc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+        rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+    } else if (2 == myproc.rank || 3 == myproc.rank) {
+        /* wait to be invited */
+        fprintf(stderr, "%s:%d waiting to be invited\n", myproc.nspace, myproc.rank);
+        DEBUG_WAIT_THREAD(&invitedlock);
+        DEBUG_DESTRUCT_LOCK(&invitedlock);
+        fprintf(stderr, "%s:%d Execute fence across group\n", myproc.nspace, myproc.rank);
+        PMIX_PROC_LOAD(&proc, "ourgroup", PMIX_RANK_WILDCARD);
+        rc = PMIx_Fence(&proc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+        rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+ done:
+    /* finalize us */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Deregister_event_handler(1, op_callbk, &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    DEBUG_DESTRUCT_LOCK(&lock);
+
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fprintf(stderr, "%s:%d COMPLETE\n", myproc.nspace, myproc.rank);
+    fflush(stderr);
+    return(0);
+}

--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -190,7 +190,7 @@ int main(int argc, char **argv)
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    if (4 < nprocs) {
+    if (nprocs < 4) {
         if (0 == myproc.rank) {
             fprintf(stderr, "This example requires a minimum of 4 processes\n");
         }

--- a/examples/group.c
+++ b/examples/group.c
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <pmix.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
+
+
+static pmix_proc_t myproc;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
+}
+
+static void op_callbk(pmix_status_t status,
+                      void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    fprintf(stderr, "Client %s:%d OP CALLBACK CALLED WITH STATUS %d\n", myproc.nspace, myproc.rank, status);
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void errhandler_reg_callbk(pmix_status_t status,
+                                  size_t errhandler_ref,
+                                  void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    fprintf(stderr, "Client %s:%d ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu\n",
+               myproc.nspace, myproc.rank, status, (unsigned long)errhandler_ref);
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    int rc;
+    pmix_value_t value;
+    pmix_value_t *val = &value;
+    pmix_proc_t proc, *procs;
+    uint32_t nprocs;
+    mylock_t lock;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+
+    /* get our universe size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    nprocs = val->data.uint32;
+    PMIX_VALUE_RELEASE(val);
+    if (nprocs < 4) {
+        if (0 == myproc.rank) {
+            fprintf(stderr, "This example requires a minimum of 4 processes\n");
+        }
+        goto done;
+    }
+    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+
+    /* register our default errhandler */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, errhandler_reg_callbk, (void*)&lock);
+    DEBUG_WAIT_THREAD(&lock);
+    rc = lock.status;
+    DEBUG_DESTRUCT_LOCK(&lock);
+    if (PMIX_SUCCESS != rc) {
+        goto done;
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+
+    /* rank=0,2,3 construct a new group */
+    if (0 == myproc.rank || 2 == myproc.rank || 3 == myproc.rank) {
+        fprintf(stderr, "%d executing Group_construct\n", myproc.rank);
+        nprocs = 3;
+        PMIX_PROC_CREATE(procs, nprocs);
+        PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
+        PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
+        PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
+        rc = PMIx_Group_construct("ourgroup", procs, nprocs, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+        PMIX_PROC_FREE(procs, nprocs);
+        fprintf(stderr, "Execute fence across group\n");
+        PMIX_PROC_LOAD(&proc, "ourgroup", PMIX_RANK_WILDCARD);
+        rc = PMIx_Fence(&proc, 1, NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
+        rc = PMIx_Group_destruct("ourgroup", NULL, 0);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto done;
+        }
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+
+ done:
+    /* finalize us */
+    DEBUG_CONSTRUCT_LOCK(&lock);
+    PMIx_Deregister_event_handler(1, op_callbk, &lock);
+    DEBUG_WAIT_THREAD(&lock);
+    DEBUG_DESTRUCT_LOCK(&lock);
+
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    sleep(myproc.rank);
+    fprintf(stderr, "%s:%d COMPLETE\n", myproc.nspace, myproc.rank);
+    fflush(stderr);
+    return(0);
+}

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -783,6 +783,9 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
  *    PMIX_GROUP_NOTIFY_TERMINATION - notify remaining members when another member
  *                                    terminates without first leaving the
  *                                    group (default=false)
+ *    PMIX_GROUP_ASSIGN_CONTEXT_ID - requests that the RM assign a unique context
+ *                                   ID (size_t) to the group. The value is returned
+ *                                   in the PMIX_GROUP_CONSTRUCT_COMPLETE event
  *    PMIX_TIMEOUT - return an error if the group doesn't assemble within the
  *                   specified number of seconds. Targets the scenario where a
  *                   process fails to call PMIx_Group_connect due to hanging
@@ -812,6 +815,9 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
  * information of the other process.
  *
  * Some relevant attributes for this operation:
+ *    PMIX_GROUP_ASSIGN_CONTEXT_ID - requests that the RM assign a unique context
+ *                                   ID (size_t) to the group. The value is returned
+ *                                   in the PMIX_GROUP_CONSTRUCT_COMPLETE event
  *    PMIX_TIMEOUT (int): return an error if the group doesn’t assemble within the
  *                        specified number of seconds. Targets the scenario where a
  *                        process fails to call PMIx_Group_connect due to hanging

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -721,6 +721,233 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
                                         const pmix_info_t directives[], size_t ndirs,
                                         pmix_op_cbfunc_t cbfunc, void *cbdata);
 
+/* Construct a new group composed of the specified processes and identified with
+ * the provided group identifier. Both blocking and non-blocking versions
+ * are provided (the callback function for the non-blocking form will be called
+ * once all specified processes have joined the group). The group identifier is
+ * a user-defined, NULL-terminated character array of length less than or equal
+ * to PMIX_MAX_NSLEN. Only characters accepted by standard string comparison
+ * functions (e.g., strncmp) are supported.
+ *
+ * Processes may engage in multiple simultaneous group construct operations as
+ * desired so long as each is provided with a unique group ID. The info array
+ * can be used to pass user-level directives regarding timeout constraints and
+ * other options available from the PMIx server.
+ *
+ * The construct leader (if PMIX_GROUP_LEADER is provided) or all participants
+ * will receive events (if registered for the PMIX_GROUP_MEMBER_FAILED event)
+ * whenever a process fails or terminates prior to calling
+ * PMIx_Group_construct(_nb) – the events will contain the identifier of the
+ * process that failed to join plus any other information that the resource
+ * manager provided. This provides an opportunity for the leader to react to
+ * the event – e.g., to invite an alternative member to the group or to decide
+ * to proceed with a smaller group. The decision to proceed with a smaller group
+ * is communicated to the PMIx library in the results array at the end of the
+ * event handler. This allows PMIx to properly adjust accounting for procedure
+ * completion. When construct is complete, the participating PMIx servers will
+ * be alerted to any change in participants and each group member will (if
+ * registered) receive a PMIX_GROUP_MEMBERSHIP_UPDATE event updating the group
+ * membership.
+ *
+ * Processes in a group under construction are not allowed to leave the group
+ * until group construction is complete. Upon completion of the construct
+ * procedure, each group member will have access to the job-level information
+ * of all nspaces represented in the group and the contact information for
+ * every group member.
+ *
+ * Failure of the leader at any time will cause a PMIX_GROUP_LEADER_FAILED event
+ * to be delivered to all participants so they can optionally declare a new leader.
+ * A new leader is identified by providing the PMIX_GROUP_LEADER attribute in
+ * the results array in the return of the event handler. Only one process is
+ * allowed to return that attribute, declaring itself as the new leader. Results
+ * of the leader selection will be communicated to all participants via a
+ * PMIX_GROUP_LEADER_SELECTED event identifying the new leader. If no leader
+ * was selected, then the status code provided in the event handler will provide
+ * an error value so the participants can take appropriate action.
+ *
+ * Any participant that returns PMIX_GROUP_CONSTRUCT_ABORT from the leader failed
+ * event handler will cause the construct process to abort. Those processes
+ * engaged in the blocking construct will return from the call with the
+ * PMIX_GROUP_CONSTRUCT_ABORT status. Non-blocking partipants will have
+ * their callback function executed with that status.
+ *
+ * Some relevant attributes for this operation:
+ *    PMIX_GROUP_LEADER - declare this process to be the leader of the construction
+ *                        procedure. If a process provides this attribute, then
+ *                        failure notification for any participating process will
+ *                        go only to that one process. In the absence of a
+ *                        declared leader, failure events go to all participants.
+ *    PMIX_GROUP_OPTIONAL - participation is optional - do not return an error if
+ *                          any of the specified processes terminate
+ *                          without having joined (default=false)
+ *    PMIX_GROUP_NOTIFY_TERMINATION - notify remaining members when another member
+ *                                    terminates without first leaving the
+ *                                    group (default=false)
+ *    PMIX_TIMEOUT - return an error if the group doesn't assemble within the
+ *                   specified number of seconds. Targets the scenario where a
+ *                   process fails to call PMIx_Group_connect due to hanging
+ */
+PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[],
+                                               const pmix_proc_t procs[], size_t nprocs,
+                                               const pmix_info_t info[], size_t ninfo);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
+                                                  const pmix_proc_t procs[], size_t nprocs,
+                                                  const pmix_info_t info[], size_t ninfo,
+                                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Explicitly invite specified processes to join a group.
+ *
+ * Each invited process will be notified of the invitation via the PMIX_GROUP_INVITED
+ * event. The processes being invited must have registered for the PMIX_GROUP_INVITED
+ * event in order to be notified of the invitation. When ready to respond, each invited
+ * process provides a response using the appropriate form of PMIx_Group_join. This will
+ * notify the inviting process that the invitation was either accepted (via the
+ * PMIX_GROUP_INVITE_ACCEPTED event) or declined (via the PMIX_GROUP_INVITE_DECLINED event).
+ * The inviting process will also receive PMIX_GROUP_MEMBER_FAILED events whenever a
+ * process fails or terminates prior to responding to the invitation.
+ *
+ * Upon accepting the invitation, both the inviting and invited process will receive
+ * access to the job-level information of each other’s nspaces and the contact
+ * information of the other process.
+ *
+ * Some relevant attributes for this operation:
+ *    PMIX_TIMEOUT (int): return an error if the group doesn’t assemble within the
+ *                        specified number of seconds. Targets the scenario where a
+ *                        process fails to call PMIx_Group_connect due to hanging
+ *
+ * The inviting process is automatically considered the leader of the asynchronous
+ * group construction procedure and will receive all failure or termination events
+ * for invited members prior to completion. The inviting process is required to
+ * provide a PMIX_GROUP_CONSTRUCT_COMPLETE event once the group has been fully
+ * assembled – this event will be distributed to all participants along with the
+ * final membership.
+ *
+ * Failure of the leader at any time will cause a PMIX_GROUP_LEADER_FAILED event
+ * to be delivered to all participants so they can optionally declare a new leader.
+ * A new leader is identified by providing the PMIX_GROUP_LEADER attribute in
+ * the results array in the return of the event handler. Only one process is
+ * allowed to return that attribute, declaring itself as the new leader. Results
+ * of the leader selection will be communicated to all participants via a
+ * PMIX_GROUP_LEADER_SELECTED event identifying the new leader. If no leader
+ * was selected, then the status code provided in the event handler will provide
+ * an error value so the participants can take appropriate action.
+ *
+ * Any participant that returns PMIX_GROUP_CONSTRUCT_ABORT from the event
+ * handler will cause all participants to receive an event notifying them
+ * of that status.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[],
+                                            const pmix_proc_t procs[], size_t nprocs,
+                                            const pmix_info_t info[], size_t ninfo);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[],
+                                               const pmix_proc_t procs[], size_t nprocs,
+                                               const pmix_info_t info[], size_t ninfo,
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Respond to an invitation to join a group that is being asynchronously constructed.
+ *
+ * The process must have registered for the PMIX_GROUP_INVITED event in order to be
+ * notified of the invitation. When ready to respond, the process provides a response
+ * using the appropriate form of PMIx_Group_join.
+ *
+ * Critical Note: Since the process is alerted to the invitation in a PMIx event handler,
+ * the process must not use the blocking form of this call unless it first “thread shifts”
+ * out of the handler and into its own thread context. Likewise, while it is safe to call
+ * the non-blocking form of the API from the event handler, the process must not block
+ * in the handler while waiting for the callback function to be called.
+ *
+ * Calling this function causes the group “leader” to be notified that the process has
+ * either accepted or declined the request. The blocking form of the API will return
+ * once the group has been completely constructed or the group’s construction has failed
+ * (as determined by the leader) – likewise, the callback function of the non-blocking
+ * form will be executed upon the same conditions.
+ *
+ * Failure of the leader at any time will cause a PMIX_GROUP_LEADER_FAILED event
+ * to be delivered to all participants so they can optionally declare a new leader.
+ * A new leader is identified by providing the PMIX_GROUP_LEADER attribute in
+ * the results array in the return of the event handler. Only one process is
+ * allowed to return that attribute, declaring itself as the new leader. Results
+ * of the leader selection will be communicated to all participants via a
+ * PMIX_GROUP_LEADER_SELECTED event identifying the new leader. If no leader
+ * was selected, then the status code provided in the event handler will provide
+ * an error value so the participants can take appropriate action.
+ *
+ * Any participant that returns PMIX_GROUP_CONSTRUCT_ABORT from the leader failed
+ * event handler will cause all participants to receive an event notifying them
+ * of that status. Similarly, the leader may elect to abort the procedure
+ * by either returning PMIX_GROUP_CONSTRUCT_ABORT from the handler assigned
+ * to the PMIX_GROUP_INVITE_ACCEPTED or PMIX_GROUP_INVITE_DECLINED codes, or
+ * by generating an event for the abort code. Abort events will be sent to
+ * all invited participants.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[],
+                                          const pmix_proc_t *leader,
+                                          pmix_group_opt_t opt,
+                                          const pmix_info_t info[], size_t ninfo);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[],
+                                             const pmix_proc_t *leader,
+                                             pmix_group_opt_t opt,
+                                             const pmix_info_t info[], size_t ninfo,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Leave a PMIx Group. Calls to PMIx_Group_leave (or its non-blocking form) will cause
+ * a PMIX_GROUP_LEFT event to be generated notifying all members of the group of the
+ * caller’s departure. The function will return (or the non-blocking function will
+ * execute the specified callback function) once the event has been locally generated
+ * and is not indicative of remote receipt. All PMIx-based collectives such as
+ * PMIx_Fence in action across the group will automatically be adjusted if the
+ * collective was called with the PMIX_GROUP_FT_COLLECTIVE attribute (default is
+ * false) – otherwise, the standard error return behavior will be provided.
+ *
+ * Critical Note: The PMIx_Group_leave API is intended solely for asynchronous
+ * departures of individual processes from a group as it is not a scalable
+ * operation – i.e., when a process determines it should no longer be a part of a
+ * defined group, but the remainder of the group retains a valid reason to continue
+ * in existence. Developers are advised to use PMIx_Group_destruct (or its
+ * non-blocking form) for all other scenarios as it represents a more scalable
+ * operation.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Group_leave(const char grp[],
+                                           const pmix_info_t info[], size_t ninfo);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_leave_nb(const char grp[],
+                                              const pmix_info_t info[], size_t ninfo,
+                                              pmix_op_cbfunc_t cbfunc, void *cbdata);
+
+/* Destruct a group identified by the provided group identifier. Both blocking and
+ * non-blocking versions are provided (the callback function for the non-blocking
+ * form will be called once all members of the group have called “destruct”).
+ * Processes may engage in multiple simultaneous group destruct operations as
+ * desired so long as each involves a unique group ID. The info array can be used
+ * to pass user-level directives regarding timeout constraints and other options
+ * available from the PMIx server.
+ *
+ * Some relevant attributes for this operation:
+ *
+ *    PMIX_TIMEOUT (int): return an error if the group doesn’t destruct within the
+ *                        specified number of seconds. Targets the scenario where
+ *                        a process fails to call PMIx_Group_destruct due to hanging
+ *
+ * The destruct API will return an error if any group process fails or terminates
+ * prior to calling PMIx_Group_destruct or its non-blocking version unless the
+ * PMIX_GROUP_NOTIFY_TERMINATION attribute was provided (with a value of true) at
+ * time of group construction. If notification was requested, then a event will
+ * be delivered (using PMIX_GROUP_MEMBER_FAILED) for each process that fails to
+ * call destruct and the destruct tracker updated to account for the lack of
+ * participation. The PMIx_Group_destruct operation will subsequently return
+ * PMIX_SUCCESS when the remaining processes have all called destruct – i.e., the
+ * event will serve in place of return of an error.
+ */
+PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
+                                              const pmix_info_t info[], size_t ninfo);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grp[],
+                                                 const pmix_info_t info[], size_t ninfo,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
+
 
 #if defined(c_plusplus) || defined(__cplusplus)
 }

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -627,6 +627,19 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_SETUP_APP_NONENVARS            "pmix.setup.nenv"       // (bool) include all non-envar data
 #define PMIX_SETUP_APP_ALL                  "pmix.setup.all"        // (bool) include all relevant data
 
+/* Attributes supporting the PMIx Groups APIs */
+#define PMIX_GROUP_ID                       "pmix.grp.id"           // (char*) user-provided group identifier
+#define PMIX_GROUP_LEADER                   "pmix.grp.ldr"          // (bool) this process is the leader of the group
+#define PMIX_GROUP_OPTIONAL                 "pmix.grp.opt"          // (bool) participation is optional - do not return an error if any of the
+                                                                    //        specified processes terminate without having joined. The default
+                                                                    //        is false
+#define PMIX_GROUP_NOTIFY_TERMINATION       "pmix.grp.notterm"      // (bool) notify remaining members when another member terminates without first
+                                                                    //        leaving the group. The default is false
+#define PMIX_GROUP_INVITE_DECLINE           "pmix.grp.decline"      // (bool) notify the inviting process that this process does not wish to
+                                                                    //        participate in the proposed group The default is true
+#define PMIX_GROUP_FT_COLLECTIVE            "pmix.grp.ftcoll"       // (bool) adjust internal tracking for terminated processes. Default is false
+#define PMIX_GROUP_MEMBERSHIP               "pmix.grp.mbrs"         // (pmix_data_array_t*) array of group member ID's
+
 
 /****    PROCESS STATE DEFINITIONS    ****/
 typedef uint8_t pmix_proc_state_t;
@@ -773,7 +786,16 @@ typedef int pmix_status_t;
 #define PMIX_OPERATION_IN_PROGRESS                  -156
 #define PMIX_OPERATION_SUCCEEDED                    -157
 #define PMIX_ERR_INVALID_OPERATION                  -158
-
+#define PMIX_GROUP_INVITED                          -159
+#define PMIX_GROUP_LEFT                             -160
+#define PMIX_GROUP_INVITE_ACCEPTED                  -161
+#define PMIX_GROUP_INVITE_DECLINED                  -162
+#define PMIX_GROUP_INVITE_FAILED                    -163
+#define PMIX_GROUP_MEMBERSHIP_UPDATE                -164
+#define PMIX_GROUP_CONSTRUCT_ABORT                  -165
+#define PMIX_GROUP_CONSTRUCT_COMPLETE               -166
+#define PMIX_GROUP_LEADER_SELECTED                  -167
+#define PMIX_GROUP_LEADER_FAILED                    -168
 
 /* system failures */
 #define PMIX_ERR_NODE_DOWN                          -231
@@ -933,6 +955,14 @@ typedef uint16_t pmix_iof_channel_t;
 #define PMIX_FWD_STDERR_CHANNEL     0x0004
 #define PMIX_FWD_STDDIAG_CHANNEL    0x0008
 #define PMIX_FWD_ALL_CHANNELS       0x00ff
+
+/* define values associated with PMIx_Group_join
+ * to indicate accept and decline - this is
+ * done for readability of user code */
+typedef enum {
+    PMIX_GROUP_DECLINE,
+    PMIX_GROUP_ACCEPT
+} pmix_group_opt_t;
 
 
 /* declare a convenience macro for checking keys */
@@ -2127,7 +2157,7 @@ PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
 PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
                                             const pmix_proc_t *source,
                                             pmix_data_range_t range,
-                                            pmix_info_t info[], size_t ninfo,
+                                            const pmix_info_t info[], size_t ninfo,
                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Provide a string representation for several types of value. Note

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -639,6 +639,7 @@ typedef uint32_t pmix_rank_t;
                                                                     //        participate in the proposed group The default is true
 #define PMIX_GROUP_FT_COLLECTIVE            "pmix.grp.ftcoll"       // (bool) adjust internal tracking for terminated processes. Default is false
 #define PMIX_GROUP_MEMBERSHIP               "pmix.grp.mbrs"         // (pmix_data_array_t*) array of group member ID's
+#define PMIX_GROUP_ASSIGN_CONTEXT_ID        "pmix.grp.ctxid"        // (bool) request that the RM assign a unique numerical (size_t) ID to this group
 
 
 /****    PROCESS STATE DEFINITIONS    ****/
@@ -796,6 +797,7 @@ typedef int pmix_status_t;
 #define PMIX_GROUP_CONSTRUCT_COMPLETE               -166
 #define PMIX_GROUP_LEADER_SELECTED                  -167
 #define PMIX_GROUP_LEADER_FAILED                    -168
+#define PMIX_GROUP_CONTEXT_ID_ASSIGNED              -169
 
 /* system failures */
 #define PMIX_ERR_NODE_DOWN                          -231

--- a/include/pmix_extend.h
+++ b/include/pmix_extend.h
@@ -63,6 +63,18 @@
 extern "C" {
 #endif
 
+/* declare a convenience macro for checking keys */
+#define PMIX_CHECK_KEY(a, b) \
+    (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
+
+/* define a convenience macro for checking nspaces */
+#define PMIX_CHECK_NSPACE(a, b) \
+    (0 == strncmp((a), (b), PMIX_MAX_NSLEN))
+
+/* define a convenience macro for checking names */
+#define PMIX_CHECK_PROCID(a, b) \
+    (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
+
 /* expose some functions that are resolved in the
  * PMIx library, but part of a header that
  * includes internal functions - we don't
@@ -73,7 +85,7 @@ void pmix_value_load(pmix_value_t *v, const void *data, pmix_data_type_t type);
 
 pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data, size_t *sz);
 
-pmix_status_t pmix_value_xfer(pmix_value_t *kv, pmix_value_t *src);
+pmix_status_t pmix_value_xfer(pmix_value_t *kv, const pmix_value_t *src);
 
 pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
 

--- a/src/client/Makefile.include
+++ b/src/client/Makefile.include
@@ -20,7 +20,8 @@ sources += \
         client/pmix_client_get.c \
         client/pmix_client_pub.c \
         client/pmix_client_spawn.c \
-        client/pmix_client_connect.c
+        client/pmix_client_connect.c \
+        client/pmix_client_group.c
 
 if WANT_PMI_BACKWARD
 pmi1_sources += \

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -1,0 +1,881 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2017 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
+ *                         All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <src/include/types.h>
+#include <src/include/pmix_stdint.h>
+
+#include <pmix.h>
+#include <pmix_rename.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/mca/gds/base/base.h"
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#include <fcntl.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_SOCKET_H
+#include <sys/socket.h>
+#endif
+#ifdef HAVE_SYS_UN_H
+#include <sys/un.h>
+#endif
+#ifdef HAVE_SYS_UIO_H
+#include <sys/uio.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#include PMIX_EVENT_HEADER
+
+#include "src/class/pmix_list.h"
+#include "src/mca/bfrops/bfrops.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+#include "src/threads/threads.h"
+#include "src/mca/gds/gds.h"
+#include "src/mca/ptl/ptl.h"
+
+#include "pmix_client_ops.h"
+
+/* define a tracking object for group operations */
+typedef struct {
+    pmix_object_t super;
+    pmix_lock_t grplock;
+    pmix_lock_t lock;
+    pmix_status_t status;
+    size_t ref;
+    size_t accepted;
+    pmix_proc_t *members;
+    size_t nmembers;
+    pmix_info_t *info;
+    size_t ninfo;
+    pmix_info_t *results;
+    size_t nresults;
+    pmix_op_cbfunc_t cbfunc;
+    void *cbdata;
+} pmix_group_tracker_t;
+
+static void gtcon(pmix_group_tracker_t *p)
+{
+    PMIX_CONSTRUCT_LOCK(&p->grplock);
+    p->status = PMIX_SUCCESS;
+    p->ref = 0;
+    p->accepted = 0;
+    p->members = NULL;
+    p->nmembers = 0;
+    p->info = NULL;
+    p->ninfo = 0;
+    p->results = NULL;
+    p->nresults = 0;
+    p->cbfunc = NULL;
+    p->cbdata = NULL;
+}
+static void gtdes(pmix_group_tracker_t *p)
+{
+    PMIX_DESTRUCT_LOCK(&p->grplock);
+    if (NULL != p->members) {
+        PMIX_PROC_FREE(p->members, p->nmembers);
+    }
+    if (NULL != p->info) {
+        PMIX_INFO_FREE(p->info, p->ninfo);
+    }
+    if (NULL != p->results) {
+        PMIX_INFO_FREE(p->results, p->nresults);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_group_tracker_t,
+                    pmix_object_t,
+                    gtcon, gtdes);
+
+/* callback for wait completion */
+static void grp_cbfunc(struct pmix_peer_t *pr,
+                        pmix_ptl_hdr_t *hdr,
+                        pmix_buffer_t *buf, void *cbdata);
+static void op_cbfunc(pmix_status_t status, void *cbdata);
+
+PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[],
+                                               const pmix_proc_t procs[], size_t nprocs,
+                                               const pmix_info_t info[], size_t ninfo)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix: group_construct called");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_cb_t);
+
+    /* push the message into our event base to send to the server */
+    if (PMIX_SUCCESS != (rc = PMIx_Group_construct_nb(grp, procs, nprocs, info, ninfo, op_cbfunc, cb))) {
+        PMIX_RELEASE(cb);
+        return rc;
+    }
+
+    /* wait for the connect to complete */
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    PMIX_RELEASE(cb);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: group construct completed");
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
+                                                  const pmix_proc_t procs[], size_t nprocs,
+                                                  const pmix_info_t info[], size_t ninfo,
+                                                  pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_GROUP_CONSTRUCT_CMD;
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix:group_construct_nb called");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* check for bozo input */
+    if (NULL == procs || 0 >= nprocs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    msg = PMIX_NEW(pmix_buffer_t);
+    /* pack the cmd */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* pack the group ID */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &grp, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* pack the number of procs */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &nprocs, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, procs, nprocs, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* pack the info structs */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+    }
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->cbfunc.opfn = cbfunc;
+    cb->cbdata = cbdata;
+
+    /* push the message into our event base to send to the server */
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, grp_cbfunc, (void*)cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cb);
+    }
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_destruct(const char grp[],
+                                              const pmix_info_t info[], size_t ninfo)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix: group_construct called");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_cb_t);
+
+    /* push the message into our event base to send to the server */
+    if (PMIX_SUCCESS != (rc = PMIx_Group_destruct_nb(grp, info, ninfo, op_cbfunc, cb))) {
+        PMIX_RELEASE(cb);
+        return rc;
+    }
+
+    /* wait for the connect to complete */
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    PMIX_RELEASE(cb);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: group construct completed");
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grp[],
+                                                 const pmix_info_t info[], size_t ninfo,
+                                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_buffer_t *msg;
+    pmix_cmd_t cmd = PMIX_GROUP_DESTRUCT_CMD;
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_client_globals.connect_output,
+                        "pmix:group_construct_nb called");
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* check for bozo input */
+    if (NULL == grp) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    msg = PMIX_NEW(pmix_buffer_t);
+    /* pack the cmd */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &cmd, 1, PMIX_COMMAND);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* pack the group ID */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &grp, 1, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    /* pack the info structs */
+    PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                     msg, &ninfo, 1, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_RELEASE(msg);
+        return rc;
+    }
+    if (0 < ninfo) {
+        PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                         msg, info, ninfo, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(msg);
+            return rc;
+        }
+    }
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which callback to use when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->cbfunc.opfn = cbfunc;
+    cb->cbdata = cbdata;
+
+    /* push the message into our event base to send to the server */
+    PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                       msg, grp_cbfunc, (void*)cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(msg);
+        PMIX_RELEASE(cb);
+    }
+
+    return rc;
+}
+
+static void chaincbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_group_tracker_t *cb = (pmix_group_tracker_t*)cbdata;
+
+    PMIX_RELEASE(cb);
+}
+
+static void invite_handler(size_t evhdlr_registration_id,
+                           pmix_status_t status,
+                           const pmix_proc_t *source,
+                           pmix_info_t info[], size_t ninfo,
+                           pmix_info_t *results, size_t nresults,
+                           pmix_event_notification_cbfunc_fn_t cbfunc,
+                           void *cbdata)
+{
+    pmix_group_tracker_t *cb = NULL;
+    pmix_proc_t *affected = NULL;
+    size_t n;
+    pmix_status_t rc;
+
+    /* find the object we asked to be returned with event */
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            if (PMIX_POINTER != info[n].value.type) {
+                /* this is an unrecoverable error - need to abort */
+            }
+            cb = (pmix_group_tracker_t*)info[n].value.data.ptr;
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            if (PMIX_PROC != info[n].value.type) {
+                /* this is an unrecoverable error - need to abort */
+            }
+            affected = info[n].value.data.proc;
+        }
+    }
+    if (NULL == cb) {
+pmix_output(0, "[%s:%d] INVITE HANDLER NULL OBJECT", pmix_globals.myid.nspace, pmix_globals.myid.rank);
+        /* this is an unrecoverable error - need to abort */
+    }
+
+    /* if the status is accepted, then record it */
+    if (PMIX_GROUP_INVITE_ACCEPTED == status) {
+        cb->accepted++;
+        /* allow the chain to continue */
+        rc = PMIX_SUCCESS;
+        goto complete;
+    }
+
+    /* if the reporting process terminated, then issue the corresponding
+     * group event - it only goes to this process */
+    if (PMIX_PROC_TERMINATED == status) {
+        PMIX_INFO_CREATE(cb->info, 1);
+        cb->ninfo = 1;
+        PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_AFFECTED_PROC, affected, PMIX_PROC);
+        rc = PMIx_Notify_event(PMIX_GROUP_INVITE_FAILED,
+                               &pmix_globals.myid,
+                               PMIX_RANGE_PROC_LOCAL,
+                               cb->info, 1,
+                               chaincbfunc, (void*)cb);
+        if (PMIX_SUCCESS != rc) {
+            /* this is an unrecoverable error - need to abort */
+pmix_output(0, "[%s:%d] INVITE HANDLER ERROR", pmix_globals.myid.nspace, pmix_globals.myid.rank);
+        }
+        goto complete;
+    }
+
+    /* otherwise, we consider the process as having "declined" and
+     * ignore it here - if the user registered a handler for that
+     * case, then the chain will eventually call it
+     */
+
+  complete:
+    /* check for complete */
+    if (cb->accepted == cb->nmembers) {
+        /* execute the completion callback */
+        if (NULL != cb->cbfunc) {
+            cb->cbfunc(PMIX_SUCCESS, cb->cbdata);
+            rc = PMIX_EVENT_ACTION_COMPLETE;
+        }
+    }
+
+    /* always must continue the chain */
+    cbfunc(rc, cb->results, cb->nresults, chaincbfunc, cb, cbdata);
+    return;
+}
+
+static void regcbfunc(pmix_status_t status,
+                      size_t refid,
+                      void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+
+    cb->status = status;
+    cb->errhandler_ref = refid;
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[],
+                                            const pmix_proc_t procs[], size_t nprocs,
+                                            const pmix_info_t info[], size_t ninfo)
+{
+    pmix_cb_t cb;
+    pmix_status_t rc;
+    size_t n;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, then we cannot notify */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* check for bozo input */
+    if (NULL == grp || NULL == procs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+
+    rc = PMIx_Group_invite_nb(grp, procs, nprocs, info, ninfo, op_cbfunc, (void*)&cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&cb);
+        return rc;
+    }
+
+    /* wait for the group construction to complete or fail */
+    PMIX_WAIT_THREAD(&cb.lock);
+    rc = cb.status;
+    PMIX_DESTRUCT(&cb);
+
+    /* announce group completion, including list of final
+     * members - only sent to members. Servers will intercept
+     * and update their membership lists */
+    PMIX_CONSTRUCT(&cb, pmix_cb_t);
+    PMIX_INFO_CREATE(cb.info, 3);
+    if (NULL == cb.info) {
+        PMIX_DESTRUCT(&cb);
+        return PMIX_ERR_NOMEM;
+    }
+    cb.ninfo = 3;
+    n = 0;
+    (void)strncpy(cb.info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN);
+    cb.info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(cb.info[n].value.data.darray, nprocs, PMIX_PROC);
+    if (NULL == cb.info[n].value.data.darray) {
+        PMIX_DESTRUCT(&cb);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_PROC_CREATE(cb.info[n].value.data.darray->array, nprocs);
+    memcpy(cb.info[n++].value.data.darray->array, procs, nprocs * sizeof(pmix_proc_t));
+    /* mark that this only goes to non-default handlers */
+    PMIX_INFO_LOAD(&cb.info[n++], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    /* provide the group ID */
+    PMIX_INFO_LOAD(&cb.info[n++], PMIX_GROUP_ID, grp, PMIX_STRING);
+
+    /* notify members */
+    rc = PMIx_Notify_event(PMIX_GROUP_CONSTRUCT_COMPLETE,
+                           &pmix_globals.myid,
+                           PMIX_RANGE_CUSTOM,
+                           cb.info, cb.ninfo,
+                           op_cbfunc, (void*)&cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_DESTRUCT(&cb);
+        return rc;
+    }
+
+    /* wait for the notify to get out */
+    PMIX_WAIT_THREAD(&cb.lock);
+    rc = cb.status;
+    PMIX_DESTRUCT(&cb);
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[],
+                                               const pmix_proc_t procs[], size_t nprocs,
+                                               const pmix_info_t info[], size_t ninfo,
+                                               pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_group_tracker_t *cb;
+    pmix_cb_t lock;
+    pmix_status_t codes[] = {
+        PMIX_GROUP_INVITE_ACCEPTED,
+        PMIX_GROUP_INVITE_DECLINED,
+        PMIX_PROC_TERMINATED
+    };
+    size_t ncodes, n;
+    pmix_info_t myinfo[2];
+    pmix_status_t rc;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, then we cannot notify */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* check for bozo input */
+    if (NULL == grp || NULL == procs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    cb = PMIX_NEW(pmix_group_tracker_t);
+    if (NULL == cb) {
+        return PMIX_ERR_NOMEM;
+    }
+    cb->cbfunc = cbfunc;
+    cb->cbdata = cbdata;
+    cb->accepted = 1;  // obviously, we accept
+
+    /* compute the number of proposed members */
+    for (n=0; n < nprocs; n++) {
+        if (PMIX_RANK_WILDCARD == procs[n].rank) {
+            /* must get the number of procs in this nspace */
+        } else {
+            cb->nmembers++;
+        }
+    }
+
+    /* register an event handler specifically to respond
+     * to accept responses */
+    PMIX_INFO_LOAD(&myinfo[0], PMIX_EVENT_RETURN_OBJECT, cb, PMIX_POINTER);
+    PMIX_INFO_LOAD(&myinfo[1], PMIX_EVENT_HDLR_PREPEND, NULL, PMIX_BOOL);
+    ncodes = sizeof(codes)/sizeof(pmix_status_t);
+    PMIX_CONSTRUCT(&lock, pmix_cb_t);
+    PMIx_Register_event_handler(codes, ncodes, myinfo, 2,
+                                invite_handler, regcbfunc, &lock);
+    PMIX_WAIT_THREAD(&lock.lock);
+    rc = lock.status;
+    cb->ref = lock.errhandler_ref;
+    PMIX_DESTRUCT(&lock);
+    PMIX_INFO_DESTRUCT(&myinfo[0]);
+    PMIX_INFO_DESTRUCT(&myinfo[1]);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cb);
+        return rc;
+    }
+
+    /* check for directives */
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                /* setup a timer */
+                break;
+            }
+        }
+    }
+
+    /* limit the range to just the procs we are inviting */
+    PMIX_INFO_CREATE(cb->info, 3);
+    if (NULL == cb->info) {
+        PMIX_CONSTRUCT(&lock, pmix_cb_t);
+        PMIx_Deregister_event_handler(cb->ref,
+                                      op_cbfunc, &lock);
+        PMIX_WAIT_THREAD(&lock.lock);
+        PMIX_DESTRUCT(&lock);
+        PMIX_RELEASE(cb);
+        return PMIX_ERR_NOMEM;
+    }
+    cb->ninfo = 3;
+    n = 0;
+    (void)strncpy(cb->info[n].key, PMIX_EVENT_CUSTOM_RANGE, PMIX_MAX_KEYLEN);
+    cb->info[n].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(cb->info[n].value.data.darray, nprocs, PMIX_PROC);
+    if (NULL == cb->info[n].value.data.darray) {
+        PMIX_CONSTRUCT(&lock, pmix_cb_t);
+        PMIx_Deregister_event_handler(cb->ref,
+                                      op_cbfunc, &lock);
+        PMIX_WAIT_THREAD(&lock.lock);
+        PMIX_DESTRUCT(&lock);
+        PMIX_RELEASE(cb);
+        return PMIX_ERR_NOMEM;
+    }
+    PMIX_PROC_CREATE(cb->info[n].value.data.darray->array, nprocs);
+    memcpy(cb->info[n++].value.data.darray->array, procs, nprocs * sizeof(pmix_proc_t));
+    /* mark that this only goes to non-default handlers */
+    PMIX_INFO_LOAD(&cb->info[n++], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+    /* provide the group ID */
+    PMIX_INFO_LOAD(&cb->info[n++], PMIX_GROUP_ID, grp, PMIX_STRING);
+
+    /* notify everyone of the invitation */
+    PMIX_CONSTRUCT(&lock, pmix_cb_t);
+    rc = PMIx_Notify_event(PMIX_GROUP_INVITED,
+                           &pmix_globals.myid,
+                           PMIX_RANGE_CUSTOM,
+                           cb->info, cb->ninfo,
+                           op_cbfunc, (void*)&lock);
+    PMIX_WAIT_THREAD(&lock.lock);
+    rc = lock.status;
+    PMIX_DESTRUCT(&lock);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_CONSTRUCT(&lock, pmix_cb_t);
+        PMIx_Deregister_event_handler(cb->ref,
+                                      op_cbfunc, &lock);
+        PMIX_WAIT_THREAD(&lock.lock);
+        PMIX_DESTRUCT(&lock);
+        PMIX_RELEASE(cb);
+    }
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[],
+                                          const pmix_proc_t *leader,
+                                          pmix_group_opt_t opt,
+                                          const pmix_info_t info[], size_t ninfo)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, don't attempt to send */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which lock to release when
+     * the return message is recvd */
+    cb = PMIX_NEW(pmix_cb_t);
+
+    if (PMIX_SUCCESS != (rc = PMIx_Group_join_nb(grp, leader, opt, info, ninfo, op_cbfunc, cb))) {
+        PMIX_RELEASE(cb);
+        return rc;
+    }
+
+    /* wait for the group construction to complete */
+    PMIX_WAIT_THREAD(&cb->lock);
+    rc = cb->status;
+    PMIX_RELEASE(cb);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix: group construction completed");
+
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[],
+                                             const pmix_proc_t *leader,
+                                             pmix_group_opt_t opt,
+                                             const pmix_info_t info[], size_t ninfo,
+                                             pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    pmix_status_t rc;
+    pmix_cb_t *cb;
+    pmix_status_t code;
+    size_t n;
+    pmix_data_range_t range;
+
+    PMIX_ACQUIRE_THREAD(&pmix_global_lock);
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "[%s:%d] pmix: join nb called",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank);
+
+    if (pmix_globals.init_cntr <= 0) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_INIT;
+    }
+
+    /* if we aren't connected, then we cannot notify */
+    if (!pmix_globals.connected) {
+        PMIX_RELEASE_THREAD(&pmix_global_lock);
+        return PMIX_ERR_UNREACH;
+    }
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
+
+    /* create a callback object as we need to pass it to the
+     * recv routine so we know which lock to release when
+     * the notification is done */
+    cb = PMIX_NEW(pmix_cb_t);
+    cb->cbfunc.opfn = cbfunc;
+    cb->cbdata = cbdata;
+
+    /* check for directives */
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                /* setup a timer */
+                break;
+            }
+        }
+    }
+
+    /* set the code according to their request */
+    if (PMIX_GROUP_ACCEPT == opt) {
+        code = PMIX_GROUP_INVITE_ACCEPTED;
+    } else {
+        code = PMIX_GROUP_INVITE_DECLINED;
+    }
+
+    /* only notify the leader so we don't hit all procs */
+    if (NULL != leader) {
+        range = PMIX_RANGE_CUSTOM;
+        PMIX_INFO_CREATE(cb->info, 1);
+        if (NULL == cb->info) {
+            PMIX_RELEASE(cb);
+            return PMIX_ERR_NOMEM;
+        }
+        PMIX_INFO_LOAD(&cb->info[0], PMIX_EVENT_CUSTOM_RANGE, leader, PMIX_PROC);
+        cb->ninfo = 1;
+    } else {
+        range = PMIX_RANGE_SESSION;
+    }
+
+    rc = PMIx_Notify_event(code,
+                           &pmix_globals.myid,
+                           range,
+                           cb->info, cb->ninfo,
+                           op_cbfunc, (void*)cb);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cb);
+    }
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "[%s:%d] pmix: group invite %s",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                        (PMIX_GROUP_INVITE_ACCEPTED == code) ? "ACCEPTED" : "DECLINED");
+
+    return rc;
+}
+
+static void op_cbfunc(pmix_status_t status, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+
+    cb->status = status;
+    if (NULL != cb->cbfunc.opfn) {
+        cb->cbfunc.opfn(status, cb->cbdata);
+        return;
+    }
+    PMIX_POST_OBJECT(cb);
+    PMIX_WAKEUP_THREAD(&cb->lock);
+}
+
+static void grp_cbfunc(struct pmix_peer_t *pr,
+                        pmix_ptl_hdr_t *hdr,
+                        pmix_buffer_t *buf, void *cbdata)
+{
+    pmix_cb_t *cb = (pmix_cb_t*)cbdata;
+    pmix_status_t rc;
+    pmix_status_t ret;
+    int32_t cnt;
+
+    pmix_output_verbose(2, pmix_globals.debug_output,
+                        "pmix:client recv callback activated with %d bytes",
+                        (NULL == buf) ? -1 : (int)buf->bytes_used);
+
+    if (NULL == buf) {
+        ret = PMIX_ERR_BAD_PARAM;
+        goto report;
+    }
+
+    /* a zero-byte buffer indicates that this recv is being
+     * completed due to a lost connection */
+    if (PMIX_BUFFER_IS_EMPTY(buf)) {
+        ret = PMIX_ERR_UNREACH;
+        goto report;
+    }
+
+    /* unpack the returned status */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
+                       buf, &ret, &cnt, PMIX_STATUS);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = rc;
+    }
+
+  report:
+    if (NULL != cb->cbfunc.opfn) {
+        cb->cbfunc.opfn(ret, cb->cbdata);
+    }
+    PMIX_RELEASE(cb);
+}

--- a/src/common/pmix_strings.c
+++ b/src/common/pmix_strings.c
@@ -230,6 +230,16 @@ PMIX_EXPORT const char* pmix_command_string(pmix_cmd_t cmd)
             return "IOF PUSH";
         case PMIX_IOF_PULL_CMD:
             return "IOF PULL";
+        case PMIX_GROUP_CONSTRUCT_CMD:
+            return "GROUP CONSTRUCT";
+        case PMIX_GROUP_JOIN_CMD:
+            return "GROUP JOIN";
+        case PMIX_GROUP_INVITE_CMD:
+            return "GROUP INVITE";
+        case PMIX_GROUP_LEAVE_CMD:
+            return "GROUP LEAVE";
+        case PMIX_GROUP_DESTRUCT_CMD:
+            return "GROUP DESTRUCT";
         default:
             return "UNKNOWN";
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -106,6 +106,11 @@ typedef uint8_t pmix_cmd_t;
 #define PMIX_VALIDATE_CRED_CMD      21
 #define PMIX_IOF_PULL_CMD           22
 #define PMIX_IOF_PUSH_CMD           23
+#define PMIX_GROUP_CONSTRUCT_CMD    24
+#define PMIX_GROUP_JOIN_CMD         25
+#define PMIX_GROUP_INVITE_CMD       26
+#define PMIX_GROUP_LEAVE_CMD        27
+#define PMIX_GROUP_DESTRUCT_CMD     28
 
 /* provide a "pretty-print" function for cmds */
 const char* pmix_command_string(pmix_cmd_t cmd);
@@ -278,6 +283,7 @@ PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
  * - instanced in pmix_server_ops.c */
 typedef struct {
     pmix_list_item_t super;
+    char *id;                       // string identifier for the collective
     pmix_cmd_t type;
     pmix_proc_t pname;
     bool hybrid;                    // true if participating procs are from more than one nspace
@@ -295,6 +301,7 @@ typedef struct {
     pmix_collect_t collect_type;    // whether or not data is to be returned at completion
     pmix_modex_cbfunc_t modexcbfunc;
     pmix_op_cbfunc_t op_cbfunc;
+    void *cbdata;
 } pmix_server_trkr_t;
 PMIX_CLASS_DECLARATION(pmix_server_trkr_t);
 

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -274,7 +274,7 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_stub_copy_payload(struct pmix_peer_t *peer
                                                         pmix_buffer_t *src);
 PMIX_EXPORT pmix_status_t pmix_bfrops_stub_value_xfer(struct pmix_peer_t *peer,
                                                       pmix_value_t *dest,
-                                                      pmix_value_t *src);
+                                                      const pmix_value_t *src);
 PMIX_EXPORT void pmix_bfrops_stub_value_load(struct pmix_peer_t *peer,
                                              pmix_value_t *v, void *data,
                                              pmix_data_type_t type);
@@ -670,7 +670,7 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_unload(pmix_value_t *kv,
                                                         size_t *sz);
 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
-                                                      pmix_value_t *src);
+                                                      const pmix_value_t *src);
 
 PMIX_EXPORT pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
                                                         pmix_value_t *p1);

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -46,7 +46,7 @@ PMIX_EXPORT pmix_status_t pmix_value_unload(pmix_value_t *kv,
 }
 
 PMIX_EXPORT pmix_status_t pmix_value_xfer(pmix_value_t *dest,
-                                          pmix_value_t *src)
+                                          const pmix_value_t *src)
 {
     return pmix_bfrops_base_value_xfer(dest, src);
 }
@@ -509,7 +509,7 @@ pmix_value_cmp_t pmix_bfrops_base_value_cmp(pmix_value_t *p,
 
 /* Xfer FUNCTIONS FOR GENERIC PMIX TYPES */
 pmix_status_t pmix_bfrops_base_value_xfer(pmix_value_t *p,
-                                          pmix_value_t *src)
+                                          const pmix_value_t *src)
 {
     /* copy the right field */
     p->type = src->type;

--- a/src/mca/bfrops/bfrops.h
+++ b/src/mca/bfrops/bfrops.h
@@ -324,7 +324,7 @@ typedef pmix_status_t (*pmix_bfrop_print_fn_t)(char **output, char *prefix,
  * @retval PMIX_ERROR(s) An appropriate error code
  */
 typedef pmix_status_t (*pmix_bfrop_value_xfer_fn_t)(pmix_value_t *dest,
-                                                    pmix_value_t *src);
+                                                    const pmix_value_t *src);
 
 
 /**

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -225,7 +225,7 @@ pmix_value_cmp_t pmix12_bfrop_value_cmp(pmix_value_t *p, pmix_value_t *p1)
     return PMIX_VALUE1_GREATER;
 }
 /* COPY FUNCTIONS FOR GENERIC PMIX TYPES */
-pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
+pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src)
 {
     /* copy the right field */
     p->type = src->type;

--- a/src/mca/bfrops/v12/internal.h
+++ b/src/mca/bfrops/v12/internal.h
@@ -107,7 +107,7 @@ pmix_status_t pmix12_bfrop_print(char **output, char *prefix, void *src, pmix_da
 
 pmix_status_t pmix12_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
 
-pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src);
+pmix_status_t pmix12_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src);
 
 void pmix12_bfrop_value_load(pmix_value_t *v, const void *data,
                             pmix_data_type_t type);

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -337,7 +337,7 @@ bool pmix_value_cmp(pmix_value_t *p, pmix_value_t *p1)
 /* COPY FUNCTIONS FOR GENERIC PMIX TYPES - we
  * are not allocating memory and so we cannot
  * use the regular copy functions */
-pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src)
+pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src)
 {
     size_t n, m;
     pmix_status_t rc;

--- a/src/mca/bfrops/v20/internal.h
+++ b/src/mca/bfrops/v20/internal.h
@@ -108,7 +108,7 @@ pmix_status_t pmix20_bfrop_print(char **output, char *prefix, void *src, pmix_da
 
 pmix_status_t pmix20_bfrop_copy_payload(pmix_buffer_t *dest, pmix_buffer_t *src);
 
-pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, pmix_value_t *src);
+pmix_status_t pmix20_bfrop_value_xfer(pmix_value_t *p, const pmix_value_t *src);
 
 void pmix20_bfrop_value_load(pmix_value_t *v, const void *data,
                             pmix_data_type_t type);

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -745,7 +745,9 @@ void pmix_ptl_base_process_msg(int fd, short flags, void *cbdata)
     /* if the tag in this message is above the dynamic marker, then
      * that is an error */
     if (PMIX_PTL_TAG_DYNAMIC <= msg->hdr.tag) {
-        pmix_output(0, "UNEXPECTED MESSAGE tag = %d", msg->hdr.tag);
+        pmix_output(0, "UNEXPECTED MESSAGE tag = %d from source %s:%d",
+                    msg->hdr.tag, msg->peer->info->pname.nspace,
+                    msg->peer->info->pname.rank);
         PMIX_REPORT_EVENT(PMIX_ERROR, msg->peer, PMIX_RANGE_NAMESPACE, _notify_complete);
         PMIX_RELEASE(msg);
         return;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -150,12 +150,15 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 }
             }
         }
-        if (!PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+            /* only connection I can lose is to my server, so mark it */
+            pmix_globals.connected = false;
+        } else {
             /* cleanup any sensors that are monitoring them */
             pmix_psensor.stop(peer, NULL);
         }
 
-        if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer)) {
+        if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer) && !pmix_globals.mypeer->finalized) {
             /* if this peer already called finalize, then
              * we are just seeing their connection go away
              * when they terminate - so do not generate

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -108,6 +108,7 @@ pmix_status_t pmix_server_initialize(void)
     PMIX_CONSTRUCT(&pmix_server_globals.events, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.nspaces, pmix_list_t);
+    PMIX_CONSTRUCT(&pmix_server_globals.groups, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_hotel_t);
     rc = pmix_hotel_init(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE,
                          pmix_globals.evbase, PMIX_IOF_MAX_STAY,
@@ -511,6 +512,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
         pmix_execute_epilog(&ns->epilog);
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.groups);
 
     pmix_hwloc_cleanup();
 
@@ -3225,6 +3227,18 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
     if (PMIX_IOF_PUSH_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
         rc = pmix_server_iofstdin(peer, buf, op_cbfunc, cd);
+        return rc;
+    }
+
+    if (PMIX_GROUP_CONSTRUCT_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        rc = pmix_server_grpconstruct(cd, buf);
+        return rc;
+    }
+
+    if (PMIX_GROUP_DESTRUCT_CMD == cmd) {
+        PMIX_GDS_CADDY(cd, peer, tag);
+        rc = pmix_server_grpdestruct(cd, buf);
         return rc;
     }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -293,7 +293,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
  *         regardless of location
  * nprocs - the number of procs in the array
  */
-static pmix_server_trkr_t* get_tracker(pmix_proc_t *procs,
+static pmix_server_trkr_t* get_tracker(char *id, pmix_proc_t *procs,
                                        size_t nprocs, pmix_cmd_t type)
 {
     pmix_server_trkr_t *trk;
@@ -304,7 +304,7 @@ static pmix_server_trkr_t* get_tracker(pmix_proc_t *procs,
                         "get_tracker called with %d procs", (int)nprocs);
 
     /* bozo check - should never happen outside of programmer error */
-    if (NULL == procs) {
+    if (NULL == procs && NULL == id) {
         PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
         return NULL;
     }
@@ -317,28 +317,35 @@ static pmix_server_trkr_t* get_tracker(pmix_proc_t *procs,
      * shouldn't take long */
     PMIX_LIST_FOREACH(trk, &pmix_server_globals.collectives, pmix_server_trkr_t) {
         /* Collective operation if unique identified by
-         * the set of participating processes and the type of collective
+         * the set of participating processes and the type of collective,
+         * or by the operation ID
          */
-        if (nprocs != trk->npcs) {
-            continue;
-        }
-        if (type != trk->type) {
-            continue;
-        }
-        matches = 0;
-        for (i=0; i < nprocs; i++) {
-            /* the procs may be in different order, so we have
-             * to do an exhaustive search */
-            for (j=0; j < trk->npcs; j++) {
-                if (0 == strcmp(procs[i].nspace, trk->pcs[j].nspace) &&
-                    procs[i].rank == trk->pcs[j].rank) {
-                    ++matches;
-                    break;
+        if (NULL != id) {
+            if (NULL != trk->id && 0 == strcmp(id, trk->id)) {
+                return trk;
+            }
+        } else {
+            if (nprocs != trk->npcs) {
+                continue;
+            }
+            if (type != trk->type) {
+                continue;
+            }
+            matches = 0;
+            for (i=0; i < nprocs; i++) {
+                /* the procs may be in different order, so we have
+                 * to do an exhaustive search */
+                for (j=0; j < trk->npcs; j++) {
+                    if (0 == strcmp(procs[i].nspace, trk->pcs[j].nspace) &&
+                        procs[i].rank == trk->pcs[j].rank) {
+                        ++matches;
+                        break;
+                    }
                 }
             }
-        }
-        if (trk->npcs == matches) {
-            return trk;
+            if (trk->npcs == matches) {
+                return trk;
+            }
         }
     }
     /* No tracker was found */
@@ -361,7 +368,7 @@ static pmix_server_trkr_t* get_tracker(pmix_proc_t *procs,
  *         regardless of location
  * nprocs - the number of procs in the array
  */
-static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
+static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
                                        size_t nprocs, pmix_cmd_t type)
 {
     pmix_server_trkr_t *trk;
@@ -380,7 +387,8 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
     }
 
     pmix_output_verbose(5, pmix_server_globals.base_output,
-                        "adding new tracker with %d procs", (int)nprocs);
+                        "adding new tracker %s with %d procs",
+                        (NULL == id) ? "NO-ID" : id, (int)nprocs);
 
     /* this tracker is new - create it */
     trk = PMIX_NEW(pmix_server_trkr_t);
@@ -389,20 +397,29 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
         return NULL;
     }
 
-    /* copy the procs */
-    PMIX_PROC_CREATE(trk->pcs, nprocs);
-    if (NULL == trk->pcs) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        PMIX_RELEASE(trk);
-        return NULL;
+    if (NULL != id) {
+        trk->id = strdup(id);
     }
-    trk->npcs = nprocs;
+
+    if (NULL != procs) {
+        /* copy the procs */
+        PMIX_PROC_CREATE(trk->pcs, nprocs);
+        if (NULL == trk->pcs) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            PMIX_RELEASE(trk);
+            return NULL;
+        }
+        memcpy(trk->pcs, procs, nprocs * sizeof(pmix_proc_t));
+        trk->npcs = nprocs;
+    }
     trk->type = type;
 
     all_def = true;
     for (i=0; i < nprocs; i++) {
-        pmix_strncpy(trk->pcs[i].nspace, procs[i].nspace, PMIX_MAX_NSLEN);
-        trk->pcs[i].rank = procs[i].rank;
+        if (NULL == id) {
+            pmix_strncpy(trk->pcs[i].nspace, procs[i].nspace, PMIX_MAX_NSLEN);
+            trk->pcs[i].rank = procs[i].rank;
+        }
         if (!all_def) {
             continue;
         }
@@ -481,7 +498,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
     int32_t cnt;
     pmix_status_t rc;
     size_t nprocs;
-    pmix_proc_t *procs=NULL, pcs;
+    pmix_proc_t *procs=NULL, pcs, *newprocs;
     bool collect_data = false;
     pmix_server_trkr_t *trk;
     char *data = NULL;
@@ -492,8 +509,11 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
     pmix_kval_t *kv;
     pmix_byte_object_t bo;
     pmix_info_t *info = NULL;
-    size_t ninfo=0, n;
+    size_t ninfo=0, n, nmbrs, idx;
     struct timeval tv = {0, 0};
+    pmix_list_t expand;
+    pmix_group_caddy_t *gcd;
+    pmix_group_t *grp;
 
     pmix_output_verbose(2, pmix_server_globals.fence_output,
                         "recvd FENCE");
@@ -530,6 +550,59 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
         goto cleanup;
     }
 
+    /* cycle thru the procs and check to see if any reference
+     * a PMIx group */
+    nmbrs = nprocs;
+    PMIX_CONSTRUCT(&expand, pmix_list_t);
+    /* use groups as the outer-most loop as there will
+     * usually not be any */
+    PMIX_LIST_FOREACH(grp, &pmix_server_globals.groups, pmix_group_t) {
+        for (n=0; n < nprocs; n++) {
+            if (PMIX_CHECK_NSPACE(procs[n].nspace, grp->grpid)) {
+                /* we need to replace this proc with grp members */
+                gcd = PMIX_NEW(pmix_group_caddy_t);
+                gcd->grp = grp;
+                gcd->idx = n;
+                gcd->rank = procs[n].rank;
+                pmix_list_append(&expand, &gcd->super);
+                /* see how many need to come across */
+                if (PMIX_RANK_WILDCARD == procs[n].rank) {
+                    nmbrs += grp->nmbrs - 1; // account for replacing current proc
+                }
+                break;
+            }
+        }
+    }
+    if (0 < pmix_list_get_size(&expand)) {
+        PMIX_PROC_CREATE(newprocs, nmbrs);
+        gcd = (pmix_group_caddy_t*)pmix_list_remove_first(&expand);
+        n=0;
+        idx = 0;
+        while (n < nmbrs) {
+            if (idx != gcd->idx) {
+                memcpy(&newprocs[n], &procs[idx], sizeof(pmix_proc_t));
+                ++n;
+            } else {
+                /* if we are bringing over just one, then simply replace */
+                if (PMIX_RANK_WILDCARD != gcd->rank) {
+                    memcpy(&newprocs[n], &gcd->grp->members[gcd->rank], sizeof(pmix_proc_t));
+                    ++n;
+                } else {
+                    /* take them all */
+                    memcpy(&newprocs[n], gcd->grp->members, gcd->grp->nmbrs * sizeof(pmix_proc_t));
+                    n += gcd->grp->nmbrs;
+                }
+                PMIX_RELEASE(gcd);
+                gcd = (pmix_group_caddy_t*)pmix_list_remove_first(&expand);
+            }
+            ++idx;
+        }
+        PMIX_PROC_FREE(procs, nprocs);
+        procs = newprocs;
+        nprocs = nmbrs;
+    }
+    PMIX_LIST_DESTRUCT(&expand);
+
     /* unpack the number of provided info structs */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &ninfo, &cnt, PMIX_SIZE);
@@ -560,9 +633,9 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
     }
 
     /* find/create the local tracker for this operation */
-    if (NULL == (trk = get_tracker(procs, nprocs, PMIX_FENCENB_CMD))) {
+    if (NULL == (trk = get_tracker(NULL, procs, nprocs, PMIX_FENCENB_CMD))) {
         /* If no tracker was found - create and initialize it once */
-        if (NULL == (trk = new_tracker(procs, nprocs, PMIX_FENCENB_CMD))) {
+        if (NULL == (trk = new_tracker(NULL, procs, nprocs, PMIX_FENCENB_CMD))) {
             /* only if a bozo error occurs */
             PMIX_ERROR_LOG(PMIX_ERROR);
             /* DO NOT HANG */
@@ -1326,9 +1399,9 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd,
     }
 
     /* find/create the local tracker for this operation */
-    if (NULL == (trk = get_tracker(procs, nprocs, PMIX_DISCONNECTNB_CMD))) {
+    if (NULL == (trk = get_tracker(NULL, procs, nprocs, PMIX_DISCONNECTNB_CMD))) {
         /* we don't have this tracker yet, so get a new one */
-        if (NULL == (trk = new_tracker(procs, nprocs, PMIX_DISCONNECTNB_CMD))) {
+        if (NULL == (trk = new_tracker(NULL, procs, nprocs, PMIX_DISCONNECTNB_CMD))) {
             /* only if a bozo error occurs */
             PMIX_ERROR_LOG(PMIX_ERROR);
             /* DO NOT HANG */
@@ -1470,9 +1543,9 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
     }
 
     /* find/create the local tracker for this operation */
-    if (NULL == (trk = get_tracker(procs, nprocs, PMIX_CONNECTNB_CMD))) {
+    if (NULL == (trk = get_tracker(NULL, procs, nprocs, PMIX_CONNECTNB_CMD))) {
         /* we don't have this tracker yet, so get a new one */
-        if (NULL == (trk = new_tracker(procs, nprocs, PMIX_CONNECTNB_CMD))) {
+        if (NULL == (trk = new_tracker(NULL, procs, nprocs, PMIX_CONNECTNB_CMD))) {
             /* only if a bozo error occurs */
             PMIX_ERROR_LOG(PMIX_ERROR);
             /* DO NOT HANG */
@@ -2064,6 +2137,7 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
             goto exit;
         }
     }
+
     /* add an info object to mark that we recvd this internally */
     PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_SERVER_INTERNAL_NOTIFY, NULL, PMIX_BOOL);
     /* process it */
@@ -2074,8 +2148,27 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
                                                                  intermed_step, cd))) {
         goto exit;
     }
-    /* tell the switchyard we will handle it from here */
-    return PMIX_SUCCESS;
+
+    /* check the range directive - if it is LOCAL, then we are
+     * done. Otherwise, it needs to go up to our
+     * host for dissemination */
+    if (PMIX_RANGE_LOCAL == cd->range) {
+        PMIX_RELEASE(cd);
+        return PMIX_SUCCESS;
+    }
+
+    if (NULL == pmix_host_server.notify_event) {
+        PMIX_RELEASE(cd);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* pass it to our host RM for distribution */
+    rc = pmix_host_server.notify_event(cd->status, &cd->source, cd->range,
+                                       cd->info, cd->ninfo, local_cbfunc, cd);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_RELEASE(cd);
+    }
+    return rc;
 
   exit:
     PMIX_RELEASE(cd);
@@ -3125,9 +3218,452 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
     return rc;
 }
 
+static void grp_timeout(int sd, short args, void *cbdata)
+{
+    pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
+    pmix_buffer_t *reply;
+    pmix_status_t ret, rc = PMIX_ERR_TIMEOUT;
+
+    pmix_output_verbose(2, pmix_server_globals.fence_output,
+                        "ALERT: grp construct timeout fired");
+
+    /* send this requestor the reply */
+    reply = PMIX_NEW(pmix_buffer_t);
+    if (NULL == reply) {
+        goto error;
+    }
+    /* setup the reply, starting with the returned status */
+    PMIX_BFROPS_PACK(ret, cd->peer, reply, &rc, 1, PMIX_STATUS);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
+        PMIX_RELEASE(reply);
+        goto error;
+    }
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "server:grp_timeout reply being sent to %s:%u",
+                        cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
+    PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+
+  error:
+    cd->event_active = false;
+    /* remove it from the list */
+    pmix_list_remove_item(&cd->trk->local_cbs, &cd->super);
+    PMIX_RELEASE(cd);
+}
+
+static void _grpcbfunc(int sd, short argc, void *cbdata)
+{
+    pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
+    pmix_server_trkr_t *trk = scd->tracker;
+    pmix_server_caddy_t *cd;
+    pmix_buffer_t *reply;
+    pmix_status_t ret;
+    pmix_group_t *grp;
+
+    PMIX_ACQUIRE_OBJECT(scd);
+
+    /* loop across all procs in the tracker, sending them the reply */
+    PMIX_LIST_FOREACH(cd, &trk->local_cbs, pmix_server_caddy_t) {
+        reply = PMIX_NEW(pmix_buffer_t);
+        if (NULL == reply) {
+            break;
+        }
+        /* setup the reply, starting with the returned status */
+        PMIX_BFROPS_PACK(ret, cd->peer, reply, &scd->status, 1, PMIX_STATUS);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_RELEASE(reply);
+            break;
+        }
+        pmix_output_verbose(2, pmix_server_globals.base_output,
+                            "server:modex_cbfunc reply being sent to %s:%u",
+                            cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
+        PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+    }
+
+    /* if the grp object is here, then we are destructing the group,
+     * so remove the grp from our list */
+    if (NULL != trk->cbdata) {
+        grp = (pmix_group_t*)trk->cbdata;
+        pmix_list_remove_item(&pmix_server_globals.groups, &grp->super);
+        PMIX_RELEASE(grp);
+    }
+
+    /* remove the tracker from the list */
+    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+    PMIX_RELEASE(trk);
+
+    /* we are done */
+    if (NULL != scd->cbfunc.relfn) {
+        scd->cbfunc.relfn(scd->cbdata);
+    }
+    PMIX_RELEASE(scd);
+}
+
+
+static void grpcbfunc(pmix_status_t status, const char *data, size_t ndata, void *cbdata,
+                      pmix_release_cbfunc_t relfn, void *relcbd)
+{
+    pmix_server_trkr_t *tracker = (pmix_server_trkr_t*)cbdata;
+    pmix_shift_caddy_t *scd;
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "server:modex_cbfunc called with %d bytes", (int)ndata);
+
+    if (NULL == tracker) {
+        /* nothing to do - but be sure to give them
+         * a release if they want it */
+        if (NULL != relfn) {
+            relfn(relcbd);
+        }
+        return;
+    }
+
+    /* need to thread-shift this callback as it accesses global data */
+    scd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == scd) {
+        /* nothing we can do */
+        if (NULL != relfn) {
+            relfn(cbdata);
+        }
+        return;
+    }
+    scd->status = status;
+    scd->tracker = tracker;
+    scd->cbfunc.relfn = relfn;
+    scd->cbdata = relcbd;
+    PMIX_THREADSHIFT(scd, _grpcbfunc);
+}
+
+pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
+                                       pmix_buffer_t *buf)
+{
+    pmix_peer_t *peer = cd->peer;
+    int32_t cnt;
+    pmix_status_t rc;
+    char *grpid;
+    pmix_proc_t *procs;
+    pmix_group_t *grp, *pgrp;
+    pmix_info_t *info = NULL;
+    size_t n, ninfo, ndirs, nprocs;
+    bool flag;
+    pmix_server_trkr_t *trk;
+    struct timeval tv = {0, 0};
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "recvd grpconstruct cmd");
+
+    if (NULL == pmix_host_server.fence_nb) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* unpack the group ID */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &grpid, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+
+    /* see if we already have this group */
+    grp = NULL;
+    PMIX_LIST_FOREACH(pgrp, &pmix_server_globals.groups, pmix_group_t) {
+        if (0 == strcmp(grpid, pgrp->grpid)) {
+            grp = pgrp;
+            break;
+        }
+    }
+    if (NULL == grp) {
+        /* create a new entry */
+        grp = PMIX_NEW(pmix_group_t);
+        if (NULL == grp) {
+            rc = PMIX_ERR_NOMEM;
+            goto error;
+        }
+        grp->grpid = grpid;
+        pmix_list_append(&pmix_server_globals.groups, &grp->super);
+    } else {
+        free(grpid);
+    }
+
+    /* unpack the number of procs */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &nprocs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    if (0 == nprocs) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    PMIX_PROC_CREATE(procs, nprocs);
+    if (NULL == procs) {
+        rc = PMIX_ERR_NOMEM;
+        goto error;
+    }
+    cnt = nprocs;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, procs, &cnt, PMIX_PROC);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        PMIX_PROC_FREE(procs, nprocs);
+        goto error;
+    }
+    if (NULL == grp->members) {
+        grp->members = procs;
+        grp->nmbrs = nprocs;
+    } else {
+        PMIX_PROC_FREE(procs, nprocs);
+    }
+
+    /* unpack the number of directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ndirs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    ninfo = ndirs + 1;
+    PMIX_INFO_CREATE(info, ninfo);
+    if (NULL == info) {
+        rc = PMIX_ERR_NOMEM;
+        goto error;
+    }
+    if (0 < ndirs) {
+        cnt = ndirs;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto error;
+        }
+        /* see if we are to enforce a timeout - we don't internally care
+         * about any other directives */
+        for (n=0; n < ndirs; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                tv.tv_sec = info[n].value.data.uint32;
+                break;
+            }
+        }
+    }
+
+    /* treat this like a fence - no data to collect */
+    flag = false;
+    PMIX_INFO_LOAD(&info[ninfo-1], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+
+    /* find/create the local tracker for this operation */
+    if (NULL == (trk = get_tracker(grp->grpid, grp->members, grp->nmbrs, PMIX_FENCENB_CMD))) {
+        /* If no tracker was found - create and initialize it once */
+        if (NULL == (trk = new_tracker(grp->grpid, grp->members, grp->nmbrs, PMIX_FENCENB_CMD))) {
+            /* only if a bozo error occurs */
+            PMIX_ERROR_LOG(PMIX_ERROR);
+            rc = PMIX_ERROR;
+            goto error;
+        }
+        trk->type = PMIX_FENCENB_CMD;
+        trk->collect_type = PMIX_COLLECT_NO;
+    }
+
+    /* we only save the info structs from the first caller
+     * who provides them - it is a user error to provide
+     * different values from different participants */
+    if (NULL == trk->info) {
+        trk->info = info;
+        trk->ninfo = ninfo;
+    } else {
+        /* cleanup */
+        PMIX_INFO_FREE(info, ninfo);
+        info = NULL;
+    }
+
+    /* add this contributor to the tracker so they get
+     * notified when we are done */
+    pmix_list_append(&trk->local_cbs, &cd->super);
+
+    /* if a timeout was specified, set it */
+    if (0 < tv.tv_sec) {
+        PMIX_RETAIN(trk);
+        cd->trk = trk;
+        pmix_event_evtimer_set(pmix_globals.evbase, &cd->ev,
+                               grp_timeout, cd);
+        pmix_event_evtimer_add(&cd->ev, &tv);
+        cd->event_active = true;
+    }
+
+    /* if all local contributions have been received,
+     * let the local host's server know that we are at the
+     * "fence" point - they will callback once the barrier
+     * across all participants has been completed */
+    if (trk->def_complete &&
+        pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        pmix_output_verbose(2, pmix_server_globals.base_output,
+                            "local fence complete with %d procs", (int)trk->npcs);
+
+        pmix_host_server.fence_nb(trk->pcs, trk->npcs,
+                                  trk->info, trk->ninfo,
+                                  NULL, 0, grpcbfunc, trk);
+    }
+
+    return PMIX_SUCCESS;
+
+  error:
+    if (NULL != info) {
+        PMIX_INFO_FREE(info, ninfo);
+    }
+    return rc;
+}
+
+pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
+                                      pmix_buffer_t *buf)
+{
+    pmix_peer_t *peer = cd->peer;
+    int32_t cnt;
+    pmix_status_t rc;
+    char *grpid;
+    pmix_info_t *info = NULL;
+    size_t n, ninfo, ndirs;
+    bool flag;
+    pmix_server_trkr_t *trk;
+    pmix_group_t *grp, *pgrp;
+    struct timeval tv = {0, 0};
+
+    pmix_output_verbose(2, pmix_server_globals.iof_output,
+                        "recvd grpdestruct cmd");
+
+    if (NULL == pmix_host_server.fence_nb) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* unpack the group ID */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &grpid, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+
+    /* find this group in our list */
+    grp = NULL;
+    PMIX_LIST_FOREACH(pgrp, &pmix_server_globals.groups, pmix_group_t) {
+        if (0 == strcmp(grpid, pgrp->grpid)) {
+            grp = pgrp;
+            break;
+        }
+    }
+    free(grpid);
+
+    /* if not found, then this is an error - we cannot
+     * destruct a group we don't know about */
+    if (NULL == grp) {
+        rc = PMIX_ERR_NOT_FOUND;
+        goto error;
+    }
+
+    /* unpack the number of directives */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ndirs, &cnt, PMIX_SIZE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        goto error;
+    }
+    ninfo = ndirs + 1;
+    PMIX_INFO_CREATE(info, ninfo);
+    if (NULL == info) {
+        rc = PMIX_ERR_NOMEM;
+        goto error;
+    }
+    if (0 < ndirs) {
+        cnt = ndirs;
+        PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto error;
+        }
+        /* see if we are to enforce a timeout - we don't internally care
+         * about any other directives */
+        for (n=0; n < ndirs; n++) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                tv.tv_sec = info[n].value.data.uint32;
+                break;
+            }
+        }
+    }
+
+    /* treat this like a fence - no data to collect */
+    flag = false;
+    PMIX_INFO_LOAD(&info[ninfo-1], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+
+    /* use the grp membership for the fence we are to
+     * execute - our host RM only knows these procs by
+     * their "true" ID */
+
+
+    /* find/create the local tracker for this operation */
+    if (NULL == (trk = get_tracker(grp->grpid, grp->members, grp->nmbrs, PMIX_FENCENB_CMD))) {
+        /* If no tracker was found - create and initialize it once */
+        if (NULL == (trk = new_tracker(grp->grpid, grp->members, grp->nmbrs, PMIX_FENCENB_CMD))) {
+            /* only if a bozo error occurs */
+            PMIX_ERROR_LOG(PMIX_ERROR);
+            rc = PMIX_ERROR;
+            goto error;
+        }
+        trk->type = PMIX_FENCENB_CMD;
+        trk->collect_type = PMIX_COLLECT_NO;
+    }
+
+    /* we only save the info structs from the first caller
+     * who provides them - it is a user error to provide
+     * different values from different participants */
+    if (NULL == trk->info) {
+        trk->info = info;
+        trk->ninfo = ninfo;
+    } else {
+        /* cleanup */
+        PMIX_INFO_FREE(info, ninfo);
+        info = NULL;
+    }
+
+    /* add this contributor to the tracker so they get
+     * notified when we are done */
+    pmix_list_append(&trk->local_cbs, &cd->super);
+
+    /* if a timeout was specified, set it */
+    if (0 < tv.tv_sec) {
+        PMIX_RETAIN(trk);
+        cd->trk = trk;
+        pmix_event_evtimer_set(pmix_globals.evbase, &cd->ev,
+                               grp_timeout, cd);
+        pmix_event_evtimer_add(&cd->ev, &tv);
+        cd->event_active = true;
+    }
+
+    /* if all local contributions have been received,
+     * let the local host's server know that we are at the
+     * "fence" point - they will callback once the barrier
+     * across all participants has been completed */
+    if (trk->def_complete &&
+        pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        pmix_output_verbose(2, pmix_server_globals.base_output,
+                            "fence complete %d", (int)trk->nlocal);
+
+        pmix_host_server.fence_nb(grp->members, grp->nmbrs,
+                                  trk->info, trk->ninfo,
+                                  NULL, 0, grpcbfunc, trk);
+    }
+
+    return PMIX_SUCCESS;
+
+  error:
+    if (NULL != info) {
+        PMIX_INFO_FREE(info, ninfo);
+    }
+    return rc;
+}
+
 /*****    INSTANCE SERVER LIBRARY CLASSES    *****/
 static void tcon(pmix_server_trkr_t *t)
 {
+    t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN+1);
     t->pname.rank = PMIX_RANK_UNDEF;
     t->pcs = NULL;
@@ -3144,9 +3680,13 @@ static void tcon(pmix_server_trkr_t *t)
     t->modexcbfunc = NULL;
     t->op_cbfunc = NULL;
     t->hybrid = false;
+    t->cbdata = NULL;
 }
 static void tdes(pmix_server_trkr_t *t)
 {
+    if (NULL != t->id) {
+        free(t->id);
+    }
     PMIX_DESTRUCT_LOCK(&t->lock);
     if (NULL != t->pcs) {
         free(t->pcs);
@@ -3350,3 +3890,26 @@ static void ildes(pmix_inventory_rollup_t *p)
 PMIX_CLASS_INSTANCE(pmix_inventory_rollup_t,
                     pmix_object_t,
                     ilcon, ildes);
+
+static void grcon(pmix_group_t *p)
+{
+    p->grpid = NULL;
+    p->members = NULL;
+    p->nmbrs = 0;
+}
+static void grdes(pmix_group_t *p)
+{
+    if (NULL != p->grpid) {
+        free(p->grpid);
+    }
+    if (NULL != p->members) {
+        PMIX_PROC_FREE(p->members, p->nmbrs);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_group_t,
+                    pmix_list_item_t,
+                    grcon, grdes);
+
+PMIX_CLASS_INSTANCE(pmix_group_caddy_t,
+                    pmix_list_item_t,
+                    NULL, NULL);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2148,23 +2148,6 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
                                                                  intermed_step, cd))) {
         goto exit;
     }
-
-    /* check the range directive - if it is LOCAL, then we are
-     * done. Otherwise, it needs to go up to our
-     * host for dissemination */
-    if (PMIX_RANGE_LOCAL == cd->range) {
-        PMIX_RELEASE(cd);
-        return PMIX_SUCCESS;
-    }
-
-    if (NULL == pmix_host_server.notify_event) {
-        PMIX_RELEASE(cd);
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-
-    /* pass it to our host RM for distribution */
-    rc = pmix_host_server.notify_event(cd->status, &cd->source, cd->range,
-                                       cd->info, cd->ninfo, local_cbfunc, cd);
     if (PMIX_SUCCESS != rc) {
         PMIX_RELEASE(cd);
     }
@@ -2172,7 +2155,9 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
 
   exit:
     PMIX_RELEASE(cd);
-    cbfunc(rc, cbdata);
+    if (PMIX_OPERATION_SUCCEEDED != rc) {
+        cbfunc(rc, cbdata);
+    }
     return rc;
 }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -131,13 +131,30 @@ typedef struct {
 PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
 typedef struct {
-    pmix_list_t nspaces;                    // list of pmix_namespace_t for the nspaces we know about
+    pmix_list_item_t super;
+    char *grpid;
+    pmix_proc_t *members;
+    size_t nmbrs;
+} pmix_group_t;
+PMIX_CLASS_DECLARATION(pmix_group_t);
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_group_t *grp;
+    pmix_rank_t rank;
+    size_t idx;
+} pmix_group_caddy_t;
+PMIX_CLASS_DECLARATION(pmix_group_caddy_t);
+
+typedef struct {
+    pmix_list_t nspaces;                    // list of pmix_nspace_t for the nspaces we know about
     pmix_pointer_array_t clients;           // array of pmix_peer_t local clients
     pmix_list_t collectives;                // list of active pmix_server_trkr_t
     pmix_list_t remote_pnd;                 // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing remote req's
     pmix_list_t local_reqs;                 // list of pmix_dmdx_local_t awaiting arrival of data from local neighbours
     pmix_list_t gdata;                      // cache of data given to me for passing to all clients
     pmix_list_t events;                     // list of pmix_regevents_info_t registered events
+    pmix_list_t groups;                     // list of pmix_group_t group memberships
     pmix_hotel_t iof;                       // IO to be forwarded to clients
     bool tool_connections_allowed;
     char *tmpdir;                           // temporary directory for this server
@@ -300,6 +317,12 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
                                    pmix_buffer_t *buf,
                                    pmix_op_cbfunc_t cbfunc,
                                    void *cbdata);
+
+pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
+                                       pmix_buffer_t *buf);
+
+pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
+                                      pmix_buffer_t *buf);
 
 pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
                                                   pmix_buffer_t *buf,

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1107,6 +1107,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         return PMIX_SUCCESS;
     }
     pmix_globals.init_cntr = 0;
+    pmix_globals.mypeer->finalized = true;
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_globals.debug_output,

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -208,6 +208,27 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
     case PMIX_ERR_INVALID_OPERATION:
         return "INVALID-OPERATION";
 
+    case PMIX_GROUP_INVITED:
+        return "GROUP-INVITED";
+    case PMIX_GROUP_LEFT:
+        return "GROUP-LEFT";
+    case PMIX_GROUP_INVITE_ACCEPTED:
+        return "GROUP-INVITE-ACCEPTED";
+    case PMIX_GROUP_INVITE_DECLINED:
+        return "GROUP-INVITE-DECLINED";
+    case PMIX_GROUP_INVITE_FAILED:
+        return "GROUP-INVITE-FAILED";
+    case PMIX_GROUP_MEMBERSHIP_UPDATE:
+        return "GROUP-MEMBERSHIP-UPDATE";
+    case PMIX_GROUP_CONSTRUCT_ABORT:
+        return "GROUP-CONSTRUCT-ABORT";
+    case PMIX_GROUP_CONSTRUCT_COMPLETE:
+        return "GROUP-CONSTRUCT-COMPLETE";
+    case PMIX_GROUP_LEADER_SELECTED:
+        return "GROUP-LEADER-SELECTED";
+    case PMIX_GROUP_LEADER_FAILED:
+        return "GROUP-LEADER-FAILED";
+
     case PMIX_ERR_NODE_DOWN:
         return "NODE-DOWN";
     case PMIX_ERR_NODE_OFFLINE:

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -228,12 +228,15 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
         return "GROUP-LEADER-SELECTED";
     case PMIX_GROUP_LEADER_FAILED:
         return "GROUP-LEADER-FAILED";
+    case PMIX_GROUP_CONTEXT_ID_ASSIGNED:
+        return "GROUP-CONTEXT-ID-ASSIGNED";
 
     case PMIX_ERR_NODE_DOWN:
         return "NODE-DOWN";
     case PMIX_ERR_NODE_OFFLINE:
         return "NODE-OFFLINE";
-
+    case PMIX_ERR_SYS_OTHER:
+        return "UNDEFINED-SYSTEM-EVENT";
 
     case PMIX_EVENT_NO_ACTION_TAKEN:
         return "EVENT-NO-ACTION-TAKEN";

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1195,7 +1195,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
                     exit_code = t2->exit_code;
                 }
                 --wakeup;
-                break;
+                return;
             }
         }
     }


### PR DESCRIPTION
Implement PMIx_Group_construct and PMIx_Group destruct. Add tracking of
PMIx group members and substitute the real members for a group involved
in the Fence operation as a first example.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>