### PR TITLE
Sync to formal PMIx v2 Standard doc

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -129,7 +129,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const pmix_key_t key, pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
@@ -200,7 +200,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
  *     an error. The timeout parameter can help avoid "hangs" due to programming
  *     errors that prevent the target proc from ever exposing its data.
  */
-PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_value_t **val);
 
@@ -208,7 +208,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
  * be executed once the specified data has been _PMIx_Put_
  * by the identified process and retrieved by the local server. The info
  * array is used as described above for the blocking form of this call. */
-PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t key,
                                       const pmix_info_t info[], size_t ninfo,
                                       pmix_value_cbfunc_t cbfunc, void *cbdata);
 
@@ -337,7 +337,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
  */
 PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                                      const pmix_app_t apps[], size_t napps,
-                                     char nspace[]);
+                                     pmix_nspace_t nspace);
 
 
 /* Non-blocking form of the _PMIx_Spawn_ function. The callback
@@ -394,7 +394,7 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t ranges[], size_t 
  * for releasing the array when done with it - the PMIX_PROC_FREE macro is
  * provided for this purpose.
  */
-PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
+PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const pmix_nspace_t nspace,
                                              pmix_proc_t **procs, size_t *nprocs);
 
 
@@ -402,7 +402,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *n
  * that nspace. The returned string will contain a comma-delimited list
  * of nodenames. The caller is responsible for releasing the string
  * when done with it */
-PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist);
+PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **nodelist);
 
 /* Query information about the system in general - can include
  * a list of active nspaces, network topology, etc. Also can be

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -81,8 +81,12 @@ extern "C" {
 /****  PMIX CONSTANTS    ****/
 
 /* define maximum value and key sizes */
-#define PMIX_MAX_NSLEN     255
-#define PMIX_MAX_KEYLEN    511
+#define PMIX_MAX_NSLEN     63
+#define PMIX_MAX_KEYLEN    63
+
+/* define abstract types for namespaces and keys */
+typedef char pmix_nspace_t[PMIX_MAX_NSLEN+1];
+typedef char pmix_key_t[PMIX_MAX_KEYLEN+1];
 
 /* define a type for rank values */
 typedef uint32_t pmix_rank_t;
@@ -140,7 +144,6 @@ typedef uint32_t pmix_rank_t;
                                                                     //        client rendezvous points and contact info
 #define PMIX_SYSTEM_TMPDIR                  "pmix.sys.tmpdir"       // (char*) temp directory for this system, where PMIx
                                                                     //        server will place tool rendezvous points and contact info
-#define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_SERVER_ENABLE_MONITORING       "pmix.srv.monitor"      // (bool) Enable PMIx internal monitoring by server
 #define PMIX_SERVER_NSPACE                  "pmix.srv.nspace"       // (char*) Name of the nspace to use for this server
 #define PMIX_SERVER_RANK                    "pmix.srv.rank"         // (pmix_rank_t) Rank of this server
@@ -274,7 +277,6 @@ typedef uint32_t pmix_rank_t;
 /* topology info */
 #define PMIX_NET_TOPO                       "pmix.ntopo"            // (char*) xml-representation of network topology
 #define PMIX_LOCAL_TOPO                     "pmix.ltopo"            // (char*) xml-representation of local node topology
-#define PMIX_NODE_LIST                      "pmix.nlist"            // (char*) comma-delimited list of nodes running procs for this job
 #define PMIX_TOPOLOGY                       "pmix.topo"             // (hwloc_topology_t) pointer to the PMIx client's internal topology object
 #define PMIX_TOPOLOGY_XML                   "pmix.topo.xml"         // (char*) XML-based description of topology
 #define PMIX_TOPOLOGY_FILE                  "pmix.topo.file"        // (char*) full path to file containing XML topology description
@@ -330,8 +332,6 @@ typedef uint32_t pmix_rank_t;
 
 /* event handler registration and notification info keys */
 #define PMIX_EVENT_HDLR_NAME                "pmix.evname"           // (char*) string name identifying this handler
-#define PMIX_EVENT_JOB_LEVEL                "pmix.evjob"            // (bool) register for job-specific events only
-#define PMIX_EVENT_ENVIRO_LEVEL             "pmix.evenv"            // (bool) register for environment events only
 #define PMIX_EVENT_HDLR_FIRST               "pmix.evfirst"          // (bool) invoke this event handler before any other handlers
 #define PMIX_EVENT_HDLR_LAST                "pmix.evlast"           // (bool) invoke this event handler after all other handlers have been called
 #define PMIX_EVENT_HDLR_FIRST_IN_CATEGORY   "pmix.evfirstcat"       // (bool) invoke this event handler before any other handlers in this category
@@ -406,19 +406,6 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_FWD_STDERR                     "pmix.fwd.stderr"       // (bool) forward stderr from the spawned processes to this process (typically used by a tool)
 #define PMIX_FWD_STDDIAG                    "pmix.fwd.stddiag"      // (bool) if a diagnostic channel exists, forward any output on it
                                                                     //        from the spawned processes to this process (typically used by a tool)
-
-
-/* connect attributes */
-#define PMIX_CONNECT_NOTIFY_EACH            "pmix.cnct.each"        // (bool) notify the other participants of the connection by event
-                                                                    //        each time a process connects
-#define PMIX_CONNECT_NOTIFY_REQ             "pmix.cnct.req"         // (bool) notify all other participants that they are requested to
-                                                                    //        connect
-#define PMIX_CONNECT_OPTIONAL               "pmix.cnt.opt"          // (bool) participation is optional - do not return error if procs
-                                                                    //        terminate without having connected
-#define PMIX_CONNECT_XCHG_ONLY              "pmix.cnt.xchg"         // (bool) provide participants with job-level info for all participating
-                                                                    //        nspaces, but do not assign a new nspace or rank
-#define PMIX_CONNECT_ID                     "pmix.cnt.id"           // (char*) an application-provided string identifier for a PMIx_Connect operation.
-
 
 /* query attributes */
 #define PMIX_QUERY_NAMESPACES               "pmix.qry.ns"           // (char*) request a comma-delimited list of active nspaces
