### PR TITLE
Further cleanup use of strncpy

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -754,7 +754,7 @@ typedef uint8_t pmix_alloc_directive_t;
 #define PMIX_LOAD_NSPACE(a, b)                      \
     do {                                            \
         memset((a), 0, PMIX_MAX_NSLEN+1);           \
-        (void)strncpy((a), (b), PMIX_MAX_NSLEN);    \
+        pmix_strncpy((a), (b), PMIX_MAX_NSLEN);     \
     }while(0)
 
 /* define a convenience macro for checking nspaces */
@@ -1104,14 +1104,19 @@ struct pmix_info_t {
         }                                       \
     } while (0)
 
-#define PMIX_INFO_LOAD(m, k, v, t)                      \
-    do {                                                \
-        (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);  \
-        pmix_value_load(&((m)->value), (v), (t));       \
+#define PMIX_INFO_LOAD(m, k, v, t)                          \
+    do {                                                    \
+        if (NULL != (k)) {                                  \
+            pmix_strncpy((m)->key, (k), PMIX_MAX_KEYLEN);   \
+        }                                                   \
+        (m)->flags = 0;                                     \
+        pmix_value_load(&((m)->value), (v), (t));           \
     } while (0)
 #define PMIX_INFO_XFER(d, s)                                        \
     do {                                                            \
-        (void)strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);         \
+        if (NULL != (s)->key) {                                     \
+            pmix_strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);      \
+        }                                                           \
         (d)->flags = (s)->flags;                                    \
         pmix_value_xfer(&(d)->value, (pmix_value_t*)&(s)->value);   \
     } while(0)
@@ -1202,9 +1207,9 @@ typedef struct pmix_pdata {
     do {                                                                    \
         if (NULL != (m)) {                                                  \
             memset((m), 0, sizeof(pmix_pdata_t));                           \
-            (void)strncpy((m)->proc.nspace, (p)->nspace, PMIX_MAX_NSLEN);   \
+            pmix_strncpy((m)->proc.nspace, (p)->nspace, PMIX_MAX_NSLEN);    \
             (m)->proc.rank = (p)->rank;                                     \
-            (void)strncpy((m)->key, (k), PMIX_MAX_KEYLEN);                  \
+            pmix_strncpy((m)->key, (k), PMIX_MAX_KEYLEN);                   \
             pmix_value_load(&((m)->value), (v), (t));                       \
         }                                                                   \
     } while (0)
@@ -1213,9 +1218,9 @@ typedef struct pmix_pdata {
     do {                                                                        \
         if (NULL != (d)) {                                                      \
             memset((d), 0, sizeof(pmix_pdata_t));                               \
-            (void)strncpy((d)->proc.nspace, (s)->proc.nspace, PMIX_MAX_NSLEN);  \
+            pmix_strncpy((d)->proc.nspace, (s)->proc.nspace, PMIX_MAX_NSLEN);   \
             (d)->proc.rank = (s)->proc.rank;                                    \
-            (void)strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);                 \
+            pmix_strncpy((d)->key, (s)->key, PMIX_MAX_KEYLEN);                  \
             pmix_value_xfer(&((d)->value), &((s)->value));                      \
         }                                                                       \
     } while (0)

--- a/src/include/pmix_config_bottom.h
+++ b/src/include/pmix_config_bottom.h
@@ -13,7 +13,7 @@
  * Copyright (c) 2009-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2013      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -561,4 +561,5 @@ typedef PMIX_PTRDIFF_TYPE ptrdiff_t;
 #undef HAVE_CONFIG_H
 
 #endif /* PMIX_BUILDING */
+
 #endif /* PMIX_CONFIG_BOTTOM_H */

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
@@ -53,37 +53,37 @@ static void set_namespace(int nprocs, char *ranks, char *name)
     char *regex, *ppn;
 
     PMIX_INFO_CREATE(info, ninfo);
-    (void)strncpy(info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[0].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
     info[0].value.type = PMIX_UINT32;
     info[0].value.data.uint32 = nprocs;
 
-    (void)strncpy(info[1].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[1].key, PMIX_SPAWNED, PMIX_MAX_KEYLEN);
     info[1].value.type = PMIX_UINT32;
     info[1].value.data.uint32 = 0;
 
-    (void)strncpy(info[2].key, PMIX_LOCAL_SIZE, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[2].key, PMIX_LOCAL_SIZE, PMIX_MAX_KEYLEN);
     info[2].value.type = PMIX_UINT32;
     info[2].value.data.uint32 = nprocs;
 
-    (void)strncpy(info[3].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[3].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
     info[3].value.type = PMIX_STRING;
     info[3].value.data.string = strdup(ranks);
 
     PMIx_generate_regex(NODE_NAME, &regex);
-    (void)strncpy(info[4].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[4].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
     info[4].value.type = PMIX_STRING;
     info[4].value.data.string = regex;
 
     PMIx_generate_ppn(ranks, &ppn);
-    (void)strncpy(info[5].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[5].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
     info[5].value.type = PMIX_STRING;
     info[5].value.data.string = ppn;
 
-    (void)strncpy(info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[6].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
     info[6].value.type = PMIX_UINT32;
     info[6].value.data.uint32 = nprocs;
 
-    (void)strncpy(info[7].key, PMIX_APPNUM, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info[7].key, PMIX_APPNUM, PMIX_MAX_KEYLEN);
     info[7].value.type = PMIX_UINT32;
     info[7].value.data.uint32 = getpid ();
 


### PR DESCRIPTION
Replace some further use of strncpy with pmix_strncpy. Also add a little
more protection to PMIx_Init so that a failure to init in a prior call
will return an error on subsequent calls without going thru init again
as we don't completely cleanup on failure.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit b2c61fbff6d0fb3c255806544e628d550db17e6c)