### PR TITLE
Fix event notification operations

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -591,6 +591,7 @@ typedef int pmix_status_t;
 /* monitoring */
 #define PMIX_MONITOR_HEARTBEAT_ALERT            (PMIX_ERR_V2X_BASE -  9)
 #define PMIX_MONITOR_FILE_ALERT                 (PMIX_ERR_V2X_BASE - 10)
+#define PMIX_PROC_TERMINATED                    (PMIX_ERR_V2X_BASE - 11)
 
 /* define a starting point for operational error constants so
  * we avoid renumbering when making additions */
@@ -605,7 +606,6 @@ typedef int pmix_status_t;
 /* gap created by v3 definitions */
 #define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
 /* gap for group codes */
-#define PMIX_PROC_TERMINATED                    (PMIX_ERR_OP_BASE - 38)
 
 /* define a starting point for system error constants so
  * we avoid renumbering when making additions */

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -604,6 +604,8 @@ typedef int pmix_status_t;
 #define PMIX_GDS_ACTION_COMPLETE                (PMIX_ERR_OP_BASE - 18)
 /* gap created by v3 definitions */
 #define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
+/* gap for group codes */
+#define PMIX_PROC_TERMINATED                    (PMIX_ERR_OP_BASE - 38)
 
 /* define a starting point for system error constants so
  * we avoid renumbering when making additions */
@@ -750,6 +752,19 @@ typedef uint8_t pmix_alloc_directive_t;
 /* define a value boundary beyond which implementers are free
  * to define their own directive values */
 #define PMIX_ALLOC_EXTERNAL     128
