### PR TITLE
Complete indirect launch via debugger/tool

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -56,9 +56,9 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
         !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         pmix_output_verbose(2, pmix_server_globals.event_output,
-                            "pmix_server_notify_event source = %s:%d event_status = %d",
+                            "pmix_server_notify_event source = %s:%d event_status = %s",
                             (NULL == source) ? "UNKNOWN" : source->nspace,
-                            (NULL == source) ? PMIX_RANK_WILDCARD : source->rank, status);
+                            (NULL == source) ? PMIX_RANK_WILDCARD : source->rank, PMIx_Error_string(status));
         rc = pmix_server_notify_client_of_event(status, source, range,
                                                 info, ninfo,
                                                 cbfunc, cbdata);

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -198,9 +198,11 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_sr_t,
 
 static void pccon(pmix_pending_connection_t *p)
 {
+    p->need_id = false;
     memset(p->nspace, 0, PMIX_MAX_NSLEN+1);
     p->info = NULL;
     p->ninfo = 0;
+    p->peer = NULL;
     p->bfrops = NULL;
     p->psec = NULL;
     p->gds = NULL;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -81,8 +81,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     }
     CLOSE_THE_SOCKET(peer->sd);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
-        !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
          * we properly account for the loss of this client
          * from any local collectives in which it was
@@ -130,7 +129,9 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
             }
         }
         /* reduce the number of local procs */
-        --peer->nptr->nlocalprocs;
+        if (0 < peer->nptr->nlocalprocs) {
+            --peer->nptr->nlocalprocs;
+        }
 
         /* remove this client from our array */
         pmix_pointer_array_set_item(&pmix_server_globals.clients,
@@ -149,8 +150,10 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 }
             }
         }
-        /* cleanup any sensors that are monitoring them */
-        pmix_psensor.stop(peer, NULL);
+        if (!PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+            /* cleanup any sensors that are monitoring them */
+            pmix_psensor.stop(peer, NULL);
+        }
 
         if (!peer->finalized && !PMIX_PROC_IS_TOOL(peer)) {
             /* if this peer already called finalize, then

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -63,15 +63,16 @@ struct pmix_ptl_module_t;
 
 /* define a process type */
 typedef uint16_t pmix_proc_type_t;
+
 #define PMIX_PROC_UNDEF             0x0000
-#define PMIX_PROC_CLIENT            0x0001
-#define PMIX_PROC_SERVER            0x0002
-#define PMIX_PROC_TOOL              0x0004
-#define PMIX_PROC_V1                0x0008
-#define PMIX_PROC_V20               0x0010
-#define PMIX_PROC_V21               0x0020
-#define PMIX_PROC_V3                0x0040
-#define PMIX_PROC_LAUNCHER_ACT      0x1000
+#define PMIX_PROC_CLIENT            0x0001      // simple client process
+#define PMIX_PROC_SERVER            0x0002      // simple server process
+#define PMIX_PROC_TOOL              0x0004      // simple tool
+#define PMIX_PROC_V1                0x0008      // process is using PMIx v1 protocols
+#define PMIX_PROC_V20               0x0010      // process is using PMIx v2.0 protocols
+#define PMIX_PROC_V21               0x0020      // process is using PMIx v2.1 protocols
+#define PMIX_PROC_V3                0x0040      // process is using PMIx v3 protocols
+#define PMIX_PROC_LAUNCHER_ACT      0x1000      // process acting as launcher
 #define PMIX_PROC_LAUNCHER          (PMIX_PROC_TOOL | PMIX_PROC_SERVER | PMIX_PROC_LAUNCHER_ACT)
 #define PMIX_PROC_CLIENT_TOOL_ACT   0x2000
 #define PMIX_PROC_CLIENT_TOOL       (PMIX_PROC_TOOL | PMIX_PROC_CLIENT | PMIX_PROC_CLIENT_TOOL_ACT)
@@ -196,11 +197,13 @@ typedef struct {
     pmix_event_t ev;
     pmix_listener_protocol_t protocol;
     int sd;
+    bool need_id;
     char nspace[PMIX_MAX_NSLEN+1];
     pmix_info_t *info;
     size_t ninfo;
     pmix_status_t status;
     struct sockaddr_storage addr;
+    struct pmix_peer_t *peer;
     char *bfrops;
     char *psec;
     char *gds;
@@ -236,9 +239,6 @@ PMIX_EXPORT extern int pmix_ptl_base_output;
 
 #define PMIX_ACTIVATE_POST_MSG(ms)                                      \
     do {                                                                \
-        pmix_output_verbose(5, pmix_ptl_base_output,                    \
-                            "[%s:%d] post msg",                         \
-                            __FILE__, __LINE__);                        \
         pmix_event_assign(&((ms)->ev), pmix_globals.evbase, -1,         \
                           EV_WRITE, pmix_ptl_base_process_msg, (ms));   \
         PMIX_POST_OBJECT(ms);                                           \

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -77,8 +77,8 @@ pmix_ptl_module_t pmix_ptl_tcp_module = {
     .connect_to_peer = connect_to_peer
 };
 
-static pmix_status_t recv_connect_ack(int sd);
-static pmix_status_t send_connect_ack(int sd);
+static pmix_status_t recv_connect_ack(int sd, uint8_t myflag);
+static pmix_status_t send_connect_ack(int sd, uint8_t *myflag, pmix_info_t info[], size_t ninfo);
 
 
 static pmix_status_t init(void)
@@ -109,8 +109,9 @@ static pmix_status_t parse_uri_file(char *filename,
                                     char **uri,
                                     char **nspace,
                                     pmix_rank_t *rank);
-static pmix_status_t try_connect(char *uri, int *sd);
+static pmix_status_t try_connect(char *uri, int *sd, pmix_info_t info[], size_t ninfo);
 static pmix_status_t df_search(char *dirname, char *prefix,
+                               pmix_info_t info[], size_t ninfo,
                                int *sd, char **nspace,
                                pmix_rank_t *rank);
 
@@ -128,6 +129,10 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     bool system_level_only = false;
     bool reconnect = false;
     pid_t pid = 0;
+    pmix_list_t ilist;
+    pmix_info_caddy_t *kv;
+    pmix_info_t *iptr = NULL;
+    size_t niptr = 0;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tcp: connecting to server");
@@ -205,7 +210,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                             "ptl:tcp:client attempt connect to %s", uri[1]);
 
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(uri[1], &sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(uri[1], &sd, info, ninfo))) {
             free(nspace);
             pmix_argv_free(uri);
             return rc;
@@ -219,6 +224,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
      * to see where they want us to connect to */
     suri = NULL;
     if (NULL != info) {
+        PMIX_CONSTRUCT(&ilist, pmix_list_t);
         for (n=0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_TO_SYSTEM)) {
                 system_level_only = PMIX_INFO_TRUE(&info[n]);
@@ -271,9 +277,26 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                 reconnect = true;
             } else if (PMIX_CHECK_KEY(&info[n], PMIX_LAUNCHER_RENDEZVOUS_FILE)) {
                 rendfile = strdup(info[n].value.data.string);
+            } else {
+                /* need to pass this to server */
+                kv = PMIX_NEW(pmix_info_caddy_t);
+                kv->info = &info[n];
+                pmix_list_append(&ilist, &kv->super);
             }
         }
     }
