### PR TITLE
Protect PMIx from bad configure entry

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -24,6 +24,8 @@ AC_DEFUN([PMIX_HWLOC_CONFIG],[
                                 [Search for hwloc libraries in DIR ])])
 
     pmix_hwloc_support=0
+    AS_IF([test "$with_hwloc" = "internal" || test "$with_hwloc" = "external"],
+          [with_hwloc=])
 
     if test "$with_hwloc" != "no"; then
         AC_MSG_CHECKING([for hwloc in])


### PR DESCRIPTION
Ignore with-hwloc=internal or external as those are meaningless to pmix

Signed-off-by: Ralph Castain <rhc@open-mpi.org>