@@ -763,10 +750,11 @@ typedef int pmix_status_t;
 #define PMIX_MONITOR_HEARTBEAT_ALERT            (PMIX_ERR_V2X_BASE -  9)
 #define PMIX_MONITOR_FILE_ALERT                 (PMIX_ERR_V2X_BASE - 10)
 #define PMIX_PROC_TERMINATED                    (PMIX_ERR_V2X_BASE - 11)
+#define PMIX_ERR_INVALID_TERMINATION            (PMIX_ERR_V2X_BASE - 12)
 
 /* define a starting point for operational error constants so
  * we avoid renumbering when making additions */
-#define PMIX_ERR_OP_BASE    PMIX_ERR_V2X_BASE-30
+#define PMIX_ERR_OP_BASE    PMIX_ERR_V2X_BASE-100
 
 /* operational */
 #define PMIX_ERR_EVENT_REGISTRATION             (PMIX_ERR_OP_BASE - 14)
@@ -783,21 +771,25 @@ typedef int pmix_status_t;
 #define PMIX_LAUNCHER_READY                     (PMIX_ERR_OP_BASE - 25)
 #define PMIX_OPERATION_IN_PROGRESS              (PMIX_ERR_OP_BASE - 26)
 #define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
-/* gap for group codes */
+#define PMIX_ERR_INVALID_OPERATION              (PMIX_ERR_OP_BASE - 28)
 
 
 /* define a starting point for system error constants so
  * we avoid renumbering when making additions */
-#define PMIX_ERR_SYS_BASE    PMIX_ERR_OP_BASE-100
+#define PMIX_ERR_SYS_BASE    PMIX_ERR_OP_BASE-200
 
 /* system failures */
-#define PMIX_ERR_NODE_DOWN                      (PMIX_ERR_SYS_BASE -  1)
-#define PMIX_ERR_NODE_OFFLINE                   (PMIX_ERR_SYS_BASE -  2)
+#define PMIX_ERR_NODE_DOWN                      (PMIX_ERR_SYS_BASE -   0)
+#define PMIX_ERR_NODE_OFFLINE                   (PMIX_ERR_SYS_BASE -   1)
+#define PMIX_ERR_SYS_OTHER                      (PMIX_ERR_EVHDLR_BASE + 1)
 
+/* define a macro for identifying system event values */
+#define PMIX_SYSTEM_EVENT(a)   \
+    (PMIX_ERR_SYS_BASE >= (a) && PMIX_ERR_EVHDLR_BASE < (a))
 
 /* define a starting point for event handler error constants so
  * we avoid renumbering when making additions */
-#define PMIX_ERR_EVHDLR_BASE    PMIX_ERR_SYS_BASE-100
+#define PMIX_ERR_EVHDLR_BASE    PMIX_ERR_SYS_BASE-500
 
 /* used by event handlers */
 #define PMIX_EVENT_NO_ACTION_TAKEN              (PMIX_ERR_EVHDLR_BASE -  1)
@@ -808,14 +800,14 @@ typedef int pmix_status_t;
 
 /* define a starting point for PMIx internal error codes
  * that are never exposed outside the library */
-#define PMIX_INTERNAL_ERR_BASE          -1000
+#define PMIX_INTERNAL_ERR_BASE          PMIX_ERR_EVHDLR_BASE-1000
 
 /* define a starting point for user-level defined error
  * constants - negative values larger than this are guaranteed
  * not to conflict with PMIx values. Definitions should always
  * be based on the PMIX_EXTERNAL_ERR_BASE constant and -not- a
  * specific value as the value of the constant may change */
-#define PMIX_EXTERNAL_ERR_BASE           -2000
+#define PMIX_EXTERNAL_ERR_BASE           PMIX_INTERNAL_ERR_BASE-2000
 
 /****    PMIX DATA TYPES    ****/
 typedef uint16_t pmix_data_type_t;