+    /* if we need to pass anything, setup an array */
+    if (0 < (niptr = pmix_list_get_size(&ilist))) {
+        PMIX_INFO_CREATE(iptr, niptr);
+        n = 0;
+        while (NULL != (kv = (pmix_info_caddy_t*)pmix_list_remove_first(&ilist))) {
+            PMIX_INFO_XFER(&iptr[n], kv->info);
+            PMIX_RELEASE(kv);
+            ++n;
+        }
+    }
+    PMIX_LIST_DESTRUCT(&ilist);
+
     if (NULL == suri && !reconnect && NULL != mca_ptl_tcp_component.super.uri) {
         suri = strdup(mca_ptl_tcp_component.super.uri);
     }
@@ -299,6 +322,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                 if (NULL != rendfile) {
                     free(rendfile);
                 }
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 return PMIX_ERR_UNREACH;
             }
             free(suri);
@@ -310,6 +336,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                 free(suri);
                 if (NULL != rendfile) {
                     free(rendfile);
+                }
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
                 }
                 return PMIX_ERR_BAD_PARAM;
             }
@@ -325,6 +354,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                 if (NULL != rendfile) {
                     free(rendfile);
                 }
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 return PMIX_ERR_BAD_PARAM;
             }
             *p = '\0';
@@ -338,7 +370,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "ptl:tcp:tool attempt connect using given URI %s", suri);
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(suri, &sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(suri, &sd, iptr, niptr))) {
             if (NULL != nspace) {
                 free(nspace);
             }
@@ -346,12 +378,18 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             if (NULL != rendfile) {
                 free(rendfile);
             }
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return rc;
         }
         free(suri);
         suri = NULL;
         if (NULL != rendfile) {
             free(rendfile);
+        }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
         }
         goto complete;
     }
@@ -366,10 +404,13 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "ptl:tcp:tool attempt connect to system server at %s", suri);
             /* go ahead and try to connect */
-            if (PMIX_SUCCESS == try_connect(suri, &sd)) {
+            if (PMIX_SUCCESS == try_connect(suri, &sd, iptr, niptr)) {
                 /* don't free nspace - we will use it below */
                 if (NULL != rendfile) {
                     free(rendfile);
+                }
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
                 }
                 goto complete;
             }
@@ -381,6 +422,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             free(suri);
         }
         free(rendfile);
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         /* since they gave us a specific rendfile and we couldn't
          * connect to it, return an error */
         return PMIX_ERR_UNREACH;
@@ -393,6 +437,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             server_nspace = NULL;
         }
         if (0 > asprintf(&filename, "pmix.%s.tool.%d", myhost, pid)) {
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return PMIX_ERR_NOMEM;
         }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -400,13 +447,16 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                             filename);
         nspace = NULL;
         rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                       filename, &sd, &nspace, &rank);
+                       filename, iptr, niptr, &sd, &nspace, &rank);
         free(filename);
         if (PMIX_SUCCESS == rc) {
             goto complete;
         }
         if (NULL != nspace) {
             free(nspace);
+        }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
         }
         /* since they gave us a specific pid and we couldn't
          * connect to it, return an error */
@@ -417,6 +467,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     if (NULL != server_nspace) {
         if (0 > asprintf(&filename, "pmix.%s.tool.%s", myhost, server_nspace)) {
             free(server_nspace);
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return PMIX_ERR_NOMEM;
         }
         free(server_nspace);
@@ -426,13 +479,16 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                             filename);
         nspace = NULL;
         rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                       filename, &sd, &nspace, &rank);
