### PR TITLE
Sync to the formal PMIx v2 Standard doc

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  *
@@ -129,7 +129,7 @@ PMIX_EXPORT pmix_status_t PMIx_Abort(int status, const char msg[],
  * the information locally until _PMIx_Commit_ is called. The provided scope
  * value is passed to the local PMIx server, which will distribute the data
  * as directed. */
-PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const char key[], pmix_value_t *val);
+PMIX_EXPORT pmix_status_t PMIx_Put(pmix_scope_t scope, const pmix_key_t key, pmix_value_t *val);
 
 
 /* Push all previously _PMIx_Put_ values to the local PMIx server.
@@ -200,7 +200,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
  *     an error. The timeout parameter can help avoid "hangs" due to programming
  *     errors that prevent the target proc from ever exposing its data.
  */
-PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const pmix_key_t key,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_value_t **val);
 
@@ -208,7 +208,7 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc, const char key[],
  * be executed once the specified data has been _PMIx_Put_
  * by the identified process and retrieved by the local server. The info
  * array is used as described above for the blocking form of this call. */
-PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const char key[],
+PMIX_EXPORT pmix_status_t PMIx_Get_nb(const pmix_proc_t *proc, const pmix_key_t key,
                                       const pmix_info_t info[], size_t ninfo,
                                       pmix_value_cbfunc_t cbfunc, void *cbdata);
 
@@ -337,7 +337,7 @@ PMIX_EXPORT pmix_status_t PMIx_Unpublish_nb(char **keys,
  */
 PMIX_EXPORT pmix_status_t PMIx_Spawn(const pmix_info_t job_info[], size_t ninfo,
                                      const pmix_app_t apps[], size_t napps,
-                                     char nspace[]);
+                                     pmix_nspace_t nspace);
 
 
 /* Non-blocking form of the _PMIx_Spawn_ function. The callback
@@ -394,7 +394,8 @@ PMIX_EXPORT pmix_status_t PMIx_Disconnect_nb(const pmix_proc_t ranges[], size_t 
  * for releasing the array when done with it - the PMIX_PROC_FREE macro is
  * provided for this purpose.
  */
-PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *nspace,
+PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename,
+                                             const pmix_nspace_t nspace,
                                              pmix_proc_t **procs, size_t *nprocs);
 
 
@@ -402,7 +403,7 @@ PMIX_EXPORT pmix_status_t PMIx_Resolve_peers(const char *nodename, const char *n
  * that nspace. The returned string will contain a comma-delimited list
  * of nodenames. The caller is responsible for releasing the string
  * when done with it */
-PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const char *nspace, char **nodelist);
+PMIX_EXPORT pmix_status_t PMIx_Resolve_nodes(const pmix_nspace_t nspace, char **nodelist);
 
 /* Query information about the system in general - can include
  * a list of active nspaces, network topology, etc. Also can be

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -81,8 +81,12 @@ extern "C" {
 /****  PMIX CONSTANTS    ****/
 
 /* define maximum value and key sizes */
-#define PMIX_MAX_NSLEN     255
-#define PMIX_MAX_KEYLEN    511
+#define PMIX_MAX_NSLEN     63
+#define PMIX_MAX_KEYLEN    63
+
+/* define abstract types for namespaces and keys */
+typedef char pmix_nspace_t[PMIX_MAX_NSLEN+1];
+typedef char pmix_key_t[PMIX_MAX_KEYLEN+1];
 
 /* define a type for rank values */
 typedef uint32_t pmix_rank_t;
@@ -128,7 +132,6 @@ typedef uint32_t pmix_rank_t;
                                                                     //        client rendezvous points and contact info
 #define PMIX_SYSTEM_TMPDIR                  "pmix.sys.tmpdir"       // (char*) temp directory for this system, where PMIx
                                                                     //        server will place tool rendezvous points and contact info
-#define PMIX_REGISTER_NODATA                "pmix.reg.nodata"       // (bool) Registration is for nspace only, do not copy job data
 #define PMIX_SERVER_ENABLE_MONITORING       "pmix.srv.monitor"      // (bool) Enable PMIx internal monitoring by server
 #define PMIX_SERVER_NSPACE                  "pmix.srv.nspace"       // (char*) Name of the nspace to use for this server
 #define PMIX_SERVER_RANK                    "pmix.srv.rank"         // (pmix_rank_t) Rank of this server
@@ -239,7 +242,6 @@ typedef uint32_t pmix_rank_t;
 /* topology info */
 #define PMIX_NET_TOPO                       "pmix.ntopo"            // (char*) xml-representation of network topology
 #define PMIX_LOCAL_TOPO                     "pmix.ltopo"            // (char*) xml-representation of local node topology
-#define PMIX_NODE_LIST                      "pmix.nlist"            // (char*) comma-delimited list of nodes running procs for this job
 #define PMIX_TOPOLOGY                       "pmix.topo"             // (hwloc_topology_t) pointer to the PMIx client's internal topology object
 #define PMIX_TOPOLOGY_SIGNATURE             "pmix.toposig"          // (char*) topology signature string
 #define PMIX_LOCALITY_STRING                "pmix.locstr"           // (char*) string describing a proc's location