@@ -957,9 +949,23 @@ typedef uint16_t pmix_iof_channel_t;
 #define PMIX_CHECK_KEY(a, b) \
     (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
 
+/* define a convenience macro for loading nspaces */
+#define PMIX_LOAD_NSPACE(a, b)                      \
+    do {                                            \
+        memset((a), 0, PMIX_MAX_NSLEN+1);           \
+        (void)strncpy((a), (b), PMIX_MAX_NSLEN);    \
+    }while(0)
+
 /* define a convenience macro for checking nspaces */
 #define PMIX_CHECK_NSPACE(a, b) \
     (0 == strncmp((a), (b), PMIX_MAX_NSLEN))
+
+/* define a convenience macro for loading names */
+#define PMIX_LOAD_PROCID(a, b, c)               \
+    do {                                        \
+        PMIX_LOAD_NSPACE((a)->nspace, (b));     \
+        (a)->rank = (c);                        \
+    }while(0)
 
 /* define a convenience macro for checking names */
 #define PMIX_CHECK_PROCID(a, b) \
@@ -1130,7 +1136,7 @@ typedef struct pmix_data_buffer {
 
 /****    PMIX PROC OBJECT    ****/
 typedef struct pmix_proc {
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t nspace;
     pmix_rank_t rank;
 } pmix_proc_t;
 #define PMIX_PROC_CREATE(m, n)                                  \
@@ -1158,13 +1164,6 @@ typedef struct pmix_proc {
             (m) = NULL;                         \
         }                                       \
     } while (0)
-
-#define PMIX_PROC_LOAD(m, n, r)                             \
-    do {                                                    \
-        PMIX_PROC_CONSTRUCT((m));                           \
-        (void)strncpy((m)->nspace, (n), PMIX_MAX_NSLEN);    \
-        (m)->rank = (r);                                    \
-    } while(0)
 
 #define PMIX_MULTICLUSTER_NSPACE_CONSTRUCT(t, c, n)                         \
     do {                                                                    \
@@ -1429,7 +1428,7 @@ pmix_status_t pmix_setenv(const char *name, const char *value,
 
 /****    PMIX INFO STRUCT    ****/
 struct pmix_info_t {
-    char key[PMIX_MAX_KEYLEN+1];    // ensure room for the NULL terminator
+    pmix_key_t key;
     pmix_info_directives_t flags;   // bit-mask of flags
     pmix_value_t value;
 };
@@ -1526,7 +1525,7 @@ struct pmix_info_t {
 /****    PMIX LOOKUP RETURN STRUCT    ****/
 typedef struct pmix_pdata {
     pmix_proc_t proc;
-    char key[PMIX_MAX_KEYLEN+1];  // ensure room for the NULL terminator
+    pmix_key_t key;
     pmix_value_t value;
 } pmix_pdata_t;
 
@@ -1794,7 +1793,7 @@ typedef void (*pmix_modex_cbfunc_t)(pmix_status_t status,
  * released by the library upon return from the callback function, so
  * the receiver must copy it if it needs to be retained */
 typedef void (*pmix_spawn_cbfunc_t)(pmix_status_t status,
-                                    char nspace[], void *cbdata);
+                                    pmix_nspace_t nspace, void *cbdata);
 
 /* define a callback for common operations that simply return
  * a status. Examples include the non-blocking versions of
@@ -2114,7 +2113,7 @@ PMIX_EXPORT const char* PMIx_Get_version(void);
  * proc. This is data that has only internal scope - it will
  * never be "pushed" externally */
 PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                              const char *key, pmix_value_t *val);
+                                              const pmix_key_t key, pmix_value_t *val);
 
 /**
  * Top-level interface function to pack one or more values into a

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -596,7 +596,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
  * for the PMIx server library to correctly handle collectives
  * as a collective operation call can occur before all the
  * procs have been started */
-PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
+PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace, int nlocalprocs,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 
@@ -605,7 +605,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int n
  * intended to support persistent PMIx servers by providing
  * an opportunity for the host RM to tell the PMIx server
  * library to release all memory for a completed job */
-PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[],
+PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace,
                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Register a client process with the PMIx server library. The
@@ -676,7 +676,7 @@ typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
  * operation in case network libraries need to perform some action
  * before responding. Any returned env will be distributed along
  * with the application */
-PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const pmix_nspace_t nspace,
                                                         pmix_info_t info[], size_t ninfo,
                                                         pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
 
@@ -692,7 +692,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
  * for the first local client - i.e., they will only be executed
  * once for a given nspace
  */
-PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace,
                                                           pmix_info_t info[], size_t ninfo,
                                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -483,7 +483,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;
     }
-    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_client_globals.myserver->nptr) {
         PMIX_RELEASE(pmix_client_globals.myserver);
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -511,7 +511,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         (void)strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
     }
     (void)strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
-    /* set the global pmix_nspace_t object for our peer */
+    /* set the global pmix_namespace_t object for our peer */
     pmix_globals.mypeer->nptr->nspace = strdup(evar);
 
     /* we also require our rank */

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -110,7 +110,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
             PMIX_RELEASE(value);
             return NULL;
         }
-        peer->nptr = PMIX_NEW(pmix_nspace_t);
+        peer->nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == peer->nptr) {
             PMIX_RELEASE(peer);
             PMIX_RELEASE(value);
@@ -157,7 +157,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
         PMIX_RELEASE(value);
         return NULL;
     }
-    peer->nptr = PMIX_NEW(pmix_nspace_t);
+    peer->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == peer->nptr) {
         PMIX_RELEASE(peer);
         PMIX_RELEASE(value);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -493,8 +493,6 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 }
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
                 name = cd->info[n].value.data.string;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_ENVIRO_LEVEL, PMIX_MAX_KEYLEN)) {
-                cd->enviro = PMIX_INFO_TRUE(&cd->info[n]);
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
                 cbobject = cd->info[n].value.data.ptr;
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_FIRST_IN_CATEGORY, PMIX_MAX_KEYLEN)) {
@@ -527,6 +525,14 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 ixfer->info = &cd->info[n];
                 pmix_list_append(&xfer, &ixfer->super);
             }
+        }
+    }
+
+    /* check the codes for system events */
+    for (n=0; n < cd->ncodes; n++) {
+        if (PMIX_SYSTEM_EVENT(cd->codes[n])) {
+            cd->enviro = true;
+            break;
         }
     }
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -96,7 +96,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_cleanup_dir_t,
                                 pmix_list_item_t,
                                 cdcon, cddes);
 
-static void nscon(pmix_nspace_t *p)
+static void nscon(pmix_namespace_t *p)
 {
     p->nspace = NULL;
     p->nprocs = 0;
@@ -113,7 +113,7 @@ static void nscon(pmix_nspace_t *p)
     PMIX_CONSTRUCT(&p->epilog.ignores, pmix_list_t);
     PMIX_CONSTRUCT(&p->setup_data, pmix_list_t);
 }
-static void nsdes(pmix_nspace_t *p)
+static void nsdes(pmix_namespace_t *p)
 {
     if (NULL != p->nspace) {
         free(p->nspace);
@@ -130,7 +130,7 @@ static void nsdes(pmix_nspace_t *p)
     PMIX_LIST_DESTRUCT(&p->epilog.ignores);
     PMIX_LIST_DESTRUCT(&p->setup_data);
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_nspace_t,
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namespace_t,
                                 pmix_list_item_t,
                                 nscon, nsdes);
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -178,14 +178,14 @@ typedef struct {
                                 // from this nspace
     pmix_list_t setup_data;     // list of pmix_kval_t containing info structs having blobs
                                 // for setting up the local node for this nspace/application
-} pmix_nspace_t;
-PMIX_CLASS_DECLARATION(pmix_nspace_t);
+} pmix_namespace_t;
+PMIX_CLASS_DECLARATION(pmix_namespace_t);
 
-/* define a caddy for quickly creating a list of pmix_nspace_t
+/* define a caddy for quickly creating a list of pmix_namespace_t
  * objects for local, dedicated purposes */
 typedef struct {
     pmix_list_item_t super;
-    pmix_nspace_t *ns;
+    pmix_namespace_t *ns;
 } pmix_nspace_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_nspace_caddy_t);
 