+                       filename, iptr, niptr, &sd, &nspace, &rank);
         free(filename);
         if (PMIX_SUCCESS == rc) {
             goto complete;
         }
         if (NULL != nspace) {
             free(nspace);
+        }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
         }
         /* since they gave us a specific nspace and we couldn't
          * connect to it, return an error */
@@ -442,6 +498,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     /* if they asked for system-level, we start there */
     if (system_level || system_level_only) {
         if (0 > asprintf(&filename, "%s/pmix.sys.%s", mca_ptl_tcp_component.system_tmpdir, myhost)) {
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return PMIX_ERR_NOMEM;
         }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -454,8 +513,11 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "ptl:tcp:tool attempt connect to system server at %s", suri);
             /* go ahead and try to connect */
-            if (PMIX_SUCCESS == try_connect(suri, &sd)) {
+            if (PMIX_SUCCESS == try_connect(suri, &sd, iptr, niptr)) {
                 /* don't free nspace - we will use it below */
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
                 goto complete;
             }
             free(nspace);
@@ -471,6 +533,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         return PMIX_ERR_UNREACH;
     }
 
@@ -483,6 +548,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         return PMIX_ERR_NOMEM;
     }
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -490,7 +558,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                         filename);
     nspace = NULL;
     rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                   filename, &sd, &nspace, &rank);
+                   filename, iptr, niptr, &sd, &nspace, &rank);
     free(filename);
     if (PMIX_SUCCESS != rc) {
         if (NULL != nspace){
@@ -499,12 +567,18 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         return PMIX_ERR_UNREACH;
+    }
+    if (NULL != iptr) {
+        PMIX_INFO_FREE(iptr, niptr);
     }
 
   complete:
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "sock_peer_try_connect: Connection across to server succeeded");
+                        "tcp_peer_try_connect: Connection across to server succeeded");
 
     /* do a final bozo check */
     if (NULL == nspace || PMIX_RANK_WILDCARD == rank) {
@@ -733,7 +807,7 @@ static pmix_status_t parse_uri_file(char *filename,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t try_connect(char *uri, int *sd)
+static pmix_status_t try_connect(char *uri, int *sd, pmix_info_t iptr[], size_t niptr)
 {
     char *p, *p2, *host;
     struct sockaddr_in *in;
@@ -741,6 +815,7 @@ static pmix_status_t try_connect(char *uri, int *sd)
     size_t len;
     pmix_status_t rc;
     bool retried = false;
+    uint8_t myflag;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:tcp try connect to %s", uri);
@@ -824,14 +899,14 @@ static pmix_status_t try_connect(char *uri, int *sd)
     }
 
     /* send our identity and any authentication credentials to the server */
-    if (PMIX_SUCCESS != (rc = send_connect_ack(*sd))) {
+    if (PMIX_SUCCESS != (rc = send_connect_ack(*sd, &myflag, iptr, niptr))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(*sd);
         return rc;
     }
 
     /* do whatever handshake is required */
-    if (PMIX_SUCCESS != (rc = recv_connect_ack(*sd))) {
+    if (PMIX_SUCCESS != (rc = recv_connect_ack(*sd, myflag))) {
         CLOSE_THE_SOCKET(*sd);
         if (PMIX_ERR_TEMP_UNAVAILABLE == rc) {
             /* give it two tries */
@@ -846,7 +921,8 @@ static pmix_status_t try_connect(char *uri, int *sd)
 
     return PMIX_SUCCESS;
 }
-static pmix_status_t send_connect_ack(int sd)
+static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
+                                      pmix_info_t iptr[], size_t niptr)
 {
     char *msg;
     pmix_ptl_hdr_t hdr;
@@ -859,7 +935,7 @@ static pmix_status_t send_connect_ack(int sd)
     uid_t euid;
     gid_t egid;
     uint32_t u32;
-    bool self_defined = false;
+    pmix_buffer_t buf;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:tcp SEND CONNECT ACK");
@@ -867,6 +943,7 @@ static pmix_status_t send_connect_ack(int sd)
     /* if we are a server, then we shouldn't be here */
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -890,35 +967,66 @@ static pmix_status_t send_connect_ack(int sd)
     /* allow space for a marker indicating client vs tool */
     sdsize = 1;
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    /* Defined marker values:
+     *
+     * 0 => simple client process
+     * 1 => legacy tool - may or may not have an identifier
+     * 2 => legacy launcher - may or may not have an identifier
+     * ------------------------------------------
+     * 3 => self-started tool process that needs an identifier
+     * 4 => self-started tool process that was given an identifier by caller
+     * 5 => tool that was started by a PMIx server - identifier specified by server
+     * 6 => self-started launcher that needs an identifier
+     * 7 => self-started launcher that was given an identifier by caller
+     * 8 => launcher that was started by a PMIx server - identifier specified by server
+     */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+            /* if we are both launcher and client, then we need
+             * to tell the server we are both */
+            flag = 8;
+            /* add space for our uid/gid for ACL purposes */
+            sdsize += 2*sizeof(uint32_t);
+            /* add space for our identifier */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+        } else {
+            /* add space for our uid/gid for ACL purposes */
+            sdsize += 2*sizeof(uint32_t);
+            /* if they gave us an identifier, we need to pass it */
+            if (0 < strlen(pmix_globals.myid.nspace) &&
+                PMIX_RANK_INVALID != pmix_globals.myid.rank) {
+                flag = 7;
+                sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            } else {
+                flag = 6;
+            }
+        }
+
+    } else if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
         flag = 0;
         /* reserve space for our nspace and rank info */
         sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-    } else if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
-        flag = 2;
-        /* add space for our uid/gid for ACL purposes */
-        sdsize += 2*sizeof(uint32_t);
-        /* if we already have an identifier, we need to pass it */
-        if (0 < strlen(pmix_globals.myid.nspace) &&
-            PMIX_RANK_INVALID != pmix_globals.myid.rank) {
-            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t) + 1;
-            self_defined = true;
-        } else {
-            ++sdsize; // need space for the flag indicating if have id
-        }
+
     } else {  // must be a simple tool
-        flag = 1;
         /* add space for our uid/gid for ACL purposes */
         sdsize += 2*sizeof(uint32_t);
-        /* if we self-defined an identifier, we need to pass it */
-        if (0 < strlen(pmix_globals.myid.nspace) &&
+        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+            /* if we are both tool and client, then we need
+             * to tell the server we are both */
+            flag = 5;
+            /* add space for our identifier */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+        } else if (0 < strlen(pmix_globals.myid.nspace) &&
             PMIX_RANK_INVALID != pmix_globals.myid.rank) {
-            sdsize += 1 + strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-            self_defined = true;
+            /* we were given an identifier by the caller, pass it */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            flag = 4;
         } else {
-            ++sdsize; // need space for the flag indicating if have id
+            /* we are a self-started tool that needs an identifier */
+            flag = 3;
         }
     }
