### PR TITLE
Pull the gds locking up to server level to improve performance

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -325,6 +325,12 @@ static inline pmix_peer_t * _client_peer(pmix_common_dstore_ctx_t *ds_ctx);
 
 static inline int _my_client(const char *nspace, pmix_rank_t rank);
 
+static pmix_status_t _acquire_ns_lock_by_name(pmix_common_dstore_ctx_t *ds_ctx,
+                                              const char *nspace);
+
+static pmix_status_t _release_ns_lock_by_name(pmix_common_dstore_ctx_t *ds_ctx,
+                                              const char *nspace);
+
 static pmix_status_t _dstore_store_nolock(pmix_common_dstore_ctx_t *ds_ctx,
                                    ns_map_data_t *ns_map,
                                    pmix_rank_t rank,
@@ -662,6 +668,7 @@ static inline int _esh_session_tbl_add(pmix_common_dstore_ctx_t *ds_ctx, size_t 
 
     for(idx = 0; idx < size; idx ++) {
         if (0 == s_tbl[idx].in_use) {
+            s_tbl[idx].active_locks = 0;
             goto done;
         }
     }
@@ -2031,7 +2038,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store(pmix_common_dstore_ctx_t *ds_c
     }
 
     /* set exclusive lock */
-    rc = _ESH_LOCK(ds_ctx, ns_map->tbl_idx, wr_lock);
+    rc = _acquire_ns_lock_by_name(ds_ctx, proc->nspace);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto exit;
@@ -2044,7 +2051,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store(pmix_common_dstore_ctx_t *ds_c
     }
 
     /* unset lock */
-    rc = _ESH_LOCK(ds_ctx, ns_map->tbl_idx, wr_unlock);
+    rc = _release_ns_lock_by_name(ds_ctx, proc->nspace);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto exit;
@@ -2625,6 +2632,89 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank)
     return local;
 }
 
+static pmix_status_t _acquire_ns_lock_by_name(pmix_common_dstore_ctx_t *ds_ctx,
+                                              const char *nspace)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    ns_map_data_t *ns_map;
+    session_t *s_tbl;
+
+    if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, nspace))) {
+        rc = PMIX_ERROR;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    s_tbl = PMIX_VALUE_ARRAY_GET_BASE(ds_ctx->session_array, session_t);
+
+    if (0 == s_tbl[ns_map->tbl_idx].active_locks) {
+        rc = _ESH_LOCK(ds_ctx, ns_map->tbl_idx, wr_lock);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+    }
+
+    /*
+     * Maintain a reference count instead of a boolean 
+     * so we hang if someone misses an unlock.
+     */
+    s_tbl[ns_map->tbl_idx].active_locks++;
+
+    return PMIX_SUCCESS;
+}
+                                            
+
+PMIX_EXPORT pmix_status_t pmix_common_dstor_acquire_ns_lock(pmix_common_dstore_ctx_t *ds_ctx,
+                                                            struct pmix_namespace_t *nspace)
+{
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
+
+    return _acquire_ns_lock_by_name(ds_ctx, ns->nspace);
+}
+
+static pmix_status_t _release_ns_lock_by_name(pmix_common_dstore_ctx_t *ds_ctx,
+                                              const char *nspace)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    ns_map_data_t *ns_map;
+    session_t *s_tbl;
+
+    if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, nspace))) {
+        rc = PMIX_ERROR;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    s_tbl = PMIX_VALUE_ARRAY_GET_BASE(ds_ctx->session_array, session_t);
+    s_tbl[ns_map->tbl_idx].active_locks--;
+
+    if (0 == s_tbl[ns_map->tbl_idx].active_locks) {
+        rc = _ESH_LOCK(ds_ctx, ns_map->tbl_idx, wr_unlock);
+        if (PMIX_SUCCESS != rc) {
+            s_tbl[ns_map->tbl_idx].active_locks++;
+            PMIX_ERROR_LOG(rc);
+            return rc;
+        }
+    }
+    else if (0 > s_tbl[ns_map->tbl_idx].active_locks) {
+        s_tbl[ns_map->tbl_idx].active_locks++;
+        rc = PMIX_ERROR;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
+    return PMIX_SUCCESS;
+}
+
+PMIX_EXPORT pmix_status_t pmix_common_dstor_release_ns_lock(pmix_common_dstore_ctx_t *ds_ctx,
+                                                            struct pmix_namespace_t *nspace)
+{
+    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
+
+    return _release_ns_lock_by_name(ds_ctx, ns->nspace);
+}
+
 /* this function is only called by the PMIx server when its
  * host has received data from some other peer. It therefore
  * always contains data solely from remote procs, and we
@@ -2680,6 +2770,17 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
         PMIX_DESTRUCT(&pbkt);
         return PMIX_SUCCESS;
     }
+
+    rc = _acquire_ns_lock_by_name(ds_ctx, proc.nspace);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        bo->bytes = pbkt.base_ptr;
+        bo->size = pbkt.bytes_used; // restore the incoming data
+        pbkt.base_ptr = NULL;
+        PMIX_DESTRUCT(&pbkt);
+        return rc;
+    }
+
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
@@ -2695,10 +2796,12 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
             PMIX_DESTRUCT(&pbkt);
             return rc;
         }
+
         if (PMIX_SUCCESS != (rc = pmix_common_dstor_store(ds_ctx, &proc, PMIX_REMOTE, kv))) {
             PMIX_ERROR_LOG(rc);
         }
         PMIX_RELEASE(kv);  // maintain accounting as the hash increments the ref count
+
         /* continue along */
         kv = PMIX_NEW(pmix_kval_t);
         cnt = 1;
@@ -2714,6 +2817,13 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
     bo->size = pbkt.bytes_used; // restore the incoming data
     pbkt.base_ptr = NULL;
     PMIX_DESTRUCT(&pbkt);
+
+    rc = _release_ns_lock_by_name(ds_ctx, proc.nspace);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+
     return rc;
 }
 