@@ -219,7 +219,7 @@ PMIX_CLASS_DECLARATION(pmix_info_caddy_t);
  * by the socket, not the process nspace/rank */
 typedef struct pmix_peer_t {
     pmix_object_t super;
-    pmix_nspace_t *nptr;            // point to the nspace object for this process
+    pmix_namespace_t *nptr;            // point to the nspace object for this process
     pmix_rank_info_t *info;
     pmix_proc_type_t proc_type;
     pmix_listener_protocol_t protocol;

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -391,7 +391,7 @@ static void dstore_finalize(void);
 
 static pmix_status_t dstore_setup_fork(const pmix_proc_t *peer, char ***env);
 
-static pmix_status_t dstore_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t dstore_cache_job_info(struct pmix_namespace_t *ns,
                                 pmix_info_t info[], size_t ninfo);
 
 static pmix_status_t dstore_register_job_info(struct pmix_peer_t *pr,
@@ -427,7 +427,7 @@ static pmix_status_t dstore_del_nspace(const char* nspace);
 static pmix_status_t dstore_assign_module(pmix_info_t *info, size_t ninfo,
                                 int *priority);
 
-static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t dstore_store_modex(struct pmix_namespace_t *nspace,
                                 pmix_list_t *cbs,
                                 pmix_byte_object_t *bo);
 
@@ -2072,7 +2072,7 @@ static inline ssize_t _get_univ_size(const char *nspace)
     return nprocs;
 }
 
-static pmix_status_t dstore_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t dstore_cache_job_info(struct pmix_namespace_t *ns,
                                 pmix_info_t info[], size_t ninfo)
 {
     return PMIX_SUCCESS;
@@ -2998,11 +2998,11 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank)
  * host has received data from some other peer. It therefore
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
-static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t dstore_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo)
 {
-    pmix_nspace_t *ns = (pmix_nspace_t*)nspace;
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
     pmix_buffer_t pbkt;
@@ -3166,7 +3166,7 @@ static pmix_status_t dstore_register_job_info(struct pmix_peer_t *pr,
                                             pmix_buffer_t *reply)
 {
     pmix_peer_t *peer = (pmix_peer_t*)pr;
-    pmix_nspace_t *ns = peer->nptr;
+    pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
     pmix_proc_t proc;
@@ -3227,11 +3227,11 @@ static pmix_status_t dstore_store_job_info(const char *nspace,  pmix_buffer_t *b
 
 static void _client_compat_save(pmix_peer_t *peer)
 {
-    pmix_nspace_t *nptr = NULL;
+    pmix_namespace_t *nptr = NULL;
 
     if (NULL == _clients_peer) {
         _clients_peer = PMIX_NEW(pmix_peer_t);
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         _clients_peer->nptr = nptr;
     }
     _clients_peer->nptr->compat = peer->nptr->compat;

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +44,7 @@
 BEGIN_C_DECLS
 /* forward declaration */
 struct pmix_peer_t;
-struct pmix_nspace_t;
+struct pmix_namespace_t;
 
 /* backdoor to base verbosity */
 PMIX_EXPORT extern int pmix_gds_base_output;
@@ -117,7 +117,7 @@ typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t
  * only we don't have packed data on the server side, and don't want
  * to incur the overhead of packing it just to unpack it in the function.
  */
-typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_nspace_t *ns,
+typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_namespace_t *ns,
                                                                   pmix_info_t info[], size_t ninfo);
 
 /* define a convenience macro for caching job info */
@@ -127,7 +127,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS CACHE JOB INFO WITH %s",           \
                             __FILE__, __LINE__, _g->name);                  \
-       (s) = _g->cache_job_info((struct pmix_nspace_t*)(n), (i), (ni));     \
+       (s) = _g->cache_job_info((struct pmix_namespace_t*)(n), (i), (ni));     \
     } while(0)
 
 /* register job-level info - this is provided as a special function
@@ -135,7 +135,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
  * prepare the job-level info provided at PMIx_Register_nspace, because
  * we don't know the GDS component to use for that application until
  * a local client contacts us. Thus, the module is required to process
- * the job-level info cached in the pmix_nspace_t for this job and
+ * the job-level info cached in the pmix_namespace_t for this job and
  * do whatever is necessary to support the client, packing any required
  * return message into the provided buffer.
  *
@@ -155,7 +155,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
  *
  * The pmix_peer_t of the requesting client is provided here so that
  * the module can access the job-level info cached on the corresponding
- * pmix_nspace_t pointed to by the pmix_peer_t
+ * pmix_namespace_t pointed to by the pmix_peer_t
  */
 typedef pmix_status_t (*pmix_gds_base_module_register_job_info_fn_t)(struct pmix_peer_t *pr,
                                                                      pmix_buffer_t *reply);
@@ -241,7 +241,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  * bo - pointer to the byte object containing the data
  *
  */
-typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspace_t *ns,
+typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_namespace_t *ns,
                                                                pmix_list_t *cbs,
                                                                pmix_byte_object_t *bo);
 
@@ -250,7 +250,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspac
  *
  * r - return status code
  *
- * n - pointer to the pmix_nspace_t this blob is to be stored for
+ * n - pointer to the pmix_namespace_t this blob is to be stored for
  *
  * l - pointer to pmix_list_t containing pmix_server_caddy_t objects
  *     of the local_cbs of the collective tracker
@@ -262,7 +262,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspac
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS STORE MODEX WITH %s",              \
                             __FILE__, __LINE__, (n)->compat.gds->name);     \
-        (r) = (n)->compat.gds->store_modex((struct pmix_nspace_t*)n, l, b); \
+        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, l, b); \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -51,7 +51,7 @@ static void hash_finalize(void);
 static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo,
                                         int *priority);
 
-static pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                          pmix_info_t info[], size_t ninfo);
 
 static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
@@ -64,7 +64,7 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_scope_t scope,
                                 pmix_kval_t *kv);
 
-static pmix_status_t hash_store_modex(struct pmix_nspace_t *ns,
+static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo);
 