+    *myflag = flag;
 
     /* add the name of our active sec module - we selected it
      * in pmix_client.c prior to entering here */
@@ -932,16 +1040,26 @@ static pmix_status_t send_connect_ack(int sd)
     /* add our active gds module for working with the server */
     gds = (char*)pmix_client_globals.myserver->nptr->compat.gds->name;
 
-    /* set the number of bytes to be read beyond the header */
+    /* if we were given info structs to pass to the server, pack them */
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    if (NULL != iptr) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &niptr, 1, PMIX_SIZE);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, iptr, niptr, PMIX_INFO);
+    }
+
+    /* set the number of bytes to be read beyond the header - must
+     * NULL terminate the strings! */
     hdr.nbytes = sdsize + strlen(PMIX_VERSION) + 1 + strlen(sec) + 1 \
                 + strlen(bfrops) + 1 + sizeof(bftype) \
-                + strlen(gds) + 1 + sizeof(uint32_t) + cred.size;  // must NULL terminate the strings!
+                + strlen(gds) + 1 + sizeof(uint32_t) + cred.size \
+                + buf.bytes_used;
 
     /* create a space for our message */
     sdsize = (sizeof(hdr) + hdr.nbytes);
     if (NULL == (msg = (char*)malloc(sdsize))) {
         PMIX_BYTE_OBJECT_DESTRUCT(&cred);
         free(sec);
+        PMIX_DESTRUCT(&buf);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
     memset(msg, 0, sdsize);
@@ -973,7 +1091,7 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, &flag, 1);
     csize += 1;
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (0 == flag) {
         /* if we are a client, provide our nspace/rank */
         memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
         csize += strlen(pmix_globals.myid.nspace)+1;
@@ -981,9 +1099,8 @@ static pmix_status_t send_connect_ack(int sd)
         u32 = htonl((uint32_t)pmix_globals.myid.rank);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
         csize += sizeof(uint32_t);
-    } else {
-        /* if we are a tool, provide our uid/gid for ACL support - note
-         * that we have to convert so we can handle heterogeneity */
+    } else if (3 == flag || 6 == flag) {
+        /* we are a tool or launcher that needs an identifier - add our ACLs */
         euid = geteuid();
         u32 = htonl(euid);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
@@ -992,6 +1109,27 @@ static pmix_status_t send_connect_ack(int sd)
         u32 = htonl(egid);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
         csize += sizeof(uint32_t);
+    } else if (4 == flag || 5 == flag || 7 == flag || 8 == flag) {
+        /* we are a tool or launcher that has an identifier - start with our ACLs */
+        euid = geteuid();
+        u32 = htonl(euid);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+        egid = getegid();
+        u32 = htonl(egid);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+        /* now add our identifier */
+        memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
+        csize += strlen(pmix_globals.myid.nspace)+1;
+        /* again, need to convert */
+        u32 = htonl((uint32_t)pmix_globals.myid.rank);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+    } else {
+        /* not a valid flag */
+        PMIX_DESTRUCT(&buf);
+        return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* provide our version */
@@ -1010,46 +1148,33 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, gds, strlen(gds));
     csize += strlen(gds)+1;
 
-    /* if we are not a client and self-defined an identifier, we need to pass it */
-    if (!PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
-        if (self_defined) {
-            flag = 1;
-            memcpy(msg+csize, &flag, 1);
-            ++csize;
-            memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
-            csize += strlen(pmix_globals.myid.nspace)+1;
-            /* again, need to convert */
-            u32 = htonl((uint32_t)pmix_globals.myid.rank);
-            memcpy(msg+csize, &u32, sizeof(uint32_t));
-            csize += sizeof(uint32_t);
-        } else {
-            flag = 0;
-            memcpy(msg+csize, &flag, 1);
-            ++csize;
-        }
-    }
+    /* provide the info struct bytes */
+    memcpy(msg+csize, buf.base_ptr, buf.bytes_used);
+    csize += buf.bytes_used;
 
     /* send the entire message across */
     if (PMIX_SUCCESS != pmix_ptl_base_send_blocking(sd, msg, sdsize)) {
         free(msg);
+        PMIX_DESTRUCT(&buf);
         return PMIX_ERR_UNREACH;
     }
     free(msg);