--- a/src/mca/common/dstore/dstore_base.h
+++ b/src/mca/common/dstore/dstore_base.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2017      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -79,6 +80,7 @@ struct session_s {
     pmix_dstore_seg_desc_t *sm_seg_first;
     pmix_dstore_seg_desc_t *sm_seg_last;   
     pmix_common_dstor_lock_ctx_t lock;
+    int active_locks;
 };
 
 struct ns_map_data_s {

--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -74,4 +75,8 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
                                 struct pmix_namespace_t *nspace,
                                 pmix_list_t *cbs,
                                 pmix_byte_object_t *bo);
+PMIX_EXPORT pmix_status_t pmix_common_dstor_acquire_ns_lock(pmix_common_dstore_ctx_t *ds_ctx,
+                                                            struct pmix_namespace_t *nspace);
+PMIX_EXPORT pmix_status_t pmix_common_dstor_release_ns_lock(pmix_common_dstore_ctx_t *ds_ctx,
+                                                            struct pmix_namespace_t *nspace);
 #endif

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -113,6 +113,16 @@ static pmix_status_t ds12_store_modex(struct pmix_namespace_t *nspace,
     return pmix_common_dstor_store_modex(ds12_ctx, nspace, cbs, bo);
 }
 
+static pmix_status_t ds12_acquire_ns_lock(struct pmix_namespace_t *nspace)
+{
+    return pmix_common_dstor_acquire_ns_lock(ds12_ctx, nspace);
+}
+
+static pmix_status_t ds12_release_ns_lock(struct pmix_namespace_t *nspace)
+{
+    return pmix_common_dstor_release_ns_lock(ds12_ctx, nspace);
+}
+
 static pmix_status_t ds12_fetch(const pmix_proc_t *proc,
                                     pmix_scope_t scope, bool copy,
                                     const char *key,
@@ -153,5 +163,7 @@ pmix_gds_base_module_t pmix_ds12_module = {
     .setup_fork = ds12_setup_fork,
     .add_nspace = ds12_add_nspace,
     .del_nspace = ds12_del_nspace,
+    .acquire_ns_lock = ds12_acquire_ns_lock,
+    .release_ns_lock = ds12_release_ns_lock,
 };
 

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -110,6 +110,16 @@ static pmix_status_t ds21_store_modex(struct pmix_namespace_t *nspace,
     return pmix_common_dstor_store_modex(ds21_ctx, nspace, cbs, bo);
 }
 
+static pmix_status_t ds21_acquire_ns_lock(struct pmix_namespace_t *nspace)
+{
+    return pmix_common_dstor_acquire_ns_lock(ds21_ctx, nspace);
+}
+
+static pmix_status_t ds21_release_ns_lock(struct pmix_namespace_t *nspace)
+{
+    return pmix_common_dstor_release_ns_lock(ds21_ctx, nspace);
+}
+
 static pmix_status_t ds21_fetch(const pmix_proc_t *proc,
                                     pmix_scope_t scope, bool copy,
                                     const char *key,
@@ -168,5 +178,7 @@ pmix_gds_base_module_t pmix_ds21_module = {
     .setup_fork = ds21_setup_fork,
     .add_nspace = ds21_add_nspace,
     .del_nspace = ds21_del_nspace,
+    .acquire_ns_lock = ds21_acquire_ns_lock,
+    .release_ns_lock = ds21_release_ns_lock,
 };
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
@@ -104,7 +104,9 @@ pmix_gds_base_module_t pmix_hash_module = {
     .add_nspace = nspace_add,
     .del_nspace = nspace_del,
     .assemb_kvs_req = assemb_kvs_req,
-    .accept_kvs_resp = accept_kvs_resp
+    .accept_kvs_resp = accept_kvs_resp,
+    .acquire_ns_lock = NULL,
+    .release_ns_lock = NULL,
 };
 
 typedef struct {

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
  * $COPYRIGHT$
  *
@@ -2200,6 +2200,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     char byte;
     bool found;
     pmix_collect_t ctype;
+    bool holding_ns_locks = false;
 
     PMIX_ACQUIRE_OBJECT(scd);
 
@@ -2242,6 +2243,16 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
             pmix_list_append(&nslist, &nptr->super);
         }
     }
+
+    // Lock down all of the namespaces
+    PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
+        PMIX_GDS_ACQUIRE_NS_LOCK(rc, nptr->ns);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            goto finish_collective;
+        }
+    }
+    holding_ns_locks = true;
 
     /* Loop over the enclosed byte object envelopes and
      * store them in our GDS module */
@@ -2309,6 +2320,18 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     }
 
   finish_collective:
+
+    // Unlock all of the namespaces
+    if( holding_ns_locks ) {
+        PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
+            PMIX_GDS_RELEASE_NS_LOCK(rc, nptr->ns);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto cleanup;
+            }
+        }
+    }
+
     /* loop across all procs in the tracker, sending them the reply */
     PMIX_LIST_FOREACH(cd, &tracker->local_cbs, pmix_server_caddy_t) {
         reply = PMIX_NEW(pmix_buffer_t);


### PR DESCRIPTION
 * Move the GDS (in particular the dstore) locks up to the `_mdxcbfunc`
   level to avoid the over head of locking and unlocking for each key
   set in the modex data.