@@ -110,7 +110,7 @@ pmix_gds_base_module_t pmix_hash_module = {
 typedef struct {
     pmix_list_item_t super;
     char *ns;
-    pmix_nspace_t *nptr;
+    pmix_namespace_t *nptr;
     pmix_hash_table_t internal;
     pmix_hash_table_t remote;
     pmix_hash_table_t local;
@@ -355,10 +355,10 @@ static pmix_status_t store_map(pmix_hash_table_t *ht,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
+pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                   pmix_info_t info[], size_t ninfo)
 {
-    pmix_nspace_t *nptr = (pmix_nspace_t*)ns;
+    pmix_namespace_t *nptr = (pmix_namespace_t*)ns;
     pmix_hash_trkr_t *trk, *t;
     pmix_hash_table_t *ht;
     pmix_kval_t *kp2, *kvptr;
@@ -580,7 +580,7 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
 }
 
 static pmix_status_t register_info(pmix_peer_t *peer,
-                                   pmix_nspace_t *ns,
+                                   pmix_namespace_t *ns,
                                    pmix_buffer_t *reply)
 {
     pmix_hash_trkr_t *trk, *t;
@@ -672,13 +672,13 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 }
 
 /* the purpose of this function is to pack the job-level
- * info stored in the pmix_nspace_t into a buffer and send
+ * info stored in the pmix_namespace_t into a buffer and send
  * it to the given client */
 static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
                                             pmix_buffer_t *reply)
 {
     pmix_peer_t *peer = (pmix_peer_t*)pr;
-    pmix_nspace_t *ns = peer->nptr;
+    pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
     pmix_hash_trkr_t *trk, *t2;
@@ -1181,11 +1181,11 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
  * host has received data from some other peer. It therefore
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
-static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo)
 {
-    pmix_nspace_t *ns = (pmix_nspace_t*)nspace;
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_hash_trkr_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;

--- a/src/mca/pnet/base/base.h
+++ b/src/mca/pnet/base/base.h
@@ -119,7 +119,7 @@ PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
                                                              size_t ninfo);
 PMIX_EXPORT pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *peer, char ***env);
 PMIX_EXPORT void pmix_pnet_base_child_finalized(pmix_proc_t *peer);