+    PMIX_DESTRUCT(&buf);
     return PMIX_SUCCESS;
 }
 
 /* we receive a connection acknowledgement from the server,
  * consisting of nothing more than a status report. If success,
  * then we initiate authentication method */
-static pmix_status_t recv_connect_ack(int sd)
+static pmix_status_t recv_connect_ack(int sd, uint8_t myflag)
 {
     pmix_status_t reply;
     pmix_status_t rc;
     struct timeval tv, save;
     pmix_socklen_t sz;
     bool sockopt = true;
+    pmix_nspace_t nspace;
     uint32_t u32;
-    char nspace[PMIX_MAX_NSLEN+1];
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix: RECV CONNECT ACK FROM SERVER");
@@ -1086,7 +1211,7 @@ static pmix_status_t recv_connect_ack(int sd)
     }
     reply = ntohl(u32);
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (0 == myflag) {
         /* see if they want us to do the handshake */
         if (PMIX_ERR_READY_FOR_HANDSHAKE == reply) {
             PMIX_PSEC_CLIENT_HANDSHAKE(rc, pmix_client_globals.myserver, sd);
@@ -1111,23 +1236,21 @@ static pmix_status_t recv_connect_ack(int sd)
             PMIX_ERROR_LOG(reply);
             return reply;
         }
-        /* recv our nspace */
-        rc = pmix_ptl_base_recv_blocking(sd, nspace, PMIX_MAX_NSLEN+1);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-        /* if we already have our nspace, then just verify it matches */
-        if (0 < strlen(pmix_globals.myid.nspace)) {
-            if (0 != strncmp(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN)) {
-                return PMIX_ERR_INIT;
+        /* if we needed an identifier, recv it */
+        if (3 == myflag || 6 == myflag) {
+            /* first the nspace */
+            rc = pmix_ptl_base_recv_blocking(sd, (char*)&nspace, PMIX_MAX_NSLEN+1);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
             }
-        } else {
-            pmix_strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
-        }
-        /* if we already have a rank, then leave it alone */
-        if (PMIX_RANK_INVALID == pmix_globals.myid.rank) {
-            /* our rank is always zero */
-            pmix_globals.myid.rank = 0;
+            PMIX_LOAD_NSPACE(pmix_globals.myid.nspace, nspace);
+            /* now the rank */
+            rc = pmix_ptl_base_recv_blocking(sd, (char*)&u32, sizeof(uint32_t));
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            /* convert and store */
+            pmix_globals.myid.rank = htonl(u32);
         }
 
         /* get the server's nspace and rank so we can send to it */
@@ -1146,7 +1269,8 @@ static pmix_status_t recv_connect_ack(int sd)
             free(pmix_client_globals.myserver->info->pname.nspace);
         }
         pmix_client_globals.myserver->info->pname.nspace = strdup(nspace);
-        pmix_ptl_base_recv_blocking(sd, (char*)&(pmix_client_globals.myserver->info->pname.rank), sizeof(int));
+        pmix_ptl_base_recv_blocking(sd, (char*)&u32, sizeof(uint32_t));
+        pmix_client_globals.myserver->info->pname.rank = htonl(u32);
 
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "pmix: RECV CONNECT CONFIRMATION FOR TOOL %s:%d FROM SERVER %s:%d",
@@ -1180,6 +1304,7 @@ static pmix_status_t recv_connect_ack(int sd)
 }
 
 static pmix_status_t df_search(char *dirname, char *prefix,
+                               pmix_info_t info[], size_t ninfo,
                                int *sd, char **nspace,
                                pmix_rank_t *rank)
 {
@@ -1211,7 +1336,7 @@ static pmix_status_t df_search(char *dirname, char *prefix,
         }
         /* if it is a directory, down search */
         if (S_ISDIR(buf.st_mode)) {
-            rc = df_search(newdir, prefix, sd, nspace, rank);
+            rc = df_search(newdir, prefix, info, ninfo, sd, nspace, rank);
             free(newdir);
             if (PMIX_SUCCESS == rc) {
                 closedir(cur_dirp);
@@ -1231,7 +1356,7 @@ static pmix_status_t df_search(char *dirname, char *prefix,
                 /* go ahead and try to connect */
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "pmix:tcp: attempting to connect to %s", suri);
-                if (PMIX_SUCCESS == try_connect(suri, sd)) {
+                if (PMIX_SUCCESS == try_connect(suri, sd, info, ninfo)) {
                     (*nspace) = nsp;
                     *rank = rk;
                     closedir(cur_dirp);

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -955,6 +955,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_info_t ginfo;
     pmix_proc_type_t proc_type;
     pmix_byte_object_t cred;
+    pmix_buffer_t buf;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -1138,6 +1139,92 @@ static void connection_handler(int sd, short args, void *cbdata)
            rc = PMIX_ERR_BAD_PARAM;
            goto error;
         }
+    } else if (3 == flag || 6 == flag) {
+        /* they are a tool or launcher that needs an identifier */
+        if (3 == flag) {
+            proc_type = PMIX_PROC_TOOL;
+        } else {
+            proc_type = PMIX_PROC_LAUNCHER;
+        }
+        /* extract the uid/gid */
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->uid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->gid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        /* they need an id */
+        pnd->need_id = true;
+    } else if (4 == flag || 5 == flag || 7 == flag || 8 == flag) {
+        /* we are a tool or launcher that has an identifier - start with our ACLs */
+        if (4 == flag || 5 == flag) {
+            proc_type = PMIX_PROC_TOOL;
+        } else {
+            proc_type = PMIX_PROC_LAUNCHER;
+        }
+        /* extract the uid/gid */
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->uid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->gid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        PMIX_STRNLEN(msglen, mg, cnt);
+        if (msglen < cnt) {
+            nspace = mg;
+            mg += strlen(nspace) + 1;
+            cnt -= strlen(nspace) + 1;
+        } else {
+            free(msg);
+            /* send an error reply to the client */
+            rc = PMIX_ERR_BAD_PARAM;
+            goto error;
+        }
+
+        if (sizeof(pmix_rank_t) <= cnt) {
+            /* have to convert this to host order */
+            memcpy(&u32, mg, sizeof(uint32_t));
+            rank = ntohl(u32);
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+        } else {
+            free(msg);
+            /* send an error reply to the client */
+            rc = PMIX_ERR_BAD_PARAM;
+            goto error;
+        }
     } else {
         /* we don't know what they are! */
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
@@ -1223,63 +1310,94 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if this is a tool connection request */
     if (0 != flag) {
-        /* does the server support tool connections? */
-        if (NULL == pmix_host_server.tool_connected) {
-            /* send an error reply to the client */
-            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
-            rc = PMIX_ERR_NOT_SUPPORTED;
-            goto error;
+        peer = PMIX_NEW(pmix_peer_t);
+        if (NULL == peer) {
+            /* probably cannot send an error reply if we are out of memory */
+            free(msg);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd);
+            return;
         }
-
-        if (PMIX_PROC_V3 & proc_type) {
-            /* the caller will have provided a flag indicating
-             * whether or not they have an assigned nspace/rank */
-            if (cnt < 1) {
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                free(msg);
-                /* send an error reply to the client */
-                rc = PMIX_ERR_BAD_PARAM;
-                goto error;
+        pnd->peer = peer;
+        nptr = PMIX_NEW(pmix_namespace_t);
+        if (NULL == nptr) {
+            PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd);
+            PMIX_RELEASE(peer);
+            return;
+        }
+        peer->nptr = nptr;
+        /* select their bfrops compat module */
+        peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(bfrops);
+        if (NULL == peer->nptr->compat.bfrops) {
+            PMIX_RELEASE(peer);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd);
+            return;
+        }
+        /* set the buffer type */
+        peer->nptr->compat.type = bftype;
+        n = 0;
+        /* if info structs need to be passed along, then unpack them */
+        if (0 < cnt) {
+            int32_t foo;
+            PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+            PMIX_LOAD_BUFFER(peer, &buf, mg, cnt);
+            foo = 1;
+            PMIX_BFROPS_UNPACK(rc, peer, &buf, &pnd->ninfo, &foo, PMIX_SIZE);
+            foo = (int32_t)pnd->ninfo;
+            /* if we have an identifier, then we leave room to pass it */
+            if (!pnd->need_id) {
+                pnd->ninfo += 5;
+            } else {
+                pnd->ninfo += 3;
             }
-            memcpy(&flag, mg, 1);
-            ++mg;
-            --cnt;
-            if (flag) {
-                PMIX_STRNLEN(msglen, mg, cnt);
-                if (msglen < cnt) {
-                    nspace = mg;
-                    mg += strlen(nspace) + 1;
-                    cnt -= strlen(nspace) + 1;
-                } else {
-                    free(msg);
-                    /* send an error reply to the client */
-                    rc = PMIX_ERR_BAD_PARAM;
-                    goto error;
-                }
-                if (sizeof(pmix_rank_t) <= cnt) {
-                    /* have to convert this to host order */
-                    memcpy(&u32, mg, sizeof(uint32_t));
-                    rank = ntohl(u32);
-                    mg += sizeof(uint32_t);
-                    cnt -= sizeof(uint32_t);
-                } else {
-                    free(msg);
-                    /* send an error reply to the client */
-                    rc = PMIX_ERR_BAD_PARAM;
-                    goto error;
-                }
+            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+            PMIX_BFROPS_UNPACK(rc, peer, &buf, pnd->info, &foo, PMIX_INFO);
+            n = foo;
+        } else {
+            if (!pnd->need_id) {
                 pnd->ninfo = 5;
             } else {
                 pnd->ninfo = 3;
             }
-        } else {
-            pnd->ninfo = 3;
+            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+        }
+
+        /* pass along the proc_type */
+        pnd->proc_type = proc_type;
+        /* pass along the bfrop, buffer_type, and sec fields so
+         * we can assign them once we create a peer object */
+        pnd->psec = strdup(sec);
+        if (NULL != gds) {
+            pnd->gds = strdup(gds);
+        }
+
+        /* does the server support tool connections? */
+        if (NULL == pmix_host_server.tool_connected) {
+            if (pnd->need_id) {
+                /* we need someone to provide the tool with an
+                 * identifier and they aren't available */
+                /* send an error reply to the client */
+                PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
+                rc = PMIX_ERR_NOT_SUPPORTED;
+                PMIX_RELEASE(peer);
+                /* release the msg */
+                free(msg);
+                goto error;
+            } else {
+                /* just process it locally */
+                PMIX_LOAD_PROCID(&proc, nspace, rank);
+                cnct_cbfunc(PMIX_SUCCESS, &proc, (void*)pnd);
+                /* release the msg */
+                free(msg);
+                return;
+            }
         }
 
         /* setup the info array to pass the relevant info
          * to the server */
-        n = 0;
-        PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
         /* provide the version */
         PMIX_INFO_LOAD(&pnd->info[n], PMIX_VERSION_INFO, version, PMIX_STRING);
         ++n;
@@ -1290,29 +1408,16 @@ static void connection_handler(int sd, short args, void *cbdata)
         PMIX_INFO_LOAD(&pnd->info[n], PMIX_GRPID, &pnd->gid, PMIX_UINT32);
         ++n;
         /* if we have it, pass along our ID */
-        if (flag) {
+        if (!pnd->need_id) {
             PMIX_INFO_LOAD(&pnd->info[n], PMIX_NSPACE, nspace, PMIX_STRING);
             ++n;
             PMIX_INFO_LOAD(&pnd->info[n], PMIX_RANK, &rank, PMIX_PROC_RANK);
             ++n;
         }
-        /* pass along the proc_type */
-        pnd->proc_type = proc_type;
-        /* pass along the bfrop, buffer_type, and sec fields so
-         * we can assign them once we create a peer object */
-        pnd->psec = strdup(sec);
-        if (NULL != bfrops) {
-            pnd->bfrops = strdup(bfrops);
-        }
-        pnd->buffer_type = bftype;
-        if (NULL != gds) {
-            pnd->gds = strdup(gds);
-        }
         /* release the msg */
         free(msg);
-        /* request an nspace for this requestor - it will
-         * automatically be assigned rank=0 if the rank
-         * isn't already known */
+
+        /* pass it up for processing */
         pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);
         return;
     }
@@ -1544,6 +1649,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
@@ -1551,24 +1657,41 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
     /* if the request failed, then we are done */
     if (PMIX_SUCCESS != cd->status) {
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
     }
 
-    /* send the nspace back to the tool */
-    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN+1))) {
-        PMIX_ERROR_LOG(rc);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
+    /* if we got an identifier, send it back to the tool */
+    if (pnd->need_id) {
+        /* start with the nspace */
+        if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN+1))) {
+            PMIX_ERROR_LOG(rc);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd->peer);
+            PMIX_RELEASE(pnd);
+            PMIX_RELEASE(cd);
+            return;
+        }
+
+        /* now the rank, suitably converted */
+        u32 = ntohl(cd->proc.rank);
+        if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
+            PMIX_ERROR_LOG(rc);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd->peer);
+            PMIX_RELEASE(pnd);
+            PMIX_RELEASE(cd);
+            return;
+        }
     }
 
     /* send my nspace back to the tool */
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, pmix_globals.myid.nspace, PMIX_MAX_NSLEN+1))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
@@ -1579,20 +1702,17 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
     }
 
