### PR TITLE
Deal with EOPNOTSUPP returned from getsockopt()

### DIFF
--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -1004,7 +1004,7 @@ static pmix_status_t recv_connect_ack(int sd)
     /* get the current timeout value so we can reset to it */
     sz = sizeof(save);
     if (0 != getsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, (void*)&save, &sz)) {
-        if (ENOPROTOOPT == errno) {
+        if (ENOPROTOOPT == errno || EOPNOTSUPP == errno) {
             sockopt = false;
         } else {
            return PMIX_ERR_UNREACH;

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -393,7 +393,7 @@ static pmix_status_t recv_connect_ack(int sd)
     /* get the current timeout value so we can reset to it */
     sz = sizeof(save);
     if (0 != getsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, (void*)&save, &sz)) {
-        if (ENOPROTOOPT == errno) {
+        if (ENOPROTOOPT == errno || EOPNOTSUPP == errno) {
             sockopt = false;
         } else {
              return PMIX_ERR_UNREACH;


### PR DESCRIPTION
`EOPNOTSUPP` can be returned by `getsockopt()` when running on QEMU user-mode emulation, which [does not support](https://github.com/qemu/qemu/blob/b8f7ff1e10b4d03555d6a5da011c2aae10063ab8/linux-user/syscall.c#L3285) `getsockopt(..., SOL_SOCKET, SO_RCVTIMEO, ..., ...)`. I discovered this with OpenMPI 2.1.1 (PMIx 1.2.1) on Ubuntu 18.04, emulating armhf on amd64, but the issue seems to persist in newer versions.

Without this patch, the following error messages appear and initialization fails:
```
$ mpiexec -n 1 --mca pmix_base_verbose 100 ./helloworld
[...]
[0086e7d4ea41:26421] pmix: init called
[0086e7d4ea41:26421] posting notification recv on tag 0
[0086e7d4ea41:26421] Security SPC include: native
[0086e7d4ea41:26421] sec: native init
[0086e7d4ea41:26421] sec: SPC native active
[0086e7d4ea41:26421] usock_peer_try_connect: attempting to connect to server
[0086e7d4ea41:26421] usock_peer_try_connect: attempting to connect to server on socket 15
[0086e7d4ea41:26421] pmix: SEND CONNECT ACK
[0086e7d4ea41:26414] listen_thread: new connection: (27, 0)
[0086e7d4ea41:26421] send blocking of 33 bytes to socket 15
[0086e7d4ea41:26421] blocking send complete to socket 15
[0086e7d4ea41:26421] pmix: RECV CONNECT ACK FROM SERVER
[0086e7d4ea41:26414] connection_handler: new connection: 27
getsockopt level=1 optname=20 not yet supported
[0086e7d4ea41:26414] RECV CONNECT ACK FROM PEER ON SOCKET 27
[0086e7d4ea41:26414] waiting for blocking recv of 12 bytes
[0086e7d4ea41:26421] PMIX ERROR: UNREACHABLE in file src/client/pmix_client.c at line 205
[0086e7d4ea41:26414] blocking receive complete from remote
[0086e7d4ea41:26414] waiting for blocking recv of 21 bytes
[0086e7d4ea41:26414] blocking receive complete from remote
[0086e7d4ea41:26414] connect-ack recvd from peer 1524039681:0:1.2.1
[0086e7d4ea41:26414] sec: native validate_cred NULL
[0086e7d4ea41:26414] sec:native checking getsockopt for peer credentials
[0086e7d4ea41:26414] sec: native credential 0:0 valid
[0086e7d4ea41:26414] client credential validated
[0086e7d4ea41:26414] send blocking of 4 bytes to socket 27
[0086e7d4ea41:26421] sec: native finalize
[0086e7d4ea41:26414] usock_peer_send_blocking: send() to socket 27 failed: Broken pipe (32)
[0086e7d4ea41:26414] PMIX ERROR: UNREACHABLE in file src/server/pmix_server_listener.c at line 507
```