### PR TITLE
Convert the code base to use pmix_strncpy

### DIFF
--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -13,6 +13,7 @@ def signal_handler(signal, frame):
 
 def harvest_constants(options, src, constants, definitions):
     global takeconst, takeapis, takedtypes
+
     path = os.path.join(options.src, src)
     # open the file
     try:
@@ -138,6 +139,16 @@ def harvest_constants(options, src, constants, definitions):
                     n += 1
                     continue
                 else:
+                    # check for a typedef that includes a named value
+                    # of either PMIX_MAX_NSLEN or PMIX_MAX_KEYLEN
+                    if "PMIX_MAX_NSLEN+1" in value:
+                        value = value.replace("PMIX_MAX_NSLEN+1", str(64))
+                    elif "PMIX_MAX_NSLEN" in value:
+                        value = value.replace("PMIX_MAX_NSLEN", str(63))
+                    elif "PMIX_MAX_KEYLEN+1" in value:
+                        value = value.replace("PMIX_MAX_KEYLEN+1", str(64))
+                    elif "PMIX_MAX_KEYLEN" in value:
+                        value = value.replace("PMIX_MAX_KEYLEN", str(63))
                     typedefs.append([value])
             # now check the third option by looking for
             # "fn_t" or "cbfunc_t" in it

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1172,7 +1172,7 @@ typedef struct pmix_proc {
 #define PMIX_PROC_LOAD(m, n, r)                             \
     do {                                                    \
         PMIX_PROC_CONSTRUCT((m));                           \
-        (void)strncpy((m)->nspace, (n), PMIX_MAX_NSLEN);    \
+        pmix_strncpy((m)->nspace, (n), PMIX_MAX_NSLEN);    \
         (m)->rank = (r);                                    \
     } while(0)
 
@@ -1182,9 +1182,9 @@ typedef struct pmix_proc {
         memset((t), 0, PMIX_MAX_NSLEN+1);                                   \
         _len = strlen((c));                                                 \
         if ((_len + strlen((n))) < PMIX_MAX_NSLEN) {                        \
-            (void)strncpy((t), (c), PMIX_MAX_NSLEN);                        \
+            pmix_strncpy((t), (c), PMIX_MAX_NSLEN);                         \
             (t)[_len] = ':';                                                \
-            (void)strncpy(&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len - 1);    \
+            pmix_strncpy(&(t)[_len+1], (n), PMIX_MAX_NSLEN - _len);         \
         }                                                                   \
     } while(0)
 
@@ -2460,6 +2460,34 @@ static inline void pmix_value_destruct(pmix_value_t * m) {
     } else if (PMIX_ENVAR == (m)->type) {
         PMIX_ENVAR_DESTRUCT(&(m)->data.envar);
     }
+}
+
+/**
+ * Provide a safe version of strncpy that doesn't generate
+ * a ton of spurious warnings. Note that not every environment
+ * provides nice string functions, and we aren't concerned about
+ * max performance here
+ *
+ * @param dest Destination string.
+ * @param src Source string.
+ * @param len Size of the dest array - 1
+ *
+ */
+static inline void pmix_strncpy(char *dest, const char *src, size_t len)
+{
+    size_t i, k;
+    char *new_dest = dest;
+
+    /* use an algorithm that also protects against
+     * non-NULL-terminated src strings */
+    for (i=0, k=0; i <= len; ++i, ++src, ++new_dest) {
+        ++k;
+        *new_dest = *src;
+        if ('\0' == *src) {
+            break;
+        }
+    }
+    dest[k-1] = '\0';
 }
 
 #include <pmix_extend.h>

--- a/include/pmix_extend.h
+++ b/include/pmix_extend.h
@@ -75,7 +75,6 @@ pmix_status_t pmix_value_unload(pmix_value_t *kv, void **data, size_t *sz);
 
 pmix_status_t pmix_value_xfer(pmix_value_t *kv, pmix_value_t *src);
 
-
 pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
 
 pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg);

--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -75,7 +75,7 @@ PMIX_EXPORT int PMI_Init(int *spawned)
                 *spawned = 0;
             }
             pmi_singleton = true;
-            (void)strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
+            pmix_strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
             myproc.rank = 0;
             pmi_init = 1;
             return PMI_SUCCESS;
@@ -242,7 +242,7 @@ PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[
         proc.rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_ANL_MAP, NULL, 0, &val) &&
                (NULL != val) && (PMIX_STRING == val->type)) {
-            strncpy(value, val->data.string, length);
+            pmix_strncpy(value, val->data.string, length-1);
             PMIX_VALUE_FREE(val, 1);
             return PMI_SUCCESS;
         } else {
@@ -259,7 +259,7 @@ PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[
 
     /* retrieve the data from PMIx - since we don't have a rank,
      * we indicate that by passing the UNDEF value */
-    (void)strncpy(proc.nspace, kvsname, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, kvsname, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_UNDEF;
 
     rc = PMIx_Get(&proc, key, NULL, 0, &val);
@@ -267,7 +267,7 @@ PMIX_EXPORT int PMI_KVS_Get( const char kvsname[], const char key[], char value[
         if (PMIX_STRING != val->type) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
-            (void)strncpy(value, val->data.string, length);
+            pmix_strncpy(value, val->data.string, length-1);
         }
         PMIX_VALUE_RELEASE(val);
     }
@@ -445,7 +445,7 @@ PMIX_EXPORT int PMI_Publish_name(const char service_name[], const char port[])
     }
 
     /* pass the service/port */
-    (void) strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
+           pmix_strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
     info.value.type = PMIX_STRING;
     info.value.data.string = (char*) port;
 
@@ -497,7 +497,7 @@ PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
     PMIX_PDATA_CONSTRUCT(&pdata);
 
     /* pass the service */
-    (void) strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
+           pmix_strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
 
     /* PMI-1 doesn't want the nspace back */
     if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, NULL, 0))) {
@@ -514,7 +514,7 @@ PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
      * potential we could overrun it. As this feature
      * isn't widely supported in PMI-1, try being
      * conservative */
-    (void) strncpy(port, pdata.value.data.string, PMIX_MAX_KEYLEN);
+           pmix_strncpy(port, pdata.value.data.string, PMIX_MAX_KEYLEN);
     PMIX_PDATA_DESTRUCT(&pdata);
 
     return PMIX_SUCCESS;
@@ -535,7 +535,7 @@ PMIX_EXPORT int PMI_Get_id(char id_str[], int length)
         return PMI_ERR_INVALID_LENGTH;
     }
 
-    (void) strncpy(id_str, myproc.nspace, length);
+    pmix_strncpy(id_str, myproc.nspace, length-1);
     return PMI_SUCCESS;
 }
 
@@ -742,7 +742,7 @@ PMIX_EXPORT int PMI_Spawn_multiple(int count,
             apps[i].info = (pmix_info_t*)malloc(apps[i].ninfo * sizeof(pmix_info_t));
             /* copy the info objects */
             for (j = 0; j < apps[i].ninfo; j++) {
-                (void)strncpy(apps[i].info[j].key, info_keyval_vectors[i][j].key, PMIX_MAX_KEYLEN);
+                pmix_strncpy(apps[i].info[j].key, info_keyval_vectors[i][j].key, PMIX_MAX_KEYLEN);
                 apps[i].info[j].value.type = PMIX_STRING;
                 apps[i].info[j].value.data.string = strdup(info_keyval_vectors[i][j].val);
             }

--- a/src/client/pmi2.c
+++ b/src/client/pmi2.c
@@ -79,7 +79,7 @@ PMIX_EXPORT int PMI2_Init(int *spawned, int *size, int *rank, int *appnum)
                 *appnum = 0;
             }
             pmi2_singleton = true;
-            (void)strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
+            pmix_strncpy(myproc.nspace, "1234", PMIX_MAX_NSLEN);
             myproc.rank = 0;
             pmi2_init = 1;
             return PMI2_SUCCESS;
@@ -227,7 +227,7 @@ PMIX_EXPORT int PMI2_Job_Spawn(int count, const char * cmds[],
         apps[i].info = (pmix_info_t*)malloc(apps[i].ninfo * sizeof(pmix_info_t));
         /* copy the info objects */
         for (j=0; j < apps[i].ninfo; j++) {
-            (void)strncpy(apps[i].info[j].key, info_keyval_vectors[i][j].key, PMIX_MAX_KEYLEN);
+            pmix_strncpy(apps[i].info[j].key, info_keyval_vectors[i][j].key, PMIX_MAX_KEYLEN);
             apps[i].info[j].value.type = PMIX_STRING;
             apps[i].info[j].value.data.string = strdup(info_keyval_vectors[i][j].val);
         }
@@ -271,7 +271,7 @@ PMIX_EXPORT int PMI2_Job_GetId(char jobid[], int jobid_size)
     if (NULL == jobid) {
         return PMI2_ERR_INVALID_ARGS;
     }
-    (void)strncpy(jobid, myproc.nspace, jobid_size);
+    pmix_strncpy(jobid, myproc.nspace, jobid_size-1);
     return PMI2_SUCCESS;
 }
 