-    /* add this nspace to our pool */
-    nptr = PMIX_NEW(pmix_namespace_t);
-    if (NULL == nptr) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
-    }
+    /* shortcuts */
+    peer = (pmix_peer_t*)pnd->peer;
+    nptr = peer->nptr;
+
+    PMIX_RETAIN(nptr);
     nptr->nspace = strdup(cd->proc.nspace);
     pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
     /* add this tool rank to the nspace */
@@ -1600,6 +1720,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (NULL == info) {
         PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
@@ -1611,22 +1732,11 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     info->gid = pnd->gid;
     pmix_list_append(&nptr->ranks, &info->super);
 
-    /* setup a peer object for this tool */
-    peer = PMIX_NEW(pmix_peer_t);
-    if (NULL == peer) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
-    }
     /* mark the peer proc type */
     peer->proc_type = pnd->proc_type;
     /* save the protocol */
     peer->protocol = pnd->protocol;
     /* add in the nspace pointer */
-    PMIX_RETAIN(nptr);
-    peer->nptr = nptr;
     PMIX_RETAIN(info);
     peer->info = info;
     /* save the uid/gid */
@@ -1651,17 +1761,6 @@ static void process_cbfunc(int sd, short args, void *cbdata)
      * tool as we received this request via that channel, so simply
      * record it here for future use */
     peer->nptr->compat.ptl = &pmix_ptl_tcp_module;