@@ -291,8 +293,6 @@ typedef uint32_t pmix_rank_t;
 
 /* event handler registration and notification info keys */
 #define PMIX_EVENT_HDLR_NAME                "pmix.evname"           // (char*) string name identifying this handler
-#define PMIX_EVENT_JOB_LEVEL                "pmix.evjob"            // (bool) register for job-specific events only
-#define PMIX_EVENT_ENVIRO_LEVEL             "pmix.evenv"            // (bool) register for environment events only
 #define PMIX_EVENT_HDLR_FIRST               "pmix.evfirst"          // (bool) invoke this event handler before any other handlers
 #define PMIX_EVENT_HDLR_LAST                "pmix.evlast"           // (bool) invoke this event handler after all other handlers have been called
 #define PMIX_EVENT_HDLR_FIRST_IN_CATEGORY   "pmix.evfirstcat"       // (bool) invoke this event handler before any other handlers in this category
@@ -592,10 +592,11 @@ typedef int pmix_status_t;
 #define PMIX_MONITOR_HEARTBEAT_ALERT            (PMIX_ERR_V2X_BASE -  9)
 #define PMIX_MONITOR_FILE_ALERT                 (PMIX_ERR_V2X_BASE - 10)
 #define PMIX_PROC_TERMINATED                    (PMIX_ERR_V2X_BASE - 11)
+#define PMIX_ERR_INVALID_TERMINATION            (PMIX_ERR_V2X_BASE - 12)
 
 /* define a starting point for operational error constants so
  * we avoid renumbering when making additions */
-#define PMIX_ERR_OP_BASE    PMIX_ERR_V2X_BASE-30
+#define PMIX_ERR_OP_BASE    PMIX_ERR_V2X_BASE-100
 
 /* operational */
 #define PMIX_ERR_EVENT_REGISTRATION             (PMIX_ERR_OP_BASE - 14)
@@ -605,20 +606,26 @@ typedef int pmix_status_t;
 #define PMIX_GDS_ACTION_COMPLETE                (PMIX_ERR_OP_BASE - 18)
 /* gap created by v3 definitions */
 #define PMIX_OPERATION_SUCCEEDED                (PMIX_ERR_OP_BASE - 27)
-/* gap for group codes */
+#define PMIX_ERR_INVALID_OPERATION              (PMIX_ERR_OP_BASE - 28)
 
-/* define a starting point for system error constants so
- * we avoid renumbering when making additions */
-#define PMIX_ERR_SYS_BASE    PMIX_ERR_OP_BASE-100
+/* define a starting point for system event constants so
+ * we avoid renumbering when making additions - host environments
+ * are responsible for translating their own event codes into
+ * the closest PMIx equivalent value */
+#define PMIX_ERR_SYS_BASE    PMIX_ERR_OP_BASE-200
 
 /* system failures */
-#define PMIX_ERR_NODE_DOWN                      (PMIX_ERR_SYS_BASE -  1)
-#define PMIX_ERR_NODE_OFFLINE                   (PMIX_ERR_SYS_BASE -  2)
+#define PMIX_ERR_NODE_DOWN                      (PMIX_ERR_SYS_BASE -   0)
+#define PMIX_ERR_NODE_OFFLINE                   (PMIX_ERR_SYS_BASE -   1)
+#define PMIX_ERR_SYS_OTHER                      (PMIX_ERR_EVHDLR_BASE + 1)
 
+/* define a macro for identifying system event values */
+#define PMIX_SYSTEM_EVENT(a)   \
+    (PMIX_ERR_SYS_BASE >= (a) && PMIX_ERR_EVHDLR_BASE < (a))
 
 /* define a starting point for event handler error constants so
  * we avoid renumbering when making additions */
-#define PMIX_ERR_EVHDLR_BASE    PMIX_ERR_SYS_BASE-100
+#define PMIX_ERR_EVHDLR_BASE    PMIX_ERR_SYS_BASE-500
 
 /* used by event handlers */
 #define PMIX_EVENT_NO_ACTION_TAKEN              (PMIX_ERR_EVHDLR_BASE -  1)
@@ -629,14 +636,14 @@ typedef int pmix_status_t;
 
 /* define a starting point for PMIx internal error codes
  * that are never exposed outside the library */
-#define PMIX_INTERNAL_ERR_BASE          -1000
+#define PMIX_INTERNAL_ERR_BASE          PMIX_ERR_EVHDLR_BASE-1000
 
 /* define a starting point for user-level defined error
  * constants - negative values larger than this are guaranteed
  * not to conflict with PMIx values. Definitions should always
  * be based on the PMIX_EXTERNAL_ERR_BASE constant and -not- a
  * specific value as the value of the constant may change */
-#define PMIX_EXTERNAL_ERR_BASE           -2000
+#define PMIX_EXTERNAL_ERR_BASE           PMIX_INTERNAL_ERR_BASE-2000
 
 /****    PMIX DATA TYPES    ****/
 typedef uint16_t pmix_data_type_t;