@@ -339,7 +339,7 @@ PMIX_EXPORT int PMI2_Job_Connect(const char jobid[], PMI2_Connect_comm_t *conn)
     }
 
     memset(proc.nspace, 0, sizeof(proc.nspace));
-    (void)strncpy(proc.nspace, (jobid ? jobid : proc.nspace), sizeof(proc.nspace)-1);
+    pmix_strncpy(proc.nspace, (jobid ? jobid : proc.nspace), PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     rc = PMIx_Connect(&proc, 1, NULL, 0);
     return convert_err(rc);
@@ -357,7 +357,7 @@ PMIX_EXPORT int PMI2_Job_Disconnect(const char jobid[])
     }
 
     memset(proc.nspace, 0, sizeof(proc.nspace));
-    (void)strncpy(proc.nspace, (jobid ? jobid : proc.nspace), sizeof(proc.nspace)-1);
+    pmix_strncpy(proc.nspace, (jobid ? jobid : proc.nspace), PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     rc = PMIx_Disconnect(&proc, 1, NULL, 0);
     return convert_err(rc);
@@ -455,7 +455,7 @@ PMIX_EXPORT int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
     pmix_output_verbose(3, pmix_globals.debug_output,
             "PMI2_KVS_Get: key=%s jobid=%s src_pmi_id=%d", key, (jobid ? jobid : "null"), src_pmi_id);
 
-    (void)strncpy(proc.nspace, (jobid ? jobid : myproc.nspace), PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, (jobid ? jobid : myproc.nspace), PMIX_MAX_NSLEN);
     if (src_pmi_id == PMI2_ID_NULL) {
         /* the rank is UNDEF */
         proc.rank = PMIX_RANK_UNDEF;
@@ -468,7 +468,7 @@ PMIX_EXPORT int PMI2_KVS_Get(const char *jobid, int src_pmi_id,
         if (PMIX_STRING != val->type) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
-            (void)strncpy(value, val->data.string, maxvalue);
+            pmix_strncpy(value, val->data.string, maxvalue-1);
             *vallen = strlen(val->data.string);
         }
         PMIX_VALUE_RELEASE(val);
@@ -511,7 +511,7 @@ PMIX_EXPORT int PMI2_Info_GetNodeAttr(const char name[],
         if (PMIX_STRING != val->type) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
-            (void)strncpy(value, val->data.string, valuelen);
+            pmix_strncpy(value, val->data.string, valuelen-1);
             *found = 1;
         }
         PMIX_VALUE_RELEASE(val);
@@ -586,7 +586,7 @@ PMIX_EXPORT int PMI2_Info_GetJobAttr(const char name[], char value[], int valuel
         proc.rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS == PMIx_Get(&proc, PMIX_ANL_MAP, NULL, 0, &val) &&
                (NULL != val) && (PMIX_STRING == val->type)) {
-            strncpy(value, val->data.string, valuelen);
+            pmix_strncpy(value, val->data.string, valuelen);
             PMIX_VALUE_FREE(val, 1);
             *found = 1;
             return PMI2_SUCCESS;
@@ -610,7 +610,7 @@ PMIX_EXPORT int PMI2_Info_GetJobAttr(const char name[], char value[], int valuel
         if (PMIX_STRING != val->type) {
             rc = PMIX_ERROR;
         } else if (NULL != val->data.string) {
-            (void)strncpy(value, val->data.string, valuelen);
+            pmix_strncpy(value, val->data.string, valuelen-1);
             *found = 1;
         }
         PMIX_VALUE_RELEASE(val);
@@ -648,14 +648,14 @@ PMIX_EXPORT int PMI2_Nameserv_publish(const char service_name[],
     }
 
     /* pass the service/port */
-    (void)strncpy(info[0].key, service_name, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[0].key, service_name, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_STRING;
     info[0].value.data.string = (char*)port;
     nvals = 1;
 
     /* if provided, add any other value */
     if (NULL != info_ptr) {
-        (void)strncpy(info[1].key, info_ptr->key, PMIX_MAX_KEYLEN);
+        pmix_strncpy(info[1].key, info_ptr->key, PMIX_MAX_KEYLEN);
         info[1].value.type = PMIX_STRING;
         info[1].value.data.string = (char*)info_ptr->val;
         nvals = 2;
@@ -689,12 +689,12 @@ PMIX_EXPORT int PMI2_Nameserv_lookup(const char service_name[],
     PMIX_PDATA_CONSTRUCT(&pdata[1]);
 
     /* pass the service */
-    (void)strncpy(pdata[0].key, service_name, PMIX_MAX_KEYLEN);
+    pmix_strncpy(pdata[0].key, service_name, PMIX_MAX_KEYLEN);
     nvals = 1;
 
     /* if provided, add any other value */
     if (NULL != info_ptr) {
-        (void)strncpy(pdata[1].key, info_ptr->key, PMIX_MAX_KEYLEN);
+        pmix_strncpy(pdata[1].key, info_ptr->key, PMIX_MAX_KEYLEN);
         pdata[1].value.type = PMIX_STRING;
         pdata[1].value.data.string = info_ptr->val;
         nvals = 2;
@@ -716,7 +716,7 @@ PMIX_EXPORT int PMI2_Nameserv_lookup(const char service_name[],
     }
 
     /* return the port */
-    (void)strncpy(port, pdata[0].value.data.string, portLen);
+    pmix_strncpy(port, pdata[0].value.data.string, portLen-1);
     PMIX_PDATA_DESTRUCT(&pdata[0]);
 
     if (NULL != info_ptr) {

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -439,7 +439,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
          * rank should be known. So return them here if
          * requested */
          if (NULL != proc) {
-            (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+            pmix_strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             proc->rank = pmix_globals.myid.rank;
         }
         ++pmix_globals.init_cntr;
@@ -508,9 +508,9 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
 
     /* we require our nspace */
     if (NULL != proc) {
-        (void)strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
     }
-    (void)strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
+    PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, evar);
     /* set the global pmix_namespace_t object for our peer */
     pmix_globals.mypeer->nptr->nspace = strdup(evar);
 
@@ -644,7 +644,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     /* look for a debugger attach key */
-    (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
     PMIX_INFO_LOAD(&ginfo, PMIX_OPTIONAL, NULL, PMIX_BOOL);
     if (PMIX_SUCCESS == PMIx_Get(&wildcard, PMIX_DEBUG_STOP_IN_INIT, &ginfo, 1, &val)) {
@@ -1239,7 +1239,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename,
     /* if the nspace wasn't found, then we need to
      * ask the server for that info */
     if (PMIX_ERR_INVALID_NAMESPACE == cb->status) {
-        (void)strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         /* any key will suffice as it will bring down
          * the entire data blob */
@@ -1309,7 +1309,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist
     /* if the nspace wasn't found, then we need to
      * ask the server for that info */
     if (PMIX_ERR_INVALID_NAMESPACE == cb->status) {
-        (void)strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         /* any key will suffice as it will bring down
          * the entire data blob */

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2015 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -147,7 +147,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
     /* if we are given a NULL proc, then the caller is referencing
      * all procs within our own nspace */
     if (NULL == procs) {
-        (void)strncpy(rg.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(rg.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
         rg.rank = PMIX_RANK_WILDCARD;
         rgs = &rg;
         nrg = 1;

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -294,7 +294,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
     }
 
     /* cache the proc id */
-    (void)strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = cb->pname.rank;
 
     /* a zero-byte buffer indicates that this recv is being
@@ -407,7 +407,7 @@ static pmix_status_t process_values(pmix_value_t **v, pmix_cb_t *cb)
     /* copy the list elements */
     n=0;
     PMIX_LIST_FOREACH(kv, kvs, pmix_kval_t) {
-        (void)strncpy(info[n].key, kv->key, PMIX_MAX_KEYLEN);
+        pmix_strncpy(info[n].key, kv->key, PMIX_MAX_KEYLEN);
         pmix_value_xfer(&info[n].value, kv->value);
         ++n;
     }
@@ -496,7 +496,7 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                         (NULL == cb->key) ? "NULL" : cb->key);
 
     /* set the proc object identifier */
-    (void)strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = cb->pname.rank;
 
     /* scan the incoming directives */

--- a/src/client/pmix_client_pub.c
+++ b/src/client/pmix_client_pub.c
@@ -660,7 +660,7 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
             for (j=0; j < cb->nvals; j++) {
                 if (0 == strcmp(pdata[i].key, tgt[j].key)) {
                     /* transfer the publishing proc id */
-                    (void)strncpy(tgt[j].proc.nspace, pdata[i].proc.nspace, PMIX_MAX_NSLEN);
+                    pmix_strncpy(tgt[j].proc.nspace, pdata[i].proc.nspace, PMIX_MAX_NSLEN);
                     tgt[j].proc.rank = pdata[i].proc.rank;
                     /* transfer the value to the pmix_info_t */
                     PMIX_BFROPS_VALUE_XFER(cb->status, pmix_client_globals.myserver, &tgt[j].value, &pdata[i].value);

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -104,7 +104,7 @@ PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
     PMIX_WAIT_THREAD(&cb->lock);
     rc = cb->status;
     if (NULL != nspace) {
-        (void)strncpy(nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
     }
     PMIX_RELEASE(cb);
 
@@ -254,7 +254,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
 
         if (NULL != n2) {
             /* protect length */
-            (void)strncpy(nspace, n2, PMIX_MAX_NSLEN);
+            pmix_strncpy(nspace, n2, PMIX_MAX_NSLEN);
             free(n2);
             PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, buf);
             /* extract and process any job-related info for this nspace */

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -98,7 +98,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
         /* didn't find it, so try to get the library version of the target
          * from the host - the result will be cached, so we will only have
          * to retrieve it once */
-        (void)strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
         wildcard.rank = PMIX_RANK_WILDCARD;
         if (PMIX_SUCCESS != (rc = PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value))) {
             /* couldn't get it - nothing we can do */
@@ -139,7 +139,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
 
     /* try to get the library version of this peer - the result will be
      * cached, so we will only have to retrieve it once */
-    (void)strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
     wildcard.rank = PMIX_RANK_WILDCARD;
     if (PMIX_SUCCESS != (rc = PMIx_Get(&wildcard, PMIX_BFROPS_MODULE, NULL, 0, &value))) {
         /* couldn't get it - nothing we can do */

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -148,7 +148,7 @@ pmix_iof_fd_always_ready(int fd)
                             "defining endpt: file %s line %d fd %d",        \
                             __FILE__, __LINE__, (fid)));                    \
         PMIX_CONSTRUCT((snk), pmix_iof_sink_t);                             \
-        (void)strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);    \
+        pmix_strncpy((snk)->name.nspace, (nm)->nspace, PMIX_MAX_NSLEN);    \
         (snk)->name.rank = (nm)->rank;                                      \
         (snk)->tag = (tg);                                                  \
         if (0 <= (fid)) {                                                   \

--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -192,7 +192,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             ch = PMIX_NEW(pmix_event_chain_t);                                      \
             ch->status = (e);                                                       \
             ch->range = (r);                                                        \
-            (void)strncpy(ch->source.nspace,                                        \
+            pmix_strncpy(ch->source.nspace,                                        \
                           (p)->nptr->nspace,                                        \
                           PMIX_MAX_NSLEN);                                          \
             ch->source.rank = (p)->info->pname.rank;                                \
@@ -210,7 +210,7 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             pmix_event_add(&ch->ev, &pmix_globals.event_window);                    \
         } else {                                                                    \
             /* add this peer to the array of sources */                             \
-            (void)strncpy(proc.nspace, (p)->nptr->nspace, PMIX_MAX_NSLEN);          \
+            pmix_strncpy(proc.nspace, (p)->nptr->nspace, PMIX_MAX_NSLEN);          \
             proc.rank = (p)->info->pname.rank;                                      \
             ninfo = ch->nallocated + 1;                                             \
             PMIX_INFO_CREATE(info, ninfo);                                          \

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -172,7 +172,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
     /* setup for our own local callbacks */
     chain = PMIX_NEW(pmix_event_chain_t);
     chain->status = status;
-    (void)strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     chain->source.rank = pmix_globals.myid.rank;
     /* we always leave space for event hdlr name and a callback object */
     chain->nallocated = ninfo + 2;
@@ -185,10 +185,10 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
     cd = PMIX_NEW(pmix_notify_caddy_t);
     cd->status = status;
     if (NULL == source) {
-        (void)strncpy(cd->source.nspace, "UNDEF", PMIX_MAX_NSLEN);
+        pmix_strncpy(cd->source.nspace, "UNDEF", PMIX_MAX_NSLEN);
         cd->source.rank = PMIX_RANK_UNDEF;
     } else {
-        (void)strncpy(cd->source.nspace, source->nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(cd->source.nspace, source->nspace, PMIX_MAX_NSLEN);
         cd->source.rank = source->rank;
     }
     cd->range = range;
@@ -306,9 +306,9 @@ static void progress_local_event_hdlr(pmix_status_t status,
 
     /* save this handler's returned status */
     if (NULL != chain->evhdlr->name) {
-        (void)strncpy(newinfo[cnt].key, chain->evhdlr->name, PMIX_MAX_KEYLEN);
+        pmix_strncpy(newinfo[cnt].key, chain->evhdlr->name, PMIX_MAX_KEYLEN);
     } else {
-        (void)strncpy(newinfo[cnt].key, "UNKNOWN", PMIX_MAX_KEYLEN);
+        pmix_strncpy(newinfo[cnt].key, "UNKNOWN", PMIX_MAX_KEYLEN);
     }
     newinfo[cnt].value.type = PMIX_STATUS;
     newinfo[cnt].value.data.status = status;
@@ -808,7 +808,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
      * against our registrations */
     chain = PMIX_NEW(pmix_event_chain_t);
     chain->status = cd->status;
-    (void)strncpy(chain->source.nspace, cd->source.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(chain->source.nspace, cd->source.nspace, PMIX_MAX_NSLEN);
     chain->source.rank = cd->source.rank;
     /* we always leave space for a callback object and
      * the evhandler name. */
@@ -1013,10 +1013,10 @@ pmix_status_t pmix_server_notify_client_of_event(pmix_status_t status,
     cd = PMIX_NEW(pmix_notify_caddy_t);
     cd->status = status;
     if (NULL == source) {
-        (void)strncpy(cd->source.nspace, "UNDEF", PMIX_MAX_NSLEN);
+        pmix_strncpy(cd->source.nspace, "UNDEF", PMIX_MAX_NSLEN);
         cd->source.rank = PMIX_RANK_UNDEF;
     } else {
-        (void)strncpy(cd->source.nspace, source->nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(cd->source.nspace, source->nspace, PMIX_MAX_NSLEN);
         cd->source.rank = source->rank;
     }
     cd->range = range;

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -293,7 +293,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
         PMIX_INFO_CREATE(cd2->info, cd2->ninfo);
         n=0;
         PMIX_LIST_FOREACH(ixfer, xfer, pmix_info_caddy_t) {
-            (void)strncpy(cd2->info[n].key, ixfer->info[n].key, PMIX_MAX_KEYLEN);
+            pmix_strncpy(cd2->info[n].key, ixfer->info[n].key, PMIX_MAX_KEYLEN);
             PMIX_BFROPS_VALUE_LOAD(pmix_client_globals.myserver,
                                    &cd2->info[n].value,
                                    &ixfer->info[n].value.data,
@@ -407,7 +407,7 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
        /* create the chain */
         chain = PMIX_NEW(pmix_event_chain_t);
         chain->status = ncd->status;
-        (void)strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(chain->source.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
         chain->source.rank = pmix_globals.myid.rank;
         /* we always leave space for event hdlr name and a callback object */
         chain->nallocated = ncd->ninfo + 2;

--- a/src/mca/base/pmix_mca_base_component_repository.c
+++ b/src/mca/base/pmix_mca_base_component_repository.c
@@ -15,7 +15,7 @@
  *                         reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -164,12 +164,12 @@ static int process_repository_item (const char *filename, void *data)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    /* strncpy does not guarantee a \0 */
+    /* pmix_strncpy does not guarantee a \0 */
     ri->ri_type[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN] = '\0';
-    strncpy (ri->ri_type, type, PMIX_MCA_BASE_MAX_TYPE_NAME_LEN);
+    pmix_strncpy (ri->ri_type, type, PMIX_MCA_BASE_MAX_TYPE_NAME_LEN);
 
     ri->ri_name[PMIX_MCA_BASE_MAX_TYPE_NAME_LEN] = '\0';
-    strncpy (ri->ri_name, name, PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN);
+    pmix_strncpy (ri->ri_name, name, PMIX_MCA_BASE_MAX_COMPONENT_NAME_LEN);
 
     pmix_list_append (component_list, &ri->super);
 

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -236,7 +236,7 @@ pmix_status_t pmix_bfrops_base_copy_info(pmix_info_t **dest,
                                          pmix_data_type_t type)
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     (*dest)->flags = src->flags;
     return pmix_bfrops_base_value_xfer(&(*dest)->value, &src->value);
 }
@@ -267,7 +267,7 @@ pmix_status_t pmix_bfrops_base_copy_app(pmix_app_t **dest,
     (*dest)->ninfo = src->ninfo;
     (*dest)->info = (pmix_info_t*)malloc(src->ninfo * sizeof(pmix_info_t));
     for (j=0; j < src->ninfo; j++) {
-        (void)strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
+        pmix_strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
         pmix_value_xfer(&(*dest)->info[j].value, &src->info[j].value);
     }
     return PMIX_SUCCESS;
@@ -300,7 +300,7 @@ pmix_status_t pmix_bfrops_base_copy_proc(pmix_proc_t **dest,
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
-    (void)strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
     (*dest)->rank = src->rank;
     return PMIX_SUCCESS;
 }
@@ -336,9 +336,9 @@ pmix_status_t pmix_bfrops_base_copy_pdata(pmix_pdata_t **dest,
                                           pmix_data_type_t type)
 {
     *dest = (pmix_pdata_t*)malloc(sizeof(pmix_pdata_t));
-    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     return pmix_bfrops_base_value_xfer(&(*dest)->value, &src->value);
 }
 

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -824,7 +824,7 @@ pmix_status_t pmix_bfrops_base_unpack_info(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack the directives */
         m=1;
@@ -878,7 +878,7 @@ pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
             PMIX_ERROR_LOG(PMIX_ERROR);
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
@@ -970,7 +970,7 @@ pmix_status_t pmix_bfrops_base_unpack_proc(pmix_buffer_t *buffer, void *dest,
             PMIX_ERROR_LOG(PMIX_ERROR);
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
+        pmix_strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
         free(tmp);
         /* unpack the rank */
         m=1;

--- a/src/mca/bfrops/v12/copy.c
+++ b/src/mca/bfrops/v12/copy.c
@@ -339,7 +339,7 @@ pmix_status_t pmix12_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
                                     pmix_data_type_t type)
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 
@@ -364,7 +364,7 @@ pmix_status_t pmix12_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
     (*dest)->ninfo = src->ninfo;
     (*dest)->info = (pmix_info_t*)malloc(src->ninfo * sizeof(pmix_info_t));
     for (j=0; j < src->ninfo; j++) {
-        (void)strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
+        pmix_strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
         pmix_value_xfer(&(*dest)->info[j].value, &src->info[j].value);
     }
     return PMIX_SUCCESS;
@@ -410,7 +410,7 @@ pmix_status_t pmix12_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
-    (void)strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
     (*dest)->rank = src->rank;
     return PMIX_SUCCESS;
 }
@@ -467,9 +467,9 @@ pmix_status_t pmix12_bfrop_copy_pdata(pmix_pdata_t **dest,
                                      pmix_data_type_t type)
 {
     *dest = (pmix_pdata_t*)malloc(sizeof(pmix_pdata_t));
-    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     return pmix_value_xfer(&(*dest)->value, &src->value);
 }
 

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -747,7 +747,7 @@ pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
@@ -801,7 +801,7 @@ pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
@@ -885,7 +885,7 @@ pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
+        pmix_strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
         free(tmp);
         /* unpack the rank */
         m=1;

--- a/src/mca/bfrops/v20/copy.c
+++ b/src/mca/bfrops/v20/copy.c
@@ -883,7 +883,7 @@ pmix_status_t pmix20_bfrop_copy_info(pmix_info_t **dest, pmix_info_t *src,
                                    pmix_data_type_t type)
 {
     *dest = (pmix_info_t*)malloc(sizeof(pmix_info_t));
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     (*dest)->flags = src->flags;
     return pmix20_bfrop_value_xfer(&(*dest)->value, &src->value);
 }
@@ -912,7 +912,7 @@ pmix_status_t pmix20_bfrop_copy_app(pmix_app_t **dest, pmix_app_t *src,
     (*dest)->ninfo = src->ninfo;
     (*dest)->info = (pmix_info_t*)malloc(src->ninfo * sizeof(pmix_info_t));
     for (j=0; j < src->ninfo; j++) {
-        (void)strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
+        pmix_strncpy((*dest)->info[j].key, src->info[j].key, PMIX_MAX_KEYLEN);
         pmix20_bfrop_value_xfer(&(*dest)->info[j].value, &src->info[j].value);
     }
     return PMIX_SUCCESS;
@@ -943,7 +943,7 @@ pmix_status_t pmix20_bfrop_copy_proc(pmix_proc_t **dest, pmix_proc_t *src,
     if (NULL == *dest) {
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
-    (void)strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->nspace, src->nspace, PMIX_MAX_NSLEN);
     (*dest)->rank = src->rank;
     return PMIX_SUCCESS;
 }
@@ -996,9 +996,9 @@ pmix_status_t pmix20_bfrop_copy_pdata(pmix_pdata_t **dest, pmix_pdata_t *src,
                                     pmix_data_type_t type)
 {
     *dest = (pmix_pdata_t*)malloc(sizeof(pmix_pdata_t));
-    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
-    (void)strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
+    pmix_strncpy((*dest)->key, src->key, PMIX_MAX_KEYLEN);
     return pmix20_bfrop_value_xfer(&(*dest)->value, &src->value);
 }
 
@@ -1006,7 +1006,7 @@ pmix_status_t pmix20_bfrop_copy_pinfo(pmix_proc_info_t **dest, pmix_proc_info_t 
                                     pmix_data_type_t type)
 {
     *dest = (pmix_proc_info_t*)malloc(sizeof(pmix_proc_info_t));
-    (void)strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy((*dest)->proc.nspace, src->proc.nspace, PMIX_MAX_NSLEN);
     (*dest)->proc.rank = src->proc.rank;
     if (NULL != src->hostname) {
         (*dest)->hostname = strdup(src->hostname);

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -824,7 +824,7 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
             PMIX_ERROR_LOG(PMIX_ERROR);
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack the flags */
         m=1;
@@ -881,7 +881,7 @@ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
+        pmix_strncpy(ptr[i].key, tmp, PMIX_MAX_KEYLEN);
         free(tmp);
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
@@ -961,7 +961,7 @@ pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         if (NULL == tmp) {
             return PMIX_ERROR;
         }
-        (void)strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
+        pmix_strncpy(ptr[i].nspace, tmp, PMIX_MAX_NSLEN);
         free(tmp);
         /* unpack the rank */
         m=1;

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -208,7 +208,7 @@ __pmix_attribute_extension__ ({                             \
     memcpy(addr, &sz, sizeof(size_t));                      \
     memset(addr + sizeof(size_t), 0,                        \
         ESH_KNAME_LEN_V20(key));                            \
-    strncpy((char *)addr + sizeof(size_t),                  \
+    pmix_strncpy((char *)addr + sizeof(size_t),                  \
             key, ESH_KNAME_LEN_V20(key));                   \
     memcpy(addr + sizeof(size_t) + ESH_KNAME_LEN_V20(key),  \
             buffer, size);                                  \
@@ -273,7 +273,7 @@ __pmix_attribute_extension__ ({                             \
 __pmix_attribute_extension__ ({                             \
     size_t sz = size;                                       \
     memset(addr, 0, ESH_KNAME_LEN_V12(key));                \
-    strncpy((char *)addr, key, ESH_KNAME_LEN_V12(key));     \
+    pmix_strncpy((char *)addr, key, ESH_KNAME_LEN_V12(key));     \
     memcpy(addr + ESH_KNAME_LEN_V12(key), &sz,              \
         sizeof(size_t));                                    \
     memcpy(addr + ESH_KNAME_LEN_V12(key) + sizeof(size_t),  \
@@ -614,7 +614,7 @@ static inline ns_map_data_t * _esh_session_map(pmix_common_dstore_ctx_t *ds_ctx,
     for(map_idx = 0; map_idx < size; map_idx++) {
         if (!ns_map[map_idx].in_use) {
             ns_map[map_idx].in_use = true;
-            strncpy(ns_map[map_idx].data.name, nspace, sizeof(ns_map[map_idx].data.name)-1);
+            pmix_strncpy(ns_map[map_idx].data.name, nspace, sizeof(ns_map[map_idx].data.name)-1);
             ns_map[map_idx].data.tbl_idx = tbl_idx;
             return  &ns_map[map_idx].data;
         }
@@ -628,7 +628,7 @@ static inline ns_map_data_t * _esh_session_map(pmix_common_dstore_ctx_t *ds_ctx,
     _esh_session_map_clean(ds_ctx, new_map);
     new_map->in_use = true;
     new_map->data.tbl_idx = tbl_idx;
-    strncpy(new_map->data.name, nspace, sizeof(new_map->data.name)-1);
+    pmix_strncpy(new_map->data.name, nspace, sizeof(new_map->data.name)-1);
 
     return  &new_map->data;
 }
@@ -960,7 +960,7 @@ static int _put_ns_info_to_initial_segment(pmix_common_dstore_ctx_t *ds_ctx,
                0, ds_ctx->initial_segment_size);
     }
     memset(&elem.ns_map, 0, sizeof(elem.ns_map));
-    strncpy(elem.ns_map.name, ns_map->name, sizeof(elem.ns_map.name)-1);
+    pmix_strncpy(elem.ns_map.name, ns_map->name, sizeof(elem.ns_map.name)-1);
     elem.ns_map.tbl_idx = ns_map->tbl_idx;
     elem.num_meta_seg = 1;
     elem.num_data_seg = 1;
@@ -1055,7 +1055,7 @@ static ns_track_elem_t *_get_track_elem_for_namespace(pmix_common_dstore_ctx_t *
         return NULL;
     }
     PMIX_CONSTRUCT(new_elem, ns_track_elem_t);
-    strncpy(new_elem->ns_map.name, ns_map->name, sizeof(new_elem->ns_map.name)-1);
+    pmix_strncpy(new_elem->ns_map.name, ns_map->name, sizeof(new_elem->ns_map.name)-1);
     /* save latest track idx to info of nspace */
     ns_map->track_idx = size;
 
@@ -1461,7 +1461,7 @@ static int pmix_sm_store(pmix_common_dstore_ctx_t *ds_ctx, ns_track_elem_t *ns_i
                 if (ESH_DATA_SIZE(_client_peer(ds_ctx), addr, ESH_DATA_PTR(_client_peer(ds_ctx), addr)) != size) {
                 //if (1) { /* if we want to test replacing values for existing keys. */
                     /* invalidate current value and store another one at the end of data region. */
-                    strncpy(ESH_KNAME_PTR(_client_peer(ds_ctx), addr), ESH_REGION_INVALIDATED,
+                    pmix_strncpy(ESH_KNAME_PTR(_client_peer(ds_ctx), addr), ESH_REGION_INVALIDATED,
                             ESH_KNAME_LEN(_client_peer(ds_ctx), ESH_REGION_INVALIDATED));
                     /* decrementing count, it will be incremented back when we add a new value for this key at the end of region. */
                     (*rinfo)->count--;
@@ -1955,7 +1955,7 @@ static pmix_status_t _dstore_store_nolock(pmix_common_dstore_ctx_t *ds_ctx,
      * data segments and update corresponding element's fields. */
     if (NULL == elem->meta_seg || NULL == elem->data_seg) {
         memset(&ns_info.ns_map, 0, sizeof(ns_info.ns_map));
-        strncpy(ns_info.ns_map.name, ns_map->name, sizeof(ns_info.ns_map.name)-1);
+        pmix_strncpy(ns_info.ns_map.name, ns_map->name, sizeof(ns_info.ns_map.name)-1);
         ns_info.ns_map.tbl_idx = ns_map->tbl_idx;
         ns_info.num_meta_seg = 1;
         ns_info.num_data_seg = 1;
@@ -2288,7 +2288,7 @@ static pmix_status_t _dstore_fetch(pmix_common_dstore_ctx_t *ds_ctx,
                     PMIX_ERROR_LOG(rc);
                     goto done;
                 }
-                strncpy(info[kval_cnt - 1].key, ESH_KNAME_PTR(_client_peer(ds_ctx), addr),
+                pmix_strncpy(info[kval_cnt - 1].key, ESH_KNAME_PTR(_client_peer(ds_ctx), addr),
                         ESH_KNAME_LEN(_client_peer(ds_ctx), (char *)addr));
                 pmix_value_xfer(&info[kval_cnt - 1].value, &val);
                 PMIX_VALUE_DESTRUCT(&val);
@@ -2815,7 +2815,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_register_job_info(pmix_common_dstore
         ns_map_data_t *ns_map;
 
         _client_compat_save(ds_ctx, peer);
-        (void)strncpy(proc.nspace, ns->nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, ns->nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, proc.nspace))) {
             rc = PMIX_ERROR;

--- a/src/mca/pif/bsdx_ipv4/pif_bsdx.c
+++ b/src/mca/pif/bsdx_ipv4/pif_bsdx.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -173,7 +174,7 @@ static int if_bsdx_open(void)
         /* fill values into the pmix_pif_t */
         memcpy(&a4, &(sin_addr->sin_addr), sizeof(struct in_addr));
 
-        strncpy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE);
+        pmix_strncpy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE-1);
         intf->if_index = pmix_list_get_size(&pmix_if_list) + 1;
         ((struct sockaddr_in*) &intf->if_addr)->sin_addr = a4;
         ((struct sockaddr_in*) &intf->if_addr)->sin_family = AF_INET;

--- a/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
+++ b/src/mca/pif/bsdx_ipv6/pif_bsdx_ipv6.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -198,7 +199,7 @@ static int if_bsdx_ipv6_open(void)
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
         intf->af_family = AF_INET6;
-        strncpy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE);
+        pmix_strncpy(intf->if_name, cur_ifaddrs->ifa_name, IF_NAMESIZE-1);
         intf->if_index = pmix_list_get_size(&pmix_if_list) + 1;
         ((struct sockaddr_in6*) &intf->if_addr)->sin6_addr = a6;
         ((struct sockaddr_in6*) &intf->if_addr)->sin6_family = AF_INET6;

--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2018      Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -142,7 +143,7 @@ static int if_linux_ipv6_open(void)
             }
 
             /* now construct the pmix_pif_t */
-            strncpy(intf->if_name, ifname, IF_NAMESIZE);
+            pmix_strncpy(intf->if_name, ifname, IF_NAMESIZE-1);
             intf->if_index = pmix_list_get_size(&pmix_if_list)+1;
             intf->if_kernel_index = (uint16_t) idx;
             ((struct sockaddr_in6*) &intf->if_addr)->sin6_addr = a6;

--- a/src/mca/pif/posix_ipv4/pif_posix.c
+++ b/src/mca/pif/posix_ipv4/pif_posix.c
@@ -265,7 +265,7 @@ static int if_posix_open(void)
 
         /* copy entry over into our data structure */
         memset(intf->if_name, 0, sizeof(intf->if_name));
-        strncpy(intf->if_name, ifr->ifr_name, sizeof(intf->if_name) - 1);
+        pmix_strncpy(intf->if_name, ifr->ifr_name, sizeof(intf->if_name) - 1);
         intf->if_flags = ifr->ifr_flags;
 
         /* every new address gets its own internal if_index */

--- a/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
+++ b/src/mca/pif/solaris_ipv6/pif_solaris_ipv6.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -146,8 +146,8 @@ static int if_solaris_ipv6_open(void)
          i += sizeof (*lifreq)) {
 
         lifreq = (struct lifreq *)((caddr_t)lifconf.lifc_buf + i);
-        strncpy (lifquery.lifr_name, lifreq->lifr_name,
-                 sizeof (lifquery.lifr_name));
+        pmix_strncpy (lifquery.lifr_name, lifreq->lifr_name,
+                 sizeof (lifquery.lifr_name)-1);
 
         /* lookup kernel index */
         error = ioctl (sd, SIOCGLIFINDEX, &lifquery);
@@ -190,7 +190,7 @@ static int if_solaris_ipv6_open(void)
                 }
                 intf->af_family = AF_INET6;
 
-                strncpy (intf->if_name, lifreq->lifr_name, IF_NAMESIZE);
+                pmix_strncpy (intf->if_name, lifreq->lifr_name, IF_NAMESIZE-1);
                 intf->if_index = pmix_list_get_size(&pmix_if_list)+1;
                 memcpy(&intf->if_addr, my_addr, sizeof (*my_addr));
                 intf->if_mask = 64;

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -742,7 +742,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                         "recvd KEY %s %s", kv->key,
                                         (PMIX_STRING == kv->value->type) ? kv->value->data.string : "NON-STRING");
                     /* xfer the value to the info */
-                    (void)strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
+                    pmix_strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
                     PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
                                            &jinfo[m].value, kv->value);
                     /* if this is the ID key, save it */
@@ -770,7 +770,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                 }
                 /* the data gets stored as a pmix_data_array_t on the provided key */
                 PMIX_INFO_CONSTRUCT(&stinfo);
-                (void)strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
+                pmix_strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
                 stinfo.value.type = PMIX_DATA_ARRAY;
                 PMIX_DATA_ARRAY_CREATE(stinfo.value.data.darray, nkvals, PMIX_INFO);
                 stinfo.value.data.darray->array = jinfo;

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -358,7 +358,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                        "recvd KEY %s %s", kv->key,
                                        (PMIX_STRING == kv->value->type) ? kv->value->data.string : "NON-STRING");
                        /* xfer the value to the info */
-                   (void)strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
+                   pmix_strncpy(jinfo[m].key, kv->key, PMIX_MAX_KEYLEN);
                    PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
                                           &jinfo[m].value, kv->value);
                        /* if this is the ID key, save it */
@@ -386,7 +386,7 @@ static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                }
                    /* the data gets stored as a pmix_data_array_t on the provided key */
                PMIX_INFO_CONSTRUCT(&stinfo);
-               (void)strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
+               pmix_strncpy(stinfo.key, idkey, PMIX_MAX_KEYLEN);
                stinfo.value.type = PMIX_DATA_ARRAY;
                PMIX_DATA_ARRAY_CREATE(stinfo.value.data.darray, nkvals, PMIX_INFO);
                stinfo.value.data.darray->array = jinfo;

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -522,7 +522,7 @@ static pmix_status_t resolve_peers(const char *nodename,
     /* scope is irrelevant as the info we seek must be local */
     cb.scope = PMIX_SCOPE_UNDEF;
     /* let the proc point to the nspace */
-    (void)strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
     cb.proc = &proc;
 
@@ -565,7 +565,7 @@ static pmix_status_t resolve_peers(const char *nodename,
                 goto complete;
             }
             for (j=0; j < np; j++) {
-                (void)strncpy(p[j].nspace, nspace, PMIX_MAX_NSLEN);
+                pmix_strncpy(p[j].nspace, nspace, PMIX_MAX_NSLEN);
                 p[j].rank = strtoul(ptr[j], NULL, 10);
             }
             rc = PMIX_SUCCESS;
@@ -619,7 +619,7 @@ static pmix_status_t resolve_nodes(const char *nspace,
     /* scope is irrelevant as the info we seek must be local */
     cb.scope = PMIX_SCOPE_UNDEF;
     /* put the nspace in the proc field */
-    (void)strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
     /* the info will be associated with PMIX_RANK_WILDCARD */
     proc.rank = PMIX_RANK_WILDCARD;
     cb.proc = &proc;

--- a/src/mca/psensor/file/psensor_file.c
+++ b/src/mca/psensor/file/psensor_file.c
@@ -345,7 +345,7 @@ static void file_sample(int sd, short args, void *cbdata)
         /* stop monitoring this client */
         pmix_list_remove_item(&mca_psensor_file_component.trackers, &ft->super);
         /* generate an event */
-        (void)strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         source.rank = ft->requestor->info->pname.rank;
         rc = PMIx_Notify_event(PMIX_MONITOR_FILE_ALERT, &source,
                                ft->range, ft->info, ft->ninfo, opcbfunc, ft);

--- a/src/mca/psensor/heartbeat/psensor_heartbeat.c
+++ b/src/mca/psensor/heartbeat/psensor_heartbeat.c
@@ -297,7 +297,7 @@ static void check_heartbeat(int fd, short dummy, void *cbdata)
                              pmix_globals.myid.nspace, pmix_globals.myid.rank,
                              ft->requestor->info->pname.nspace, ft->requestor->info->pname.rank));
         /* generate an event */
-        (void)strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(source.nspace, ft->requestor->info->pname.nspace, PMIX_MAX_NSLEN);
         source.rank = ft->requestor->info->pname.rank;
         /* ensure the tracker remains throughout the process */
         PMIX_RETAIN(ft);

--- a/src/mca/pshmem/mmap/pshmem_mmap.c
+++ b/src/mca/pshmem/mmap/pshmem_mmap.c
@@ -3,7 +3,7 @@
  *                         All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2017      Intel, Inc. All rights reserved.
+ * Copyright (c) 2017-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -121,7 +121,7 @@ static int _mmap_segment_create(pmix_pshmem_seg_t *sm_seg, const char *file_name
     sm_seg->seg_cpid = my_pid;
     sm_seg->seg_size = size;
     sm_seg->seg_base_addr = (unsigned char *)seg_addr;
-    (void)strncpy(sm_seg->seg_name, file_name, PMIX_PATH_MAX - 1);
+    pmix_strncpy(sm_seg->seg_name, file_name, PMIX_PATH_MAX);
 
 out:
     if (-1 != sm_seg->seg_id) {

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -1122,7 +1122,7 @@ static pmix_status_t recv_connect_ack(int sd)
                 return PMIX_ERR_INIT;
             }
         } else {
-            (void)strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
+            pmix_strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
         }
         /* if we already have a rank, then leave it alone */
         if (PMIX_RANK_INVALID == pmix_globals.myid.rank) {

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1487,7 +1487,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
       /* let the host server know that this client has connected */
       if (NULL != pmix_host_server.client_connected) {
-          (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+          pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
           proc.rank = peer->info->pname.rank;
           rc = pmix_host_server.client_connected(&proc, peer->info->server_object,
                                                  NULL, NULL);
@@ -1762,7 +1762,7 @@ static void cnct_cbfunc(pmix_status_t status,
         return;
     }
     cd->status = status;
-    (void)strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
     cd->cbdata = cbdata;
     PMIX_THREADSHIFT(cd, process_cbfunc);
 }

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -718,7 +718,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* let the host server know that this client has connected */
     if (NULL != pmix_host_server.client_connected) {
-        (void)strncpy(proc.nspace, psave->info->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, psave->info->pname.nspace, PMIX_MAX_NSLEN);
         proc.rank = psave->info->pname.rank;
         rc = pmix_host_server.client_connected(&proc, psave->info->server_object, NULL, NULL);
         if (PMIX_SUCCESS != rc) {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -309,7 +309,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
             if (0 == strncmp(info[n].key, PMIX_SERVER_NSPACE, PMIX_MAX_KEYLEN)) {
-                (void)strncpy(pmix_globals.myid.nspace, info[n].value.data.string, PMIX_MAX_NSLEN);
+                pmix_strncpy(pmix_globals.myid.nspace, info[n].value.data.string, PMIX_MAX_NSLEN);
                 nspace_given = true;
             } else if (0 == strncmp(info[n].key, PMIX_SERVER_RANK, PMIX_MAX_KEYLEN)) {
                 pmix_globals.myid.rank = info[n].value.data.rank;
@@ -353,9 +353,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         /* look for our namespace, if one was given */
         if (NULL == (evar = getenv("PMIX_SERVER_NAMESPACE"))) {
             /* use a fake namespace */
-            (void)strncpy(pmix_globals.myid.nspace, "pmix-server", PMIX_MAX_NSLEN);
+            pmix_strncpy(pmix_globals.myid.nspace, "pmix-server", PMIX_MAX_NSLEN);
         } else {
-            (void)strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
+            pmix_strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
         }
     }
     if (!rank_given) {
@@ -635,7 +635,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int n
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
-    (void)strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
     cd->nlocalprocs = nlocalprocs;
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
@@ -706,7 +706,7 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[],
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
      cd = PMIX_NEW(pmix_setup_caddy_t);
-    (void)strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
 
@@ -796,7 +796,7 @@ void pmix_server_execute_collective(int sd, short args, void *cbdata)
                 }
                 if (trk->hybrid || first) {
                     /* setup the nspace */
-                    (void)strncpy(proc.nspace, cd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
+                    pmix_strncpy(proc.nspace, cd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
                     first = false;
                 }
                 proc.rank = cd->peer->info->pname.rank;
@@ -1012,7 +1012,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_client(const pmix_proc_t *proc,
     if (NULL == cd) {
         return PMIX_ERR_NOMEM;
     }
-    (void)strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
     cd->proc.rank = proc->rank;
     cd->uid = uid;
     cd->gid = gid;
@@ -1126,7 +1126,7 @@ PMIX_EXPORT void PMIx_server_deregister_client(const pmix_proc_t *proc,
         }
         return;
     }
-    (void)strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
     cd->proc.rank = proc->rank;
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
@@ -1364,7 +1364,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
                         proc->nspace, proc->rank);
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
-    (void)strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
     cd->proc.rank = proc->rank;
     cd->cbfunc = cbfunc;
     cd->cbdata = cbdata;
@@ -1382,7 +1382,7 @@ static void _store_internal(int sd, short args, void *cbdata)
 
     PMIX_ACQUIRE_OBJECT(cd);
 
-    (void)strncpy(proc.nspace, cd->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, cd->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = cd->pname.rank;
     PMIX_GDS_STORE_KV(cd->status, pmix_globals.mypeer,
                       &proc, PMIX_INTERNAL, cd->kv);
@@ -1506,7 +1506,7 @@ static void _setup_app(int sd, short args, void *cbdata)
         }
         n = 0;
         PMIX_LIST_FOREACH(kv, &ilist, pmix_kval_t) {
-            (void)strncpy(fcd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
+            pmix_strncpy(fcd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
             pmix_value_xfer(&fcd->info[n].value, kv->value);
             ++n;
         }
@@ -1730,7 +1730,7 @@ pmix_status_t PMIx_server_IOF_deliver(const pmix_proc_t *source,
         PMIX_RELEASE(cd);
         return PMIX_ERR_NOMEM;
     }
-    (void)strncpy(cd->procs[0].nspace, source->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(cd->procs[0].nspace, source->nspace, PMIX_MAX_NSLEN);
     cd->procs[0].rank = source->rank;
     cd->channels = channel;
     PMIX_BYTE_OBJECT_CREATE(cd->bo, 1);
@@ -1813,7 +1813,7 @@ static void clct_complete(pmix_status_t status,
                 /* transfer the results */
                 n=0;
                 PMIX_LIST_FOREACH(kv, &cd->payload, pmix_kval_t) {
-                    (void)strncpy(cd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
+                    pmix_strncpy(cd->info[n].key, kv->key, PMIX_MAX_KEYLEN);
                     rc = pmix_value_xfer(&cd->info[n].value, kv->value);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_INFO_FREE(cd->info, cd->ninfo);
@@ -2089,7 +2089,7 @@ static void _spcb(int sd, short args, void *cbdata)
         /* pass back the name of the nspace */
         PMIX_BFROPS_PACK(rc, cd->cd->peer, reply, &cd->pname.nspace, 1, PMIX_STRING);
         /* add the job-level info, if we have it */
-        (void)strncpy(proc.nspace, cd->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, cd->pname.nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         /* this is going to a local client, so let the gds
          * have the option of returning a copy of the data,
@@ -2507,7 +2507,7 @@ static void _cnct(int sd, short args, void *cbdata)
                  * local storage */
                 /* add the job-level info, if necessary */
                 proc.rank = PMIX_RANK_WILDCARD;
-                (void)strncpy(proc.nspace, nspaces[i], PMIX_MAX_NSLEN);
+                pmix_strncpy(proc.nspace, nspaces[i], PMIX_MAX_NSLEN);
                 PMIX_CONSTRUCT(&cb, pmix_cb_t);
                 /* this is for a local client, so give the gds the
                  * option of returning a complete copy of the data,
@@ -3072,7 +3072,7 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         PMIX_GDS_CADDY(cd, peer, tag);
         /* call the local server, if supported */
         if (NULL != pmix_host_server.client_finalized) {
-            (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+            pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
             proc.rank = peer->info->pname.rank;
             /* now tell the host server */
             if (PMIX_SUCCESS == (rc = pmix_host_server.client_finalized(&proc, peer->info->server_object,

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -148,7 +148,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    (void)strncpy(nspace, cptr, PMIX_MAX_NSLEN);
+    pmix_strncpy(nspace, cptr, PMIX_MAX_NSLEN);
     free(cptr);
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, cd->peer, buf, &rank, &cnt, PMIX_PROC_RANK);
@@ -282,7 +282,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * for it, so there is no guarantee we have it */
         data = NULL;
         sz = 0;
-        (void)strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
         /* if we have local procs for this nspace, then we
          * can retrieve the info from that GDS. Otherwise,
@@ -490,7 +490,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
     if (NULL == lcd){
         return PMIX_ERR_NOMEM;
     }
-    strncpy(lcd->proc.nspace, nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(lcd->proc.nspace, nspace, PMIX_MAX_NSLEN);
     lcd->proc.rank = rank;
     lcd->info = info;
     lcd->ninfo = ninfo;
@@ -584,7 +584,7 @@ static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
      * a remote peer, or due to data from a local client
      * having been committed */
     PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-    (void)strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
 
     /* if we have local clients of this nspace, then we use
      * the corresponding GDS to retrieve the data. Otherwise,
@@ -931,7 +931,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
                     PMIX_DESTRUCT(&cb);
                     goto complete;
                 }
-                (void)strncpy(cb.proc->nspace, nm->ns->nspace, PMIX_MAX_NSLEN);
+                pmix_strncpy(cb.proc->nspace, nm->ns->nspace, PMIX_MAX_NSLEN);
                 cb.proc->rank = PMIX_RANK_WILDCARD;
                 cb.scope = PMIX_INTERNAL;
                 cb.copy = false;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -116,7 +116,7 @@ pmix_status_t pmix_server_abort(pmix_peer_t *peer, pmix_buffer_t *buf,
 
     /* let the local host's server execute it */
     if (NULL != pmix_host_server.abort) {
-        (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
         proc.rank = peer->info->pname.rank;
         rc = pmix_host_server.abort(&proc, peer->info->server_object, status, msg,
                                     procs, nprocs, cbfunc, cbdata);
@@ -156,7 +156,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
     /* shorthand */
     info = peer->info;
     nptr = peer->nptr;
-    (void)strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, nptr->nspace, PMIX_MAX_NSLEN);
     proc.rank = info->pname.rank;
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
@@ -401,7 +401,7 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
 
     all_def = true;
     for (i=0; i < nprocs; i++) {
-        (void)strncpy(trk->pcs[i].nspace, procs[i].nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(trk->pcs[i].nspace, procs[i].nspace, PMIX_MAX_NSLEN);
         trk->pcs[i].rank = procs[i].rank;
         if (!all_def) {
             continue;
@@ -650,7 +650,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
             PMIX_LIST_FOREACH(scd, &trk->local_cbs, pmix_server_caddy_t) {
                 /* get any remote contribution - note that there
                  * may not be a contribution */
-                (void)strncpy(pcs.nspace, scd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
+                pmix_strncpy(pcs.nspace, scd->peer->info->pname.nspace, PMIX_MAX_NSLEN);
                 pcs.rank = scd->peer->info->pname.rank;
                 PMIX_CONSTRUCT(&cb, pmix_cb_t);
                 cb.proc = &pcs;
@@ -792,12 +792,12 @@ pmix_status_t pmix_server_publish(pmix_peer_t *peer,
             goto cleanup;
         }
     }
-    (void)strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo-1].value.type = PMIX_UINT32;
     cd->info[cd->ninfo-1].value.data.uint32 = uid;
 
     /* call the local server */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
     rc = pmix_host_server.publish(&proc, cd->info, cd->ninfo, opcbfunc, cd);
 
@@ -906,12 +906,12 @@ pmix_status_t pmix_server_lookup(pmix_peer_t *peer,
             goto cleanup;
         }
     }
-    (void)strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo-1].value.type = PMIX_UINT32;
     cd->info[cd->ninfo-1].value.data.uint32 = uid;
 
     /* call the local server */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
     rc = pmix_host_server.lookup(&proc, cd->keys, cd->info, cd->ninfo, lkcbfunc, cd);
 
@@ -1002,12 +1002,12 @@ pmix_status_t pmix_server_unpublish(pmix_peer_t *peer,
             goto cleanup;
         }
     }
-    (void)strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
+    pmix_strncpy(cd->info[cd->ninfo-1].key, PMIX_USERID, PMIX_MAX_KEYLEN);
     cd->info[cd->ninfo-1].value.type = PMIX_UINT32;
     cd->info[cd->ninfo-1].value.data.uint32 = uid;
 
     /* call the local server */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
     rc = pmix_host_server.unpublish(&proc, cd->keys, cd->info, cd->ninfo, opcbfunc, cd);
 
@@ -1242,7 +1242,7 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
         }
     }
     /* call the local server */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
     rc = pmix_host_server.spawn(&proc, cd->info, cd->ninfo, cd->apps, cd->napps, spcbfunc, cd);
 
@@ -2128,7 +2128,7 @@ pmix_status_t pmix_server_query(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host for the info */
@@ -2171,7 +2171,7 @@ pmix_status_t pmix_server_log(pmix_peer_t *peer,
      * the request itself */
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     cd = PMIX_NEW(pmix_shift_caddy_t);
@@ -2299,7 +2299,7 @@ pmix_status_t pmix_server_alloc(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
@@ -2603,7 +2603,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
@@ -2695,7 +2695,7 @@ pmix_status_t pmix_server_monitor(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
@@ -2754,7 +2754,7 @@ pmix_status_t pmix_server_get_credential(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
@@ -2819,7 +2819,7 @@ pmix_status_t pmix_server_validate_credential(pmix_peer_t *peer,
     }
 
     /* setup the requesting peer name */
-    (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = peer->info->pname.rank;
 
     /* ask the host to execute the request */
@@ -3111,7 +3111,7 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
     }
 
     /* pass the data to the host */
-    (void)strncpy(source.nspace, peer->nptr->nspace, PMIX_MAX_NSLEN);
+    pmix_strncpy(source.nspace, peer->nptr->nspace, PMIX_MAX_NSLEN);
     source.rank = peer->info->pname.rank;
     if (PMIX_SUCCESS != (rc = pmix_host_server.push_stdin(&source, cd->procs, cd->nprocs,
                                                           cd->info, cd->ninfo, cd->bo,

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -290,7 +290,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
          * rank should be known. So return them here if
          * requested */
         if (NULL != proc) {
-            (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+            pmix_strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
             proc->rank = pmix_globals.myid.rank;
         }
         ++pmix_globals.init_cntr;
@@ -438,7 +438,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
     /* if we were given a name, then set it now */
     if (nspace_given || nspace_in_enviro) {
-        (void)strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
         free(nspace);
         pmix_globals.myid.rank = rank;
     }
@@ -593,7 +593,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
     if (!nspace_given) {
         /* Success, so copy the nspace and rank to the proc struct they gave us */
-        (void)strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(proc->nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
     }
     if (!rank_given) {
         proc->rank = pmix_globals.myid.rank;
@@ -727,7 +727,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
          * datastore with typical job-related info. No point
          * in having the server generate these as we are
          * obviously a singleton, and so the values are well-known */
-        (void)strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
+        pmix_strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
         wildcard.rank = pmix_globals.myid.rank;
 
         /* the jobid is just our nspace */

--- a/src/tools/plookup/plookup.c
+++ b/src/tools/plookup/plookup.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -269,7 +269,7 @@ int main(int argc, char **argv)
     /* setup the keys */
     PMIX_PDATA_CREATE(pdata, ndata);
     for (n=0; n < ndata; n++) {
-        (void)strncpy(pdata[n].key, keys[n], PMIX_MAX_KEYLEN);
+        pmix_strncpy(pdata[n].key, keys[n], PMIX_MAX_KEYLEN);
     }
     /* perform the lookup */
     rc = PMIx_Lookup(pdata, ndata, info, ninfo);

--- a/src/util/argv.c
+++ b/src/util/argv.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007      Voltaire. All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
- * Copyright (c) 2014-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  *
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -221,7 +221,7 @@ static char **pmix_argv_split_inter(const char *src_string, int delimiter,
       if (NULL == argtemp)
         return NULL;
 
-      strncpy(argtemp, src_string, arglen);
+      pmix_strncpy(argtemp, src_string, arglen);
       argtemp[arglen] = '\0';
 
       if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, argtemp)) {
@@ -235,7 +235,7 @@ static char **pmix_argv_split_inter(const char *src_string, int delimiter,
     /* short argument, copy to buffer and add */
 
     else {
-      strncpy(arg, src_string, arglen);
+      pmix_strncpy(arg, src_string, arglen);
       arg[arglen] = '\0';
 
       if (PMIX_SUCCESS != pmix_argv_append(&argc, &argv, arg))

--- a/src/util/basename.c
+++ b/src/util/basename.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2009-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2014      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2014-2015 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -123,11 +123,7 @@ char* pmix_dirname(const char* filename)
             }
             if( p != filename ) {
                 char* ret = (char*)malloc( p - filename + 1 );
-#ifdef HAVE_STRNCPY_S
-                strncpy_s( ret, (p - filename + 1), filename, p - filename );
-#else
-                strncpy(ret, filename, p - filename);
-#endif
+                pmix_strncpy(ret, filename, p - filename);
                 ret[p - filename] = '\0';
                 return pmix_make_filename_os_friendly(ret);
             }

--- a/src/util/hash.c
+++ b/src/util/hash.c
@@ -6,7 +6,7 @@
  *                         reserved.
  * Copyright (c) 2011-2014 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -172,7 +172,7 @@ pmix_status_t pmix_hash_fetch(pmix_hash_table_t *table, pmix_rank_t rank,
             /* copy the list elements */
             n=0;
             PMIX_LIST_FOREACH(hv, &proc_data->data, pmix_kval_t) {
-                (void)strncpy(info[n].key, hv->key, PMIX_MAX_KEYLEN);
+                pmix_strncpy(info[n].key, hv->key, PMIX_MAX_KEYLEN);
                 pmix_value_xfer(&info[n].value, hv->value);
                 ++n;
             }

--- a/src/util/keyval_parse.c
+++ b/src/util/keyval_parse.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015-2016 Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016      Intel, Inc. All rights reserved
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -136,7 +136,7 @@ static int parse_line(void)
         key_buffer = tmp;
     }
 
-    strncpy(key_buffer, pmix_util_keyval_yytext, key_buffer_len);
+    pmix_strncpy(key_buffer, pmix_util_keyval_yytext, key_buffer_len-1);
 
     /* The first thing we have to see is an "=" */
 
@@ -259,7 +259,7 @@ static int save_param_name (void)
         key_buffer = tmp;
     }
 
-    strncpy (key_buffer, pmix_util_keyval_yytext, key_buffer_len);
+    pmix_strncpy (key_buffer, pmix_util_keyval_yytext, key_buffer_len-1);
 
     return PMIX_SUCCESS;
 }

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -694,7 +694,7 @@ static int open_file(int i)
         if (NULL == filename) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
-        strncpy(filename, output_dir, PMIX_PATH_MAX);
+        pmix_strncpy(filename, output_dir, PMIX_PATH_MAX-1);
         strcat(filename, "/");
         if (NULL != output_prefix) {
             strcat(filename, output_prefix);

--- a/src/util/pif.c
+++ b/src/util/pif.c
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -218,7 +218,7 @@ int pmix_ifaddrtoname(const char* if_addr, char* if_name, int length)
                 memcpy (&ipv4, r->ai_addr, r->ai_addrlen);
 
                 if (inaddr->sin_addr.s_addr == ipv4.sin_addr.s_addr) {
-                    strncpy(if_name, intf->if_name, length);
+                    pmix_strncpy(if_name, intf->if_name, length-1);
                     freeaddrinfo (res);
                     return PMIX_SUCCESS;
                 }
@@ -226,7 +226,7 @@ int pmix_ifaddrtoname(const char* if_addr, char* if_name, int length)
             else {
                 if (IN6_ARE_ADDR_EQUAL(&((struct sockaddr_in6*) &intf->if_addr)->sin6_addr,
                     &((struct sockaddr_in6*) r->ai_addr)->sin6_addr)) {
-                    strncpy(if_name, intf->if_name, length);
+                    pmix_strncpy(if_name, intf->if_name, length-1);
                     freeaddrinfo (res);
                     return PMIX_SUCCESS;
                 }
@@ -493,7 +493,7 @@ int pmix_ifindextoname(int if_index, char* if_name, int length)
         intf != (pmix_pif_t*)pmix_list_get_end(&pmix_if_list);
         intf =  (pmix_pif_t*)pmix_list_get_next(intf)) {
         if (intf->if_index == if_index) {
-            strncpy(if_name, intf->if_name, length);
+            pmix_strncpy(if_name, intf->if_name, length-1);
             return PMIX_SUCCESS;
         }
     }
@@ -514,7 +514,7 @@ int pmix_ifkindextoname(int if_kindex, char* if_name, int length)
         intf != (pmix_pif_t*)pmix_list_get_end(&pmix_if_list);
         intf =  (pmix_pif_t*)pmix_list_get_next(intf)) {
         if (intf->if_kernel_index == if_kindex) {
-            strncpy(if_name, intf->if_name, length);
+            pmix_strncpy(if_name, intf->if_name, length-1);
             return PMIX_SUCCESS;
         }
     }


### PR DESCRIPTION
We have been seeing lots and lots of warnings appearing on certain
combinations of compiler and environment due to unused return value from
strncpy and the possibility that the resulting string could fill the
provided array without leaving room for a NULL terminator. In addition,
the security risk from non-NULL-terminated strings being input by the
user has been flagged.

Therefore, transition all uses of "strncpy" to a new "pmix_strncpy"
function that resolves the warnings and closes the security gap.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>