### PR TITLE
Ensure we only open the pshmem framework once

### DIFF
--- a/config/pmix_mca.m4
+++ b/config/pmix_mca.m4
@@ -11,7 +11,7 @@ dnl                         University of Stuttgart.  All rights reserved.
 dnl Copyright (c) 2004-2005 The Regents of the University of California.
 dnl                         All rights reserved.
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+dnl Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -428,7 +428,7 @@ AC_DEFUN([MCA_CONFIGURE_FRAMEWORK],[
     # Create the final .h file that will be included in the type's
     # top-level glue.  This lists all the static components.  We don't
     # need to do this for "common".
-    if test "$2" != "common"; then
+    if test "$1" != "common"; then
         cat > $outfile <<EOF
 /*
  * \$HEADER\$

--- a/src/mca/pshmem/base/pshmem_base_frame.c
+++ b/src/mca/pshmem/base/pshmem_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -60,6 +60,9 @@ static pmix_status_t pmix_pshmem_close(void)
 
 static pmix_status_t pmix_pshmem_open(pmix_mca_base_open_flag_t flags)
 {
+    if (initialized) {
+        return PMIX_SUCCESS;
+    }
     /* initialize globals */
     initialized = true;
 


### PR DESCRIPTION
Now that there are TWO dstore components, they are causing the pshmem
framework to be opened twice, thus crashing the code

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit d070754b5cd529aa8dae329a105527f1a4c79aab)