@@ -758,9 +765,23 @@ typedef uint8_t pmix_alloc_directive_t;
 #define PMIX_CHECK_KEY(a, b) \
     (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
 
+/* define a convenience macro for loading nspaces */
+#define PMIX_LOAD_NSPACE(a, b)                      \
+    do {                                            \
+        memset((a), 0, PMIX_MAX_NSLEN+1);           \
+        (void)strncpy((a), (b), PMIX_MAX_NSLEN);    \
+    }while(0)
+
 /* define a convenience macro for checking nspaces */
 #define PMIX_CHECK_NSPACE(a, b) \
     (0 == strncmp((a), (b), PMIX_MAX_NSLEN))
+
+/* define a convenience macro for loading names */
+#define PMIX_LOAD_PROCID(a, b, c)               \
+    do {                                        \
+        PMIX_LOAD_NSPACE((a)->nspace, (b));     \
+        (a)->rank = (c);                        \
+    }while(0)
 
 /* define a convenience macro for checking names */
 #define PMIX_CHECK_PROCID(a, b) \
@@ -853,7 +874,7 @@ typedef struct pmix_data_buffer {
 
 /****    PMIX PROC OBJECT    ****/
 typedef struct pmix_proc {
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t nspace;
     pmix_rank_t rank;
 } pmix_proc_t;
 #define PMIX_PROC_CREATE(m, n)                                  \
@@ -1065,7 +1086,7 @@ pmix_status_t pmix_setenv(const char *name, const char *value,
 
 /****    PMIX INFO STRUCT    ****/
 struct pmix_info_t {
-    char key[PMIX_MAX_KEYLEN+1];    // ensure room for the NULL terminator
+    pmix_key_t key;
     pmix_info_directives_t flags;   // bit-mask of flags
     pmix_value_t value;
 };
@@ -1115,6 +1136,11 @@ struct pmix_info_t {
 #define PMIX_INFO_OPTIONAL(m)       \
     (m)->flags &= ~PMIX_INFO_REQD;
 
+#define PMIX_INFO_IS_REQUIRED(m)    \
+    (m)->flags & PMIX_INFO_REQD
+#define PMIX_INFO_IS_OPTIONAL(m)    \
+    !((m)->flags & PMIX_INFO_REQD)
+
 #define PMIX_INFO_UNLOAD(r, v, l)                              \
     do {                                                       \
         pmix_info_t *_info;                                    \
@@ -1149,7 +1175,7 @@ struct pmix_info_t {
 /****    PMIX LOOKUP RETURN STRUCT    ****/
 typedef struct pmix_pdata {
     pmix_proc_t proc;
-    char key[PMIX_MAX_KEYLEN+1];  // ensure room for the NULL terminator
+    pmix_key_t key;
     pmix_value_t value;
 } pmix_pdata_t;
 
@@ -1334,7 +1360,7 @@ typedef struct pmix_query {
 
 /****    PMIX MODEX STRUCT    ****/
 typedef struct pmix_modex_data {
-    char nspace[PMIX_MAX_NSLEN+1];
+    pmix_nspace_t nspace;
     int rank;
     uint8_t *blob;
     size_t size;
@@ -1401,7 +1427,7 @@ typedef void (*pmix_modex_cbfunc_t)(pmix_status_t status,
  * released by the library upon return from the callback function, so
  * the receiver must copy it if it needs to be retained */
 typedef void (*pmix_spawn_cbfunc_t)(pmix_status_t status,
-                                    char nspace[], void *cbdata);
+                                    pmix_nspace_t nspace, void *cbdata);
 
 /* define a callback for common operations that simply return
  * a status. Examples include the non-blocking versions of
@@ -1635,7 +1661,7 @@ PMIX_EXPORT const char* PMIx_Get_version(void);
  * proc. This is data that has only internal scope - it will
  * never be "pushed" externally */
 PMIX_EXPORT pmix_status_t PMIx_Store_internal(const pmix_proc_t *proc,
-                                              const char *key, pmix_value_t *val);
+                                              const pmix_key_t key, pmix_value_t *val);
 
 /**
  * Top-level interface function to pack one or more values into a

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
@@ -442,7 +442,7 @@ PMIX_EXPORT pmix_status_t PMIx_generate_ppn(const char *input, char **ppn);
  * for the PMIx server library to correctly handle collectives
  * as a collective operation call can occur before all the
  * procs have been started */
-PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int nlocalprocs,
+PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace, int nlocalprocs,
                                           pmix_info_t info[], size_t ninfo,
                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 
@@ -451,7 +451,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int n
  * intended to support persistent PMIx servers by providing
  * an opportunity for the host RM to tell the PMIx server
  * library to release all memory for a completed job */
-PMIX_EXPORT void PMIx_server_deregister_nspace(const char nspace[],
+PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace,
                                                pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 /* Register a client process with the PMIx server library. The
@@ -521,7 +521,7 @@ typedef void (*pmix_setup_application_cbfunc_t)(pmix_status_t status,
  * is defined as a non-blocking operation in case network
  * libraries need to perform some action before responding. The
  * returned env will be distributed along with the application */
-PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const pmix_nspace_t nspace,
                                                         pmix_info_t info[], size_t ninfo,
                                                         pmix_setup_application_cbfunc_t cbfunc, void *cbdata);
 
@@ -530,7 +530,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_setup_application(const char nspace[],
  * clients of a given application. For example, a network library
  * might need to setup the local driver for "instant on" addressing.
  */
-PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const char nspace[],
+PMIX_EXPORT pmix_status_t PMIx_server_setup_local_support(const pmix_nspace_t nspace,
                                                           pmix_info_t info[], size_t ninfo,
                                                           pmix_op_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/client/pmix_client.c
+++ b/src/client/pmix_client.c
@@ -336,7 +336,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
 {
     char *evar;
     pmix_status_t rc;
-    pmix_nspace_t *nsptr;
+    pmix_namespace_t *nsptr;
     pmix_cb_t cb;
     pmix_buffer_t *req;
     pmix_cmd_t cmd = PMIX_REQ_CMD;
@@ -393,7 +393,7 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;
     }
-    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_client_globals.myserver->nptr) {
         PMIX_RELEASE(pmix_client_globals.myserver);
         PMIX_RELEASE_THREAD(&pmix_global_lock);
@@ -422,8 +422,8 @@ PMIX_EXPORT pmix_status_t PMIx_Init(pmix_proc_t *proc,
         (void)strncpy(proc->nspace, evar, PMIX_MAX_NSLEN);
     }
     (void)strncpy(pmix_globals.myid.nspace, evar, PMIX_MAX_NSLEN);
-    /* create a pmix_nspace_t object for our peer */
-    nsptr = PMIX_NEW(pmix_nspace_t);
+    /* create a pmix_namespace_t object for our peer */
+    nsptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == nsptr){
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_NOMEM;

--- a/src/common/pmix_data.c
+++ b/src/common/pmix_data.c
@@ -110,7 +110,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
             PMIX_RELEASE(value);
             return NULL;
         }
-        peer->nptr = PMIX_NEW(pmix_nspace_t);
+        peer->nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == peer->nptr) {
             PMIX_RELEASE(peer);
             PMIX_RELEASE(value);
@@ -151,7 +151,7 @@ static pmix_peer_t* find_peer(const pmix_proc_t *proc)
         PMIX_RELEASE(value);
         return NULL;
     }
-    peer->nptr = PMIX_NEW(pmix_nspace_t);
+    peer->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == peer->nptr) {
         PMIX_RELEASE(peer);
         PMIX_RELEASE(value);

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -459,8 +459,6 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 }
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_NAME, PMIX_MAX_KEYLEN)) {
                 name = cd->info[n].value.data.string;
-            } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_ENVIRO_LEVEL, PMIX_MAX_KEYLEN)) {
-                cd->enviro = PMIX_INFO_TRUE(&cd->info[n]);
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
                 cbobject = cd->info[n].value.data.ptr;
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_HDLR_FIRST_IN_CATEGORY, PMIX_MAX_KEYLEN)) {
@@ -487,6 +485,14 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
                 ixfer->info = &cd->info[n];
                 pmix_list_append(&xfer, &ixfer->super);
             }
+        }
+    }
+
+    /* check the codes for system events */
+    for (n=0; n < cd->ncodes; n++) {
+        if (PMIX_SYSTEM_EVENT(cd->codes[n])) {
+            cd->enviro = true;
+            break;
         }
     }
 

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -52,7 +52,7 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namelist_t,
                                 pmix_list_item_t,
                                 NULL, NULL);
 