-    /* select their bfrops compat module */
-    peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(pnd->bfrops);
-    if (NULL == peer->nptr->compat.bfrops) {
-        PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
-        PMIX_RELEASE(nptr);  // will release the info object
-        CLOSE_THE_SOCKET(pnd->sd);
-        goto done;
-    }
-    /* set the buffer type */
-    peer->nptr->compat.type = pnd->buffer_type;
     /* set the gds */
     PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, pnd->gds, PMIX_STRING);
     peer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2986,8 +2986,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         return rc;
     }
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "recvd pmix cmd %d from %s:%u",
-                        cmd, peer->info->pname.nspace, peer->info->pname.rank);
+                        "recvd pmix cmd %s from %s:%u",
+                        pmix_command_string(cmd), peer->info->pname.nspace, peer->info->pname.rank);
 
     if (PMIX_REQ_CMD == cmd) {
         reply = PMIX_NEW(pmix_buffer_t);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -327,7 +327,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                 /* they want us to forward our stdin to someone */
                 fwd_stdin = true;
             } else if (0 == strncmp(info[n].key, PMIX_LAUNCHER, PMIX_MAX_KEYLEN)) {
-                ptype = PMIX_PROC_LAUNCHER;
+                ptype |= PMIX_PROC_LAUNCHER;
             } else if (0 == strncmp(info[n].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
             } else if (0 == strncmp(info[n].key, PMIX_SYSTEM_TMPDIR, PMIX_MAX_KEYLEN)) {
@@ -406,7 +406,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
 
     /* if we are a launcher, then we also need to act as a server,
      * so setup the server-related structures here */
-    if (PMIX_PROC_LAUNCHER == ptype) {
+    if (PMIX_PROC_LAUNCHER_ACT & ptype) {
         if (PMIX_SUCCESS != (rc = pmix_server_initialize())) {
             PMIX_ERROR_LOG(rc);
             if (NULL != nspace) {
@@ -611,36 +611,14 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     pmix_globals.mypeer->info->pname.nspace = strdup(pmix_globals.myid.nspace);
     pmix_globals.mypeer->info->pname.rank = pmix_globals.myid.rank;
 
-    /* if we are acting as a client, then send a request for our
-     * job info - we do this as a non-blocking
-     * transaction because some systems cannot handle very large
-     * blocking operations and error out if we try them. */
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
-         req = PMIX_NEW(pmix_buffer_t);
-         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
-                          req, &cmd, 1, PMIX_COMMAND);
-         if (PMIX_SUCCESS != rc) {
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(req);
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return rc;
-        }
-        /* send to the server */
-        PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
-                           req, job_data, (void*)&cb);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return rc;
-        }
-        /* wait for the data to return */
-        PMIX_WAIT_THREAD(&cb.lock);
-        rc = cb.status;
-        PMIX_DESTRUCT(&cb);
-        if (PMIX_SUCCESS != rc) {
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return rc;
-        }
+    /* if we are acting as a server, then start listening */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        /* setup the wildcard recv for inbound messages from clients */
+        rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
+        rcv->tag = UINT32_MAX;
+        rcv->cbfunc = pmix_server_message_handler;
+        /* add it to the end of the list of recvs */
+        pmix_list_append(&pmix_ptl_globals.posted_recvs, &rcv->super);
     }
 
     /* setup IOF */
@@ -689,7 +667,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                                &stdinev.ev, fd,
                                PMIX_EV_READ,
                                pmix_iof_read_local_handler, &stdinev);
-            }                                                               \
+            }
             /* check to see if we want the stdin read event to be
              * active - we will always at least define the event,
              * but may delay its activation
@@ -722,7 +700,37 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     /* increment our init reference counter */
     pmix_globals.init_cntr++;
 
