### PR TITLE
Allow for multiple children in the waitpid loop

### DIFF
--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -1166,7 +1166,7 @@ static void wait_signal_callback(int fd, short event, void *arg)
                     exit_code = status;
                 }
                 --wakeup;
-                return;
+                break;
             }
         }
     }


### PR DESCRIPTION
 - If we get 1 SIGCHLD for multiple children exiting at the same time,
   then the `simtest` will hang because it called `return` instead of
   `break`.

Signed-off-by: Joshua Hursey <jhursey@us.ibm.com>
(cherry picked from commit 33873f2bee1f262a107eae7f8ff5be158611530f)