-static void nscon(pmix_nspace_t *p)
+static void nscon(pmix_namespace_t *p)
 {
     p->nspace = NULL;
     p->nprocs = 0;
@@ -64,7 +64,7 @@ static void nscon(pmix_nspace_t *p)
     PMIX_CONSTRUCT(&p->ranks, pmix_list_t);
     memset(&p->compat, 0, sizeof(p->compat));
 }
-static void nsdes(pmix_nspace_t *p)
+static void nsdes(pmix_namespace_t *p)
 {
     if (NULL != p->nspace) {
         free(p->nspace);
@@ -74,7 +74,7 @@ static void nsdes(pmix_nspace_t *p)
     }
     PMIX_LIST_DESTRUCT(&p->ranks);
 }
-PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_nspace_t,
+PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_namespace_t,
                                 pmix_list_item_t,
                                 nscon, nsdes);
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -139,14 +139,14 @@ typedef struct {
      * Since servers may support clients from multiple nspaces,
      * track their respective compatibility modules here */
     pmix_personality_t compat;
-} pmix_nspace_t;
-PMIX_CLASS_DECLARATION(pmix_nspace_t);
+} pmix_namespace_t;
+PMIX_CLASS_DECLARATION(pmix_namespace_t);
 
-/* define a caddy for quickly creating a list of pmix_nspace_t
+/* define a caddy for quickly creating a list of pmix_namespace_t
  * objects for local, dedicated purposes */
 typedef struct {
     pmix_list_item_t super;
-    pmix_nspace_t *ns;
+    pmix_namespace_t *ns;
 } pmix_nspace_caddy_t;
 PMIX_CLASS_DECLARATION(pmix_nspace_caddy_t);
 