-PMIX_EXPORT void pmix_pnet_base_local_app_finalized(pmix_nspace_t *nptr);
+PMIX_EXPORT void pmix_pnet_base_local_app_finalized(pmix_namespace_t *nptr);
 PMIX_EXPORT void pmix_pnet_base_deregister_nspace(char *nspace);
 PMIX_EXPORT void pmix_pnet_base_collect_inventory(pmix_info_t directives[], size_t ndirs,
                                                   pmix_inventory_cbfunc_t cbfunc,

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -40,7 +40,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
 {
     pmix_pnet_base_active_module_t *active;
     pmix_status_t rc;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     size_t n;
     char *nregex, *pregex;
 
@@ -59,7 +59,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
         nptr = NULL;
         /* find this nspace - note that it may not have
          * been registered yet */
-        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
             if (0 == strcmp(ns->nspace, nspace)) {
                 nptr = ns;
                 break;
@@ -67,7 +67,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
         }
         if (NULL == nptr) {
             /* add it */
-            nptr = PMIX_NEW(pmix_nspace_t);
+            nptr = PMIX_NEW(pmix_namespace_t);
             if (NULL == nptr) {
                 return PMIX_ERR_NOMEM;
             }
@@ -141,7 +141,7 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
 {
     pmix_pnet_base_active_module_t *active;
     pmix_status_t rc;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
 
     if (!pmix_pnet_globals.initialized) {
         return PMIX_ERR_INIT;
@@ -157,7 +157,7 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
 
     /* find this proc's nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, nspace)) {
             nptr = ns;
             break;
@@ -165,7 +165,7 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
     }
     if (NULL == nptr) {
         /* add it */
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             return PMIX_ERR_NOMEM;
         }
@@ -189,7 +189,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
 {
     pmix_pnet_base_active_module_t *active;
     pmix_status_t rc;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
 
     if (!pmix_pnet_globals.initialized) {
         return PMIX_ERR_INIT;
@@ -202,7 +202,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
 
     /* find this proc's nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, proc->nspace)) {
             nptr = ns;
             break;
@@ -210,7 +210,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
     }
     if (NULL == nptr) {
         /* add it */
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             return PMIX_ERR_NOMEM;
         }
@@ -252,7 +252,7 @@ void pmix_pnet_base_child_finalized(pmix_proc_t *peer)
     return;
 }
 
-void pmix_pnet_base_local_app_finalized(pmix_nspace_t *nptr)
+void pmix_pnet_base_local_app_finalized(pmix_namespace_t *nptr)
 {
     pmix_pnet_base_active_module_t *active;
 
@@ -277,7 +277,7 @@ void pmix_pnet_base_local_app_finalized(pmix_nspace_t *nptr)
 void pmix_pnet_base_deregister_nspace(char *nspace)
 {
     pmix_pnet_base_active_module_t *active;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
 
     if (!pmix_pnet_globals.initialized) {
         return;
@@ -290,7 +290,7 @@ void pmix_pnet_base_deregister_nspace(char *nspace)
 
     /* find this nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, nspace)) {
             nptr = ns;
             break;

--- a/src/mca/pnet/opa/pnet_opa.c
+++ b/src/mca/pnet/opa/pnet_opa.c
@@ -52,18 +52,18 @@
 
 static pmix_status_t opa_init(void);
 static void opa_finalize(void);
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist);
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo);
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env);
 static void child_finalized(pmix_proc_t *peer);
-static void local_app_finalized(pmix_nspace_t *nptr);
-static void deregister_nspace(pmix_nspace_t *nptr);
+static void local_app_finalized(pmix_namespace_t *nptr);
+static void deregister_nspace(pmix_namespace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_inventory_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
@@ -229,7 +229,7 @@ static char* transports_print(uint64_t *unique_key)
 /* NOTE: if there is any binary data to be transferred, then
  * this function MUST pack it for transport as the host will
  * not know how to do so */
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist)
 {
@@ -327,7 +327,7 @@ static pmix_status_t allocate(pmix_nspace_t *nptr,
     return PMIX_ERR_TAKE_NEXT_OPTION;
 }
 
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo)
 {
@@ -361,7 +361,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env)
 {
@@ -387,14 +387,14 @@ static void child_finalized(pmix_proc_t *peer)
                         "pnet:opa child finalized");
 }
 
-static void local_app_finalized(pmix_nspace_t *nptr)
+static void local_app_finalized(pmix_namespace_t *nptr)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:opa app finalized");
 
 }
 
-static void deregister_nspace(pmix_nspace_t *nptr)
+static void deregister_nspace(pmix_namespace_t *nptr)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:opa deregister nspace");

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -60,7 +60,7 @@ typedef void (*pmix_pnet_base_module_fini_fn_t)(void);
  * each other, environmental variables picked up at the login node
  * for forwarding to compute nodes, or allocation of static endpts
  */
-typedef pmix_status_t (*pmix_pnet_base_module_allocate_fn_t)(pmix_nspace_t *nptr,
+typedef pmix_status_t (*pmix_pnet_base_module_allocate_fn_t)(pmix_namespace_t *nptr,
                                                              pmix_info_t *info,
                                                              pmix_list_t *ilist);
 
@@ -68,7 +68,7 @@ typedef pmix_status_t (*pmix_pnet_base_module_allocate_fn_t)(pmix_nspace_t *nptr
  * Give the local network library an opportunity to setup address information
  * for the application by passing in the layout type and a regex describing
  * the layout */
-typedef pmix_status_t (*pmix_pnet_base_module_setup_local_net_fn_t)(pmix_nspace_t *nptr,
+typedef pmix_status_t (*pmix_pnet_base_module_setup_local_net_fn_t)(pmix_namespace_t *nptr,
                                                                     pmix_info_t info[],
                                                                     size_t ninfo);
 
@@ -76,7 +76,7 @@ typedef pmix_status_t (*pmix_pnet_base_module_setup_local_net_fn_t)(pmix_nspace_
  * Give the local network library an opportunity to add any envars to the
  * environment of a local application process prior to fork/exec
  */
-typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(pmix_nspace_t *nptr,
+typedef pmix_status_t (*pmix_pnet_base_module_setup_fork_fn_t)(pmix_namespace_t *nptr,
                                                                const pmix_proc_t *proc,
                                                                char ***env);
 
@@ -90,13 +90,13 @@ typedef void (*pmix_pnet_base_module_child_finalized_fn_t)(pmix_proc_t *peer);
  * Provide  an opportunity for the local network library to cleanup after
  * all local clients for a given application have terminated
  */
-typedef void (*pmix_pnet_base_module_local_app_finalized_fn_t)(pmix_nspace_t *nptr);
+typedef void (*pmix_pnet_base_module_local_app_finalized_fn_t)(pmix_namespace_t *nptr);
 
 /**
  * Provide an opportunity for the fabric components to cleanup any
  * resource allocations (e.g., static ports) they may have assigned
  */
-typedef void (*pmix_pnet_base_module_dregister_nspace_fn_t)(pmix_nspace_t *nptr);
+typedef void (*pmix_pnet_base_module_dregister_nspace_fn_t)(pmix_namespace_t *nptr);
 
 
 /**
@@ -166,7 +166,7 @@ typedef struct {
 
 
 /* define a few API versions of the functions - main difference is the
- * string nspace parameter instead of a pointer to pmix_nspace_t. This
+ * string nspace parameter instead of a pointer to pmix_namespace_t. This
  * is done as an optimization to avoid having every component look for
  * that pointer */
 typedef pmix_status_t (*pmix_pnet_base_API_allocate_fn_t)(char *nspace,

--- a/src/mca/pnet/tcp/pnet_tcp.c
+++ b/src/mca/pnet/tcp/pnet_tcp.c
@@ -47,17 +47,17 @@
 
 static pmix_status_t tcp_init(void);
 static void tcp_finalize(void);
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist);
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo);
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *peer, char ***env);
 static void child_finalized(pmix_proc_t *peer);
-static void local_app_finalized(pmix_nspace_t *nptr);
-static void deregister_nspace(pmix_nspace_t *nptr);
+static void local_app_finalized(pmix_namespace_t *nptr);
+static void deregister_nspace(pmix_namespace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_inventory_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
@@ -102,7 +102,7 @@ typedef struct {
 } tcp_port_tracker_t;
 
 static pmix_list_t allocations, available;
-static pmix_status_t process_request(pmix_nspace_t *nptr,
+static pmix_status_t process_request(pmix_namespace_t *nptr,
                                      char *idkey, int ports_per_node,
                                      tcp_port_tracker_t *trk,
                                      pmix_list_t *ilist);
@@ -295,7 +295,7 @@ static inline void generate_key(uint64_t* unique_key) {
  * NOTE: this implementation is offered as an example that can
  * undoubtedly be vastly improved/optimized */
 
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist)
 {
@@ -696,7 +696,7 @@ static pmix_status_t allocate(pmix_nspace_t *nptr,
 /* upon receipt of the launch message, each daemon adds the
  * static address assignments to the job-level info cache
  * for that job */
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo)
 {
@@ -782,7 +782,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *peer, char ***env)
 {
     return PMIX_SUCCESS;
@@ -801,7 +801,7 @@ static void child_finalized(pmix_proc_t *peer)
  * provides an opportunity for the local network to cleanup
  * any resources consumed locally by the clients of that job.
  * We don't have anything we need to do */
-static void local_app_finalized(pmix_nspace_t *nptr)
+static void local_app_finalized(pmix_namespace_t *nptr)
 {
     pmix_output_verbose(2, pmix_pnet_base_framework.framework_output,
                         "pnet:tcp app finalized");
@@ -811,7 +811,7 @@ static void local_app_finalized(pmix_nspace_t *nptr)
  * PMix function, which in turn calls my TCP component to release the
  * assignments for that job. The addresses are marked as "available"
  * for reuse on the next job. */
-static void deregister_nspace(pmix_nspace_t *nptr)
+static void deregister_nspace(pmix_namespace_t *nptr)
 {
     tcp_port_tracker_t *trk;
 
@@ -949,7 +949,7 @@ static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t process_request(pmix_nspace_t *nptr,
+static pmix_status_t process_request(pmix_namespace_t *nptr,
                                      char *idkey, int ports_per_node,
                                      tcp_port_tracker_t *trk,
                                      pmix_list_t *ilist)

--- a/src/mca/pnet/test/pnet_test.c
+++ b/src/mca/pnet/test/pnet_test.c
@@ -46,18 +46,18 @@
 
 static pmix_status_t test_init(void);
 static void test_finalize(void);
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist);
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo);
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env);
 static void child_finalized(pmix_proc_t *peer);
-static void local_app_finalized(pmix_nspace_t *nptr);
-static void deregister_nspace(pmix_nspace_t *nptr);
+static void local_app_finalized(pmix_namespace_t *nptr);
+static void deregister_nspace(pmix_namespace_t *nptr);
 static pmix_status_t collect_inventory(pmix_info_t directives[], size_t ndirs,
                                        pmix_inventory_cbfunc_t cbfunc, void *cbdata);
 static pmix_status_t deliver_inventory(pmix_info_t info[], size_t ninfo,
@@ -94,7 +94,7 @@ static void test_finalize(void)
 /* NOTE: if there is any binary data to be transferred, then
  * this function MUST pack it for transport as the host will
  * not know how to do so */
-static pmix_status_t allocate(pmix_nspace_t *nptr,
+static pmix_status_t allocate(pmix_namespace_t *nptr,
                               pmix_info_t *info,
                               pmix_list_t *ilist)
 {
@@ -283,7 +283,7 @@ static pmix_status_t allocate(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
+static pmix_status_t setup_local_network(pmix_namespace_t *nptr,
                                          pmix_info_t info[],
                                          size_t ninfo)
 {
@@ -404,7 +404,7 @@ static pmix_status_t setup_local_network(pmix_nspace_t *nptr,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t setup_fork(pmix_nspace_t *nptr,
+static pmix_status_t setup_fork(pmix_namespace_t *nptr,
                                 const pmix_proc_t *proc,
                                 char ***env)
 {
@@ -457,12 +457,12 @@ static void child_finalized(pmix_proc_t *peer)
                 peer->nspace, peer->rank);
 }
 
-static void local_app_finalized(pmix_nspace_t *nptr)
+static void local_app_finalized(pmix_namespace_t *nptr)
 {
     pmix_output(0, "pnet:test NSPACE %s LOCALLY FINALIZED", nptr->nspace);
 }
 
-static void deregister_nspace(pmix_nspace_t *nptr)
+static void deregister_nspace(pmix_namespace_t *nptr)
 {
     pmix_output(0, "pnet:test DEREGISTER NSPACE %s", nptr->nspace);
 }

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -476,7 +476,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
         }
         if (NULL == pmix_client_globals.myserver->nptr) {
-            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
         }
         if (NULL != pmix_client_globals.myserver->nptr->nspace) {
             free(pmix_client_globals.myserver->nptr->nspace);
@@ -1082,7 +1082,7 @@ static pmix_status_t recv_connect_ack(int sd)
             pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
         }
         if (NULL == pmix_client_globals.myserver->nptr) {
-            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
         }
         pmix_ptl_base_recv_blocking(sd, (char*)nspace, PMIX_MAX_NSLEN+1);
         if (NULL != pmix_client_globals.myserver->nptr->nspace) {

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -907,7 +907,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     uint32_t len, u32;
     size_t cnt, msglen, n;
     uint8_t flag;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     bool found;
     pmix_rank_info_t *info;
     pmix_proc_t proc;
@@ -1275,7 +1275,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;
@@ -1483,7 +1483,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_pending_connection_t *pnd = (pmix_pending_connection_t*)cd->cbdata;
-    pmix_nspace_t *nptr;
+    pmix_namespace_t *nptr;
     pmix_rank_info_t *info;
     pmix_peer_t *peer;
     int rc;
@@ -1541,7 +1541,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     }
 
     /* add this nspace to our pool */
-    nptr = PMIX_NEW(pmix_nspace_t);
+    nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == nptr) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         CLOSE_THE_SOCKET(pnd->sd);

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -146,7 +146,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr) {
-        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr->nspace) {
         pmix_client_globals.myserver->nptr->nspace = strdup(uri[0]);

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -341,7 +341,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_status_t rc;
     unsigned int rank;
     pmix_usock_hdr_t hdr;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_rank_info_t *info;
     pmix_peer_t *psave = NULL;
     bool found;
@@ -541,7 +541,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -223,7 +223,7 @@ int pmix_rte_init(pmix_proc_type_t type,
     pmix_globals.mypeer->proc_type = type | PMIX_PROC_V3;
     /* create an nspace object for ourselves - we will
      * fill in the nspace name later */
-    pmix_globals.mypeer->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_globals.mypeer->nptr) {
         PMIX_RELEASE(pmix_globals.mypeer);
         ret = PMIX_ERR_NOMEM;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -367,7 +367,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         rinfo = pmix_globals.mypeer->info;
     }
     if (NULL == pmix_globals.mypeer->nptr) {
-        pmix_globals.mypeer->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);
         /* ensure our own nspace is first on the list */
         PMIX_RETAIN(pmix_globals.mypeer->nptr);
         pmix_list_prepend(&pmix_server_globals.nspaces, &pmix_globals.mypeer->nptr->super);
@@ -442,7 +442,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 {
     int i;
     pmix_peer_t *peer;
-    pmix_nspace_t *ns;
+    pmix_namespace_t *ns;
     pmix_setup_caddy_t *cd;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
@@ -494,7 +494,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         /* ensure that we do the specified cleanup - if this is an
          * abnormal termination, then the nspace object may not be
          * at zero refcount */
@@ -548,7 +548,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 static void _register_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_status_t rc;
     size_t i;
 
@@ -559,14 +559,14 @@ static void _register_nspace(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             nptr = tmp;
             break;
         }
     }
     if (NULL == nptr) {
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             rc = PMIX_ERR_NOMEM;
             goto release;
@@ -644,7 +644,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int n
 static void _deregister_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
-    pmix_nspace_t *tmp;
+    pmix_namespace_t *tmp;
     pmix_status_t rc;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -660,7 +660,7 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
     PMIX_GDS_DEL_NSPACE(rc, cd->proc.nspace);
 
     /* release this nspace */
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             pmix_list_remove_item(&pmix_server_globals.nspaces, &tmp->super);
             PMIX_RELEASE(tmp);
@@ -863,7 +863,7 @@ static void _register_client(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info, *iptr;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     pmix_server_trkr_t *trk;
     pmix_trkr_caddy_t *tcd;
     bool all_def;
@@ -878,14 +878,14 @@ static void _register_client(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, cd->proc.nspace)) {
             nptr = ns;
             break;
         }
     }
     if (NULL == nptr) {
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
@@ -932,7 +932,7 @@ static void _register_client(int sd, short args, void *cbdata)
                  * if the nspaces are all defined */
                 if (all_def) {
                     /* so far, they have all been defined - check this one */
-                    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+                    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
                         if (0 < ns->nlocalprocs &&
                             0 == strcmp(trk->pcs[i].nspace, ns->nspace)) {
                             all_def = ns->all_registered;
@@ -1020,7 +1020,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_peer_t *peer;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -1031,7 +1031,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             nptr = tmp;
             break;
@@ -1204,7 +1204,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info, *iptr;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     char *data = NULL;
     size_t sz = 0;
     pmix_dmdx_remote_t *dcd;
@@ -1224,7 +1224,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
      * been informed of it - so first check to see if we know
      * about this nspace yet */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, cd->proc.nspace)) {
             nptr = ns;
             break;
@@ -2214,7 +2214,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         goto finish_collective;
     }
 
-    // collect the pmix_nspace_t's of all local participants
+    // collect the pmix_namespace_t's of all local participants
     PMIX_LIST_FOREACH(cd, &tracker->local_cbs, pmix_server_caddy_t) {
         // see if we already have this nspace
         found = false;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -84,7 +84,7 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_reply_caddy_t,
 static void dmdx_cbfunc(pmix_status_t status, const char *data,
                         size_t ndata, void *cbdata,
                         pmix_release_cbfunc_t relfn, void *relcbdata);
-static pmix_status_t _satisfy_request(pmix_nspace_t *ns, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *ns, pmix_rank_t rank,
                                       pmix_server_caddy_t *cd,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata, bool *scope);
 static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
@@ -119,7 +119,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_rank_t rank;
     char *cptr;
     char nspace[PMIX_MAX_NSLEN+1];
-    pmix_nspace_t *ns, *nptr;
+    pmix_namespace_t *ns, *nptr;
     pmix_info_t *info=NULL;
     size_t ninfo=0;
     pmix_dmdx_local_t *lcd;
@@ -191,7 +191,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
 
     /* find the nspace object for this client */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(nspace, ns->nspace)) {
             nptr = ns;
             break;
@@ -515,7 +515,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
     return rc;
 }
 
-void pmix_pending_nspace_requests(pmix_nspace_t *nptr)
+void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
 {
     pmix_dmdx_local_t *cd, *cd_next;
 
@@ -557,7 +557,7 @@ void pmix_pending_nspace_requests(pmix_nspace_t *nptr)
     }
 }
 
-static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                                       pmix_server_caddy_t *cd,
                                       pmix_modex_cbfunc_t cbfunc,
                                       void *cbdata, bool *local)
@@ -771,7 +771,7 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 }
 
 /* Resolve pending requests to this namespace/rank */
-pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, pmix_rank_t rank,
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
                                    pmix_status_t status, pmix_dmdx_local_t *lcd)
 {
     pmix_dmdx_local_t *cd, *ptr;
@@ -838,7 +838,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
     pmix_rank_info_t *rinfo;
     int32_t cnt;
     pmix_kval_t *kv;
-    pmix_nspace_t *ns, *nptr;
+    pmix_namespace_t *ns, *nptr;
     pmix_status_t rc;
     pmix_list_t nspaces;
     pmix_nspace_caddy_t *nm;
@@ -856,7 +856,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
 
     /* find the nspace object for the proc whose data is being received */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(caddy->lcd->proc.nspace, ns->nspace)) {
             nptr = ns;
             break;
@@ -867,7 +867,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
         /* We may not have this namespace because there are no local
          * processes from it running on this host - so just record it
          * so we know we have the data for any future requests */
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         nptr->nspace = strdup(caddy->lcd->proc.nspace);
         /* add to the list */
         pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -131,7 +131,7 @@ typedef struct {
 PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
 typedef struct {
-    pmix_list_t nspaces;                    // list of pmix_nspace_t for the nspaces we know about
+    pmix_list_t nspaces;                    // list of pmix_namespace_t for the nspaces we know about
     pmix_pointer_array_t clients;           // array of pmix_peer_t local clients
     pmix_list_t collectives;                // list of active pmix_server_trkr_t
     pmix_list_t remote_pnd;                 // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing remote req's
@@ -194,8 +194,8 @@ typedef struct {
 
 bool pmix_server_trk_update(pmix_server_trkr_t *trk);
 
-void pmix_pending_nspace_requests(pmix_nspace_t *nptr);
-pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, pmix_rank_t rank,
+void pmix_pending_nspace_requests(pmix_namespace_t *nptr);
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
                                    pmix_status_t status, pmix_dmdx_local_t *lcd);
 
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -452,7 +452,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;
     }
-    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_client_globals.myserver->nptr) {
         PMIX_RELEASE(pmix_client_globals.myserver);
         if (gdsfound) {


### PR DESCRIPTION
Mostly small addition/deletion of constants and attributes. From a code base standpoint, the biggest change was globally renaming the internal pmix_nspace_t object to pmix_namespace_t to resolve the conflict with the new user-facing structure type.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>