### PR TITLE
Shift the PROC_TERMINATED constant into v2 region

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -760,6 +760,7 @@ typedef int pmix_status_t;
 /* monitoring */
 #define PMIX_MONITOR_HEARTBEAT_ALERT            (PMIX_ERR_V2X_BASE -  9)
 #define PMIX_MONITOR_FILE_ALERT                 (PMIX_ERR_V2X_BASE - 10)
+#define PMIX_PROC_TERMINATED                    (PMIX_ERR_V2X_BASE - 11)
 
 /* define a starting point for operational error constants so
  * we avoid renumbering when making additions */
@@ -781,7 +782,6 @@ typedef int pmix_status_t;
 #define PMIX_OPERATION_IN_PROGRESS              (PMIX_ERR_OP_BASE - 26)
 #define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
 /* gap for group codes */
-#define PMIX_PROC_TERMINATED                    (PMIX_ERR_OP_BASE - 38)
 
 
 /* define a starting point for system error constants so


### PR DESCRIPTION
Change the value of PMIX_PROC_TERMINATED to put it in the v2 error
constant region

Signed-off-by: Ralph Castain <rhc@open-mpi.org>