@@ -169,7 +169,7 @@ PMIX_CLASS_DECLARATION(pmix_rank_info_t);
  * by the socket, not the process nspace/rank */
 typedef struct pmix_peer_t {
     pmix_object_t super;
-    pmix_nspace_t *nptr;            // point to the nspace object for this process
+    pmix_namespace_t *nptr;            // point to the nspace object for this process
     pmix_rank_info_t *info;
     pmix_proc_type_t proc_type;
     int proc_cnt;

--- a/src/mca/gds/ds12/gds_dstore.c
+++ b/src/mca/gds/ds12/gds_dstore.c
@@ -389,7 +389,7 @@ static void dstore_finalize(void);
 
 static pmix_status_t dstore_setup_fork(const pmix_proc_t *peer, char ***env);
 
-static pmix_status_t dstore_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t dstore_cache_job_info(struct pmix_namespace_t *ns,
                                 pmix_info_t info[], size_t ninfo);
 
 static pmix_status_t dstore_register_job_info(struct pmix_peer_t *pr,
@@ -425,7 +425,7 @@ static pmix_status_t dstore_del_nspace(const char* nspace);
 static pmix_status_t dstore_assign_module(pmix_info_t *info, size_t ninfo,
                                 int *priority);
 
-static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t dstore_store_modex(struct pmix_namespace_t *nspace,
                                 pmix_list_t *cbs,
                                 pmix_byte_object_t *bo);
 
@@ -2070,7 +2070,7 @@ static inline ssize_t _get_univ_size(const char *nspace)
     return nprocs;
 }
 
-static pmix_status_t dstore_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t dstore_cache_job_info(struct pmix_namespace_t *ns,
                                 pmix_info_t info[], size_t ninfo)
 {
     return PMIX_SUCCESS;
@@ -2992,11 +2992,11 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank)
  * host has received data from some other peer. It therefore
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
-static pmix_status_t dstore_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t dstore_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo)
 {
-    pmix_nspace_t *ns = (pmix_nspace_t*)nspace;
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
     pmix_buffer_t pbkt;
@@ -3160,7 +3160,7 @@ static pmix_status_t dstore_register_job_info(struct pmix_peer_t *pr,
                                             pmix_buffer_t *reply)
 {
     pmix_peer_t *peer = (pmix_peer_t*)pr;
-    pmix_nspace_t *ns = peer->nptr;
+    pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
     pmix_proc_t proc;
@@ -3221,11 +3221,11 @@ static pmix_status_t dstore_store_job_info(const char *nspace,  pmix_buffer_t *b
 
 static void _client_compat_save(pmix_peer_t *peer)
 {
-    pmix_nspace_t *nptr = NULL;
+    pmix_namespace_t *nptr = NULL;
 
     if (NULL == _clients_peer) {
         _clients_peer = PMIX_NEW(pmix_peer_t);
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         _clients_peer->nptr = nptr;
     }
     _clients_peer->nptr->compat = peer->nptr->compat;

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -44,7 +44,7 @@
 BEGIN_C_DECLS
 /* forward declaration */
 struct pmix_peer_t;
-struct pmix_nspace_t;
+struct pmix_namespace_t;
 
 /* backdoor to base verbosity */
 PMIX_EXPORT extern int pmix_gds_base_output;
@@ -117,7 +117,7 @@ typedef pmix_status_t (*pmix_gds_base_module_accept_kvs_resp_fn_t)(pmix_buffer_t
  * only we don't have packed data on the server side, and don't want
  * to incur the overhead of packing it just to unpack it in the function.
  */
-typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_nspace_t *ns,
+typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_namespace_t *ns,
                                                                   pmix_info_t info[], size_t ninfo);
 
 /* define a convenience macro for caching job info */
@@ -127,7 +127,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS CACHE JOB INFO WITH %s",           \
                             __FILE__, __LINE__, _g->name);                  \
-       (s) = _g->cache_job_info((struct pmix_nspace_t*)(n), (i), (ni));     \
+       (s) = _g->cache_job_info((struct pmix_namespace_t*)(n), (i), (ni));     \
     } while(0)
 
 /* register job-level info - this is provided as a special function
@@ -135,7 +135,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
  * prepare the job-level info provided at PMIx_Register_nspace, because
  * we don't know the GDS component to use for that application until
  * a local client contacts us. Thus, the module is required to process
- * the job-level info cached in the pmix_nspace_t for this job and
+ * the job-level info cached in the pmix_namespace_t for this job and
  * do whatever is necessary to support the client, packing any required
  * return message into the provided buffer.
  *
@@ -155,7 +155,7 @@ typedef pmix_status_t (*pmix_gds_base_module_cache_job_info_fn_t)(struct pmix_ns
  *
  * The pmix_peer_t of the requesting client is provided here so that
  * the module can access the job-level info cached on the corresponding
- * pmix_nspace_t pointed to by the pmix_peer_t
+ * pmix_namespace_t pointed to by the pmix_peer_t
  */
 typedef pmix_status_t (*pmix_gds_base_module_register_job_info_fn_t)(struct pmix_peer_t *pr,
                                                                      pmix_buffer_t *reply);
@@ -241,7 +241,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  * bo - pointer to the byte object containing the data
  *
  */
-typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspace_t *ns,
+typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_namespace_t *ns,
                                                                pmix_list_t *cbs,
                                                                pmix_byte_object_t *bo);
 
@@ -250,7 +250,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspac
  *
  * r - return status code
  *
- * n - pointer to the pmix_nspace_t this blob is to be stored for
+ * n - pointer to the pmix_namespace_t this blob is to be stored for
  *
  * l - pointer to pmix_list_t containing pmix_server_caddy_t objects
  *     of the local_cbs of the collective tracker
@@ -262,7 +262,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_nspac
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS STORE MODEX WITH %s",              \
                             __FILE__, __LINE__, (n)->compat.gds->name);     \
-        (r) = (n)->compat.gds->store_modex((struct pmix_nspace_t*)n, l, b); \
+        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, l, b); \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -49,7 +49,7 @@ static void hash_finalize(void);
 static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo,
                                         int *priority);
 
-static pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
+static pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                          pmix_info_t info[], size_t ninfo);
 
 static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
@@ -62,7 +62,7 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_scope_t scope,
                                 pmix_kval_t *kv);
 