-    if (!PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    /* if we are acting as a client, then send a request for our
+     * job info - we do this as a non-blocking
+     * transaction because some systems cannot handle very large
+     * blocking operations and error out if we try them. */
+    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+         req = PMIX_NEW(pmix_buffer_t);
+         PMIX_BFROPS_PACK(rc, pmix_client_globals.myserver,
+                          req, &cmd, 1, PMIX_COMMAND);
+         if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_RELEASE(req);
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        /* send to the server */
+        PMIX_CONSTRUCT(&cb, pmix_cb_t);
+        PMIX_PTL_SEND_RECV(rc, pmix_client_globals.myserver,
+                           req, job_data, (void*)&cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        /* wait for the data to return */
+        PMIX_WAIT_THREAD(&cb.lock);
+        rc = cb.status;
+        PMIX_DESTRUCT(&cb);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+    } else {
         /* now finish the initialization by filling our local
          * datastore with typical job-related info. No point
          * in having the server generate these as we are
@@ -1035,13 +1043,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
 
     /* if we are acting as a server, then start listening */
     if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
-        /* setup the wildcard recv for inbound messages from clients */
-        rcv = PMIX_NEW(pmix_ptl_posted_recv_t);
-        rcv->tag = UINT32_MAX;
-        rcv->cbfunc = pmix_server_message_handler;
-        /* add it to the end of the list of recvs */
-        pmix_list_append(&pmix_ptl_globals.posted_recvs, &rcv->super);
-
         /* start listening for connections */
         if (PMIX_SUCCESS != pmix_ptl_base_start_listening(info, ninfo)) {
             pmix_show_help("help-pmix-server.txt", "listener-thread-start", true);
@@ -1169,7 +1170,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         (void)pmix_progress_thread_pause(NULL);
     }
 
-    PMIX_RELEASE(pmix_client_globals.myserver);
+//    PMIX_RELEASE(pmix_client_globals.myserver);
     PMIX_LIST_DESTRUCT(&pmix_client_globals.pending_requests);
     for (n=0; n < pmix_client_globals.peers.size; n++) {
         if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_client_globals.peers, n))) {


### PR DESCRIPTION
Debuggers can now launch prun, pass it directives, and then have it
launch its application.

Still need to resolve IOF from launcher thru debugger

Signed-off-by: Ralph Castain <rhc@open-mpi.org>