+
+
+/* declare a convenience macro for checking keys */
+#define PMIX_CHECK_KEY(a, b) \
+    (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
+
+/* define a convenience macro for checking nspaces */
+#define PMIX_CHECK_NSPACE(a, b) \
+    (0 == strncmp((a), (b), PMIX_MAX_NSLEN))
+
+/* define a convenience macro for checking names */
+#define PMIX_CHECK_PROCID(a, b) \
+    (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
 
 
 /****    PMIX BYTE OBJECT    ****/
@@ -1088,11 +1103,11 @@ struct pmix_info_t {
         (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);  \
         pmix_value_load(&((m)->value), (v), (t));       \
     } while (0)
-#define PMIX_INFO_XFER(d, s)                                \
-    do {                                                    \
-        (void)strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN); \
-        (d)->flags = (s)->flags;                      \
-        pmix_value_xfer(&(d)->value, &(s)->value);          \
+#define PMIX_INFO_XFER(d, s)                                        \
+    do {                                                            \
+        (void)strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);         \
+        (d)->flags = (s)->flags;                                    \
+        pmix_value_xfer(&(d)->value, (pmix_value_t*)&(s)->value);   \
     } while(0)
 
 #define PMIX_INFO_REQUIRED(m)       \

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -167,14 +167,9 @@ static void pmix_client_notify_recv(struct pmix_peer_t *peer,
             PMIX_RELEASE(chain);
             goto error;
         }
-        /* check for non-default flag */
-        for (cnt=0; cnt < (int)ninfo; cnt++) {
-            if (0 == strncmp(chain->info[cnt].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
-                chain->nondefault = PMIX_INFO_TRUE(&chain->info[cnt]);
-                break;
-            }
-        }
     }
+    /* prep the chain for processing */
+    pmix_prep_event_chain(chain, chain->info, ninfo, false);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "[%s:%d] pmix:client_notify_recv - processing event %d, calling errhandler",

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1646,6 +1646,47 @@ static void local_cbfunc(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(cd);
 }
 
+static void intermed_step(pmix_status_t status, void *cbdata)
+{
+    pmix_notify_caddy_t *cd = (pmix_notify_caddy_t*)cbdata;
+    pmix_status_t rc;
+
+    if (PMIX_SUCCESS != status) {
+        rc = status;
+        goto complete;
+    }
+
+    /* check the range directive - if it is LOCAL, then we are
+     * done. Otherwise, it needs to go up to our
+     * host for dissemination */
+    if (PMIX_RANGE_LOCAL == cd->range) {
+        rc = PMIX_SUCCESS;
+        goto complete;
+    }
+
+    if (NULL == pmix_host_server.notify_event) {
+        rc = PMIX_ERR_NOT_SUPPORTED;
+        goto complete;
+    }
+
+    /* pass it to our host RM for distribution */
+    rc = pmix_host_server.notify_event(cd->status, &cd->source, cd->range,
+                                       cd->info, cd->ninfo, local_cbfunc, cd);
+    if (PMIX_SUCCESS == rc) {
+        /* let the callback function respond for us */
+        return;
+    }
+    if (PMIX_OPERATION_SUCCEEDED == rc) {
+        rc = PMIX_SUCCESS;  // local_cbfunc will not be called
+    }
+
+  complete:
+    if (NULL != cd->cbfunc) {
+        cd->cbfunc(rc, cd->cbdata);
+    }
+    PMIX_RELEASE(cd);
+}
+
 pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
                                                   pmix_buffer_t *buf,
                                                   pmix_op_cbfunc_t cbfunc,
@@ -1654,13 +1695,11 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
     int32_t cnt;
     pmix_status_t rc;
     pmix_notify_caddy_t *cd;
+    size_t ninfo;
 
     pmix_output_verbose(2, pmix_globals.debug_output,
-                        "recvd event notification from client");
-
-    if (NULL == pmix_host_server.notify_event) {
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
+                        "%s:%d recvd event notification from client",
+                        pmix_globals.myid.nspace, pmix_globals.myid.rank);
 
     cd = PMIX_NEW(pmix_notify_caddy_t);
     if (NULL == cd) {
@@ -1690,44 +1729,36 @@ pmix_status_t pmix_server_event_recvd_from_client(pmix_peer_t *peer,
 
     /* unpack the info keys */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &cd->ninfo, &cnt, PMIX_SIZE);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto exit;
     }
-    if (0 < cd->ninfo) {
-        PMIX_INFO_CREATE(cd->info, cd->ninfo);
-        if (NULL == cd->info) {
-            rc = PMIX_ERR_NOMEM;
-            goto exit;
-        }
-        cnt = cd->ninfo;
+    cd->ninfo = ninfo + 1;
+    PMIX_INFO_CREATE(cd->info, cd->ninfo);
+    if (NULL == cd->info) {
+        rc = PMIX_ERR_NOMEM;
+        goto exit;
+    }
+    if (0 < ninfo) {
+        cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, cd->info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             goto exit;
         }
     }
-
-    /* check the range directive - if it is LOCAL, then we just
-     * process it ourselves. Otherwise, it needs to go up to our
-     * host for dissemination */
-    if (PMIX_RANGE_LOCAL == cd->range) {
-        if (PMIX_SUCCESS != (rc = pmix_server_notify_client_of_event(cd->status,
-                                                                     &cd->source,
-                                                                     cd->range,
-                                                                     cd->info, cd->ninfo,
-                                                                     local_cbfunc, cd))) {
-            goto exit;
-        }
-        return PMIX_SUCCESS;
+    /* add an info object to mark that we recvd this internally */
+    PMIX_INFO_LOAD(&cd->info[ninfo], PMIX_SERVER_INTERNAL_NOTIFY, NULL, PMIX_BOOL);
+    /* process it */
+    if (PMIX_SUCCESS != (rc = pmix_server_notify_client_of_event(cd->status,
+                                                                 &cd->source,
+                                                                 cd->range,
+                                                                 cd->info, cd->ninfo,
+                                                                 intermed_step, cd))) {
+        goto exit;
     }
-
-    /* when we receive an event from a client, we just pass it to
-     * our host RM for distribution - if any targeted recipients
-     * are local to us, the host RM will let us know */
-    pmix_host_server.notify_event(cd->status, &cd->source, cd->range,
-                                  cd->info, cd->ninfo, local_cbfunc, cd);
+    /* tell the switchyard we will handle it from here */
     return PMIX_SUCCESS;
 
   exit:

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -137,9 +137,9 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
         goto error;
     }
 
-    /* we always leave space for a callback object */
-    chain->ninfo = ninfo + 1;
-    PMIX_INFO_CREATE(chain->info, chain->ninfo);
+    /* we always leave space for event hdlr name and a callback object */
+    chain->nallocated = ninfo + 2;
+    PMIX_INFO_CREATE(chain->info, chain->nallocated);
     if (NULL == chain->info) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         PMIX_RELEASE(chain);
@@ -155,16 +155,9 @@ static void pmix_tool_notify_recv(struct pmix_peer_t *peer,
             PMIX_RELEASE(chain);
             goto error;
         }
-        /* check for non-default flag */
-        for (cnt=0; cnt < (int)ninfo; cnt++) {
-            if (0 == strncmp(chain->info[cnt].key, PMIX_EVENT_NON_DEFAULT, PMIX_MAX_KEYLEN)) {
-                chain->nondefault = PMIX_INFO_TRUE(&chain->info[cnt]);
-                break;
-            }
-        }
     }