-static pmix_status_t hash_store_modex(struct pmix_nspace_t *ns,
+static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo);
 
@@ -108,7 +108,7 @@ pmix_gds_base_module_t pmix_hash_module = {
 typedef struct {
     pmix_list_item_t super;
     char *ns;
-    pmix_nspace_t *nptr;
+    pmix_namespace_t *nptr;
     pmix_hash_table_t internal;
     pmix_hash_table_t remote;
     pmix_hash_table_t local;
@@ -348,10 +348,10 @@ static pmix_status_t store_map(pmix_hash_table_t *ht,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
+pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                   pmix_info_t info[], size_t ninfo)
 {
-    pmix_nspace_t *nptr = (pmix_nspace_t*)ns;
+    pmix_namespace_t *nptr = (pmix_namespace_t*)ns;
     pmix_hash_trkr_t *trk, *t;
     pmix_hash_table_t *ht;
     pmix_kval_t *kp2, *kvptr;
@@ -557,7 +557,7 @@ pmix_status_t hash_cache_job_info(struct pmix_nspace_t *ns,
 }
 
 static pmix_status_t register_info(pmix_peer_t *peer,
-                                   pmix_nspace_t *ns,
+                                   pmix_namespace_t *ns,
                                    pmix_buffer_t *reply)
 {
     pmix_hash_trkr_t *trk, *t;
@@ -649,13 +649,13 @@ static pmix_status_t register_info(pmix_peer_t *peer,
 }
 
 /* the purpose of this function is to pack the job-level
- * info stored in the pmix_nspace_t into a buffer and send
+ * info stored in the pmix_namespace_t into a buffer and send
  * it to the given client */
 static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
                                             pmix_buffer_t *reply)
 {
     pmix_peer_t *peer = (pmix_peer_t*)pr;
-    pmix_nspace_t *ns = peer->nptr;
+    pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
     pmix_hash_trkr_t *trk, *t2;
@@ -1154,11 +1154,11 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
  * host has received data from some other peer. It therefore
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
-static pmix_status_t hash_store_modex(struct pmix_nspace_t *nspace,
+static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
                                       pmix_byte_object_t *bo)
 {
-    pmix_nspace_t *ns = (pmix_nspace_t*)nspace;
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_hash_trkr_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -383,7 +383,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr) {
-        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr->nspace) {
         pmix_client_globals.myserver->nptr->nspace = nspace;
@@ -934,7 +934,7 @@ static pmix_status_t recv_connect_ack(int sd)
             pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
         }
         if (NULL == pmix_client_globals.myserver->nptr) {
-            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+            pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
         }
         pmix_ptl_base_recv_blocking(sd, (char*)nspace, PMIX_MAX_NSLEN+1);
         if (NULL != pmix_client_globals.myserver->nptr->nspace) {

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -817,7 +817,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     uint32_t len, u32;
     size_t cnt, msglen, n;
     uint8_t flag;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     bool found;
     pmix_rank_info_t *info;
     pmix_proc_t proc;
@@ -1117,7 +1117,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;
@@ -1317,7 +1317,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_pending_connection_t *pnd = (pmix_pending_connection_t*)cd->cbdata;
-    pmix_nspace_t *nptr;
+    pmix_namespace_t *nptr;
     pmix_rank_info_t *info;
     pmix_peer_t *peer;
     int rc;
@@ -1373,7 +1373,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     }
 
     /* add this nspace to our pool */
-    nptr = PMIX_NEW(pmix_nspace_t);
+    nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == nptr) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         CLOSE_THE_SOCKET(pnd->sd);

--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -145,7 +145,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr) {
-        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
     }
     if (NULL == pmix_client_globals.myserver->nptr->nspace) {
         pmix_client_globals.myserver->nptr->nspace = strdup(uri[0]);

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -341,7 +341,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_status_t rc;
     unsigned int rank;
     pmix_usock_hdr_t hdr;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_rank_info_t *info;
     pmix_peer_t *psave = NULL;
     bool found;
@@ -538,7 +538,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -173,7 +173,7 @@ int pmix_rte_init(pmix_proc_type_t type,
     pmix_globals.mypeer->proc_type = type | PMIX_PROC_V21;
     /* create an nspace object for ourselves - we will
      * fill in the nspace name later */
-    pmix_globals.mypeer->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);
     if (NULL == pmix_globals.mypeer->nptr) {
         PMIX_RELEASE(pmix_globals.mypeer);
         ret = PMIX_ERR_NOMEM;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -264,7 +264,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
         rinfo = pmix_globals.mypeer->info;
     }
     if (NULL == pmix_globals.mypeer->nptr) {
-        pmix_globals.mypeer->nptr = PMIX_NEW(pmix_nspace_t);
+        pmix_globals.mypeer->nptr = PMIX_NEW(pmix_namespace_t);
         /* ensure our own nspace is first on the list */
         PMIX_RETAIN(pmix_globals.mypeer->nptr);
         pmix_list_prepend(&pmix_server_globals.nspaces, &pmix_globals.mypeer->nptr->super);
@@ -383,7 +383,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 static void _register_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_status_t rc;
     size_t i;
 
@@ -394,14 +394,14 @@ static void _register_nspace(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             nptr = tmp;
             break;
         }
     }
     if (NULL == nptr) {
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             rc = PMIX_ERR_NOMEM;
             goto release;
@@ -479,7 +479,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const char nspace[], int n
 static void _deregister_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
-    pmix_nspace_t *tmp;
+    pmix_namespace_t *tmp;
     pmix_status_t rc;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -489,7 +489,7 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
                         cd->proc.nspace);
 
     /* see if we already have this nspace */
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             pmix_list_remove_item(&pmix_server_globals.nspaces, &tmp->super);
             PMIX_RELEASE(tmp);
@@ -698,7 +698,7 @@ static void _register_client(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info, *iptr;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     pmix_server_trkr_t *trk;
     pmix_trkr_caddy_t *tcd;
     bool all_def;
@@ -713,14 +713,14 @@ static void _register_client(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, cd->proc.nspace)) {
             nptr = ns;
             break;
         }
     }
     if (NULL == nptr) {
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         if (NULL == nptr) {
             rc = PMIX_ERR_NOMEM;
             goto cleanup;
@@ -767,7 +767,7 @@ static void _register_client(int sd, short args, void *cbdata)
                  * if the nspaces are all defined */
                 if (all_def) {
                     /* so far, they have all been defined - check this one */
-                    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+                    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
                         if (0 < ns->nlocalprocs &&
                             0 == strcmp(trk->pcs[i].nspace, ns->nspace)) {
                             all_def = ns->all_registered;
@@ -855,7 +855,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info;
-    pmix_nspace_t *nptr, *tmp;
+    pmix_namespace_t *nptr, *tmp;
     pmix_peer_t *peer;
 
     PMIX_ACQUIRE_OBJECT(cd);
@@ -866,7 +866,7 @@ static void _deregister_client(int sd, short args, void *cbdata)
 
     /* see if we already have this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, cd->proc.nspace)) {
             nptr = tmp;
             break;
@@ -1003,7 +1003,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_rank_info_t *info, *iptr;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     char *data = NULL;
     size_t sz = 0;
     pmix_dmdx_remote_t *dcd;
@@ -1023,7 +1023,7 @@ static void _dmodex_req(int sd, short args, void *cbdata)
      * been informed of it - so first check to see if we know
      * about this nspace yet */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, cd->proc.nspace)) {
             nptr = ns;
             break;
@@ -1632,7 +1632,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         goto finish_collective;
     }
 
-    // collect the pmix_nspace_t's of all local participants
+    // collect the pmix_namespace_t's of all local participants
     PMIX_LIST_FOREACH(cd, &tracker->local_cbs, pmix_server_caddy_t) {
         // see if we already have this nspace
         found = false;

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -84,7 +84,7 @@ PMIX_CLASS_INSTANCE(pmix_dmdx_reply_caddy_t,
 static void dmdx_cbfunc(pmix_status_t status, const char *data,
                         size_t ndata, void *cbdata,
                         pmix_release_cbfunc_t relfn, void *relcbdata);
-static pmix_status_t _satisfy_request(pmix_nspace_t *ns, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *ns, pmix_rank_t rank,
                                       pmix_server_caddy_t *cd,
                                       pmix_modex_cbfunc_t cbfunc, void *cbdata, bool *scope);
 static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
@@ -116,7 +116,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_rank_t rank;
     char *cptr;
     char nspace[PMIX_MAX_NSLEN+1];
-    pmix_nspace_t *ns, *nptr;
+    pmix_namespace_t *ns, *nptr;
     pmix_info_t *info=NULL;
     size_t ninfo=0;
     pmix_dmdx_local_t *lcd;
@@ -184,7 +184,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
 
     /* find the nspace object for this client */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(nspace, ns->nspace)) {
             nptr = ns;
             break;
@@ -444,7 +444,7 @@ static pmix_status_t create_local_tracker(char nspace[], pmix_rank_t rank,
     return rc;
 }
 
-void pmix_pending_nspace_requests(pmix_nspace_t *nptr)
+void pmix_pending_nspace_requests(pmix_namespace_t *nptr)
 {
     pmix_dmdx_local_t *cd, *cd_next;
 
@@ -486,7 +486,7 @@ void pmix_pending_nspace_requests(pmix_nspace_t *nptr)
     }
 }
 
-static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
+static pmix_status_t _satisfy_request(pmix_namespace_t *nptr, pmix_rank_t rank,
                                       pmix_server_caddy_t *cd,
                                       pmix_modex_cbfunc_t cbfunc,
                                       void *cbdata, bool *local)
@@ -694,7 +694,7 @@ static pmix_status_t _satisfy_request(pmix_nspace_t *nptr, pmix_rank_t rank,
 }
 
 /* Resolve pending requests to this namespace/rank */
-pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, pmix_rank_t rank,
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
                                    pmix_status_t status, pmix_dmdx_local_t *lcd)
 {
     pmix_dmdx_local_t *cd, *ptr;
@@ -761,7 +761,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
     pmix_rank_info_t *rinfo;
     int32_t cnt;
     pmix_kval_t *kv;
-    pmix_nspace_t *ns, *nptr;
+    pmix_namespace_t *ns, *nptr;
     pmix_status_t rc;
     pmix_list_t nspaces;
     pmix_nspace_caddy_t *nm;
@@ -779,7 +779,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
 
     /* find the nspace object for the proc whose data is being received */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(caddy->lcd->proc.nspace, ns->nspace)) {
             nptr = ns;
             break;
@@ -790,7 +790,7 @@ static void _process_dmdx_reply(int fd, short args, void *cbdata)
         /* We may not have this namespace because there are no local
          * processes from it running on this host - so just record it
          * so we know we have the data for any future requests */
-        nptr = PMIX_NEW(pmix_nspace_t);
+        nptr = PMIX_NEW(pmix_namespace_t);
         nptr->nspace = strdup(caddy->lcd->proc.nspace);
         /* add to the list */
         pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -143,7 +143,7 @@ pmix_status_t pmix_server_commit(pmix_peer_t *peer, pmix_buffer_t *buf)
     pmix_buffer_t b2, pbkt;
     pmix_kval_t *kp;
     pmix_scope_t scope;
-    pmix_nspace_t *nptr;
+    pmix_namespace_t *nptr;
     pmix_rank_info_t *info;
     pmix_proc_t proc;
     pmix_dmdx_remote_t *dcd, *dcdnext;
@@ -365,7 +365,7 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
     pmix_server_trkr_t *trk;
     size_t i;
     bool all_def;
-    pmix_nspace_t *nptr, *ns;
+    pmix_namespace_t *nptr, *ns;
     pmix_rank_info_t *info;
 
     pmix_output_verbose(5, pmix_globals.debug_output,
@@ -406,7 +406,7 @@ static pmix_server_trkr_t* new_tracker(pmix_proc_t *procs,
         }
         /* is this nspace known to us? */
         nptr = NULL;
-        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_nspace_t) {
+        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
             if (0 == strcmp(procs[i].nspace, ns->nspace)) {
                 nptr = ns;
                 break;
@@ -1318,9 +1318,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
 
     /* check the directives */
     for (n=0; n < ninfo; n++) {
-        if (0 == strncmp(info[n].key, PMIX_EVENT_ENVIRO_LEVEL, PMIX_MAX_KEYLEN)) {
-            enviro_events = PMIX_INFO_TRUE(&info[n]);
-        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
             if (NULL != affected) {
                 PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
                 rc = PMIX_ERR_BAD_PARAM;
@@ -1338,6 +1336,14 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
             naffected = info[n].value.data.darray->size;
             PMIX_PROC_CREATE(affected, naffected);
             memcpy(affected, info[n].value.data.darray->array, naffected * sizeof(pmix_proc_t));
+        }
+    }
+
+    /* check the codes for system events */
+    for (n=0; n < ncodes; n++) {
+        if (PMIX_SYSTEM_EVENT(codes[n])) {
+            enviro_events = true;
+            break;
         }
     }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.
@@ -99,7 +99,7 @@ typedef struct {
 PMIX_CLASS_DECLARATION(pmix_regevents_info_t);
 
 typedef struct {
-    pmix_list_t nspaces;                    // list of pmix_nspace_t for the nspaces we know about
+    pmix_list_t nspaces;                    // list of pmix_namespace_t for the nspaces we know about
     pmix_pointer_array_t clients;           // array of pmix_peer_t local clients
     pmix_list_t collectives;                // list of active pmix_server_trkr_t
     pmix_list_t remote_pnd;                 // list of pmix_dmdx_remote_t awaiting arrival of data fror servicing remote req's
@@ -135,8 +135,8 @@ typedef struct {
 
 bool pmix_server_trk_update(pmix_server_trkr_t *trk);
 
-void pmix_pending_nspace_requests(pmix_nspace_t *nptr);
-pmix_status_t pmix_pending_resolve(pmix_nspace_t *nptr, pmix_rank_t rank,
+void pmix_pending_nspace_requests(pmix_namespace_t *nptr);
+pmix_status_t pmix_pending_resolve(pmix_namespace_t *nptr, pmix_rank_t rank,
                                    pmix_status_t status, pmix_dmdx_local_t *lcd);
 
 

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -229,7 +229,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     PMIX_CONSTRUCT(&pmix_client_globals.peers, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_client_globals.peers, 1, INT_MAX, 1);
     pmix_client_globals.myserver = PMIX_NEW(pmix_peer_t);
-    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_nspace_t);
+    pmix_client_globals.myserver->nptr = PMIX_NEW(pmix_namespace_t);
 
     pmix_output_verbose(2, pmix_globals.debug_output,
                         "pmix: init called");


### PR DESCRIPTION
Mostly small addition/deletion of constants and attributes. From a code base standpoint, the biggest change was globally renaming the internal pmix_nspace_t object to pmix_namespace_t to resolve the conflict with the new user-facing structure type.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>