### PR TITLE
ptl/usock: Guard against assumption that zero-length credential is NULL

### DIFF
--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -481,6 +482,10 @@ static void connection_handler(int sd, short args, void *cbdata)
             cred.bytes = ptr;
             ptr += cred.size;
             len -= cred.size;
+        } else {
+            /* set cred pointer to NULL to guard against validation
+             * methods that assume a zero length credential is NULL */
+            cred.bytes = NULL;
         }
     }
 


### PR DESCRIPTION
This guards against corruption seen in https://github.com/pmix/pmix/issues/824.

This will need some more discussion as to whether we should bail out of the server here or not.