-    /* now put the callback object tag in the last element */
-    PMIX_INFO_LOAD(&chain->info[ninfo], PMIX_EVENT_RETURN_OBJECT, NULL, PMIX_POINTER);
+    /* prep the chain for processing */
+    pmix_prep_event_chain(chain, chain->info, ninfo, false);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "[%s:%d] pmix:tool_notify_recv - processing event %d, calling errhandler",

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -176,6 +176,7 @@ PMIX_CLASS_INSTANCE(myxfer_t,
 
 typedef struct {
     pmix_list_item_t super;
+    int exit_code;
     pid_t pid;
 } wait_tracker_t;
 PMIX_CLASS_INSTANCE(wait_tracker_t,
@@ -259,6 +260,17 @@ static void model_registration_callback(pmix_status_t status,
                    status, (unsigned long)evhandler_ref);
     }
     *active = status;
+}
+
+static void set_handler_default(int sig)
+{
+    struct sigaction act;
+
+    act.sa_handler = SIG_DFL;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+
+    sigaction(sig, &act, (struct sigaction *)0);
 }
 
 int main(int argc, char **argv)
@@ -440,14 +452,22 @@ int main(int argc, char **argv)
             PMIx_server_finalize();
             return -1;
         }
-        child = PMIX_NEW(wait_tracker_t);
-        child->pid = pid;
-        pmix_list_append(&children, &child->super);
-
         if (pid == 0) {
+            sigset_t sigs;
+            set_handler_default(SIGTERM);
+            set_handler_default(SIGINT);
+            set_handler_default(SIGHUP);
+            set_handler_default(SIGPIPE);
+            set_handler_default(SIGCHLD);
+            sigprocmask(0, 0, &sigs);
+            sigprocmask(SIG_UNBLOCK, &sigs, 0);
             execve(executable, client_argv, client_env);
             /* Does not return */
             exit(0);
+        } else {
+            child = PMIX_NEW(wait_tracker_t);
+            child->pid = pid;
+            pmix_list_append(&children, &child->super);
         }
     }
     free(executable);
@@ -460,6 +480,15 @@ int main(int argc, char **argv)
         ts.tv_sec = 0;
         ts.tv_nsec = 100000;
         nanosleep(&ts, NULL);
+    }
+
+    /* see if anyone exited with non-zero status */
+    n=0;
+    PMIX_LIST_FOREACH(child, &children, wait_tracker_t) {
+        if (0 != child->exit_code) {
+            fprintf(stderr, "Child %d [%d] exited with status %d - test FAILED\n", n, child->pid, child->exit_code);
+        }
+        ++n;
     }
 
     /* try notifying ourselves */
@@ -868,7 +897,8 @@ static pmix_status_t notify_event(pmix_status_t code,
                                   pmix_info_t info[], size_t ninfo,
                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    return PMIX_SUCCESS;
+    pmix_output(0, "SERVER: NOTIFY EVENT");
+    return PMIX_OPERATION_SUCCEEDED;
 }
 
 typedef struct query_data_t {
@@ -987,8 +1017,9 @@ static void wait_signal_callback(int fd, short event, void *arg)
             if (pid == t2->pid) {
                 /* found it! */
                 --wakeup;
-                break;
+                return;
             }
         }
     }
+    fprintf(stderr, "ENDLOOP\n");
 }


### PR DESCRIPTION
Fix a few bugs in the event notification system and provide some missing
implementation (support for specifying target procs to receive the
event).

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit d4b7c68ab0b592d31ce92c41456f58f6a5a0a258)