### PR TITLE
Continue implementation of PMIx Groups

### DIFF
--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -108,7 +108,10 @@ static void errhandler_reg_callbk(pmix_status_t status,
 }
 
 static void grpcomplete(pmix_status_t status,
-                        void *cbdata)
+                        pmix_info_t *info, size_t ninfo,
+                        void *cbdata,
+                        pmix_release_cbfunc_t release_fn,
+                        void *release_cbdata)
 {
     fprintf(stderr, "%s:%d GRPCOMPLETE\n", myproc.nspace, myproc.rank);
     DEBUG_WAKEUP_THREAD(&invitedlock);
@@ -169,6 +172,8 @@ int main(int argc, char **argv)
     uint32_t nprocs;
     mylock_t lock;
     pmix_status_t code;
+    pmix_info_t *results;
+    size_t nresults;
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -238,7 +243,7 @@ int main(int argc, char **argv)
         PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
         PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
         PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
-        rc = PMIx_Group_invite("ourgroup", procs, nprocs, NULL, 0);
+        rc = PMIx_Group_invite("ourgroup", procs, nprocs, NULL, 0, &results, &nresults);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_invite failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;

--- a/examples/group.c
+++ b/examples/group.c
@@ -114,6 +114,8 @@ int main(int argc, char **argv)
     pmix_proc_t proc, *procs;
     uint32_t nprocs;
     mylock_t lock;
+    pmix_info_t *results;
+    size_t nresults;
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -169,34 +171,19 @@ int main(int argc, char **argv)
         PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
         PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
         PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
-        rc = PMIx_Group_construct("ourgroup", procs, nprocs, NULL, 0);
+        rc = PMIx_Group_construct("ourgroup", procs, nprocs, NULL, 0, &results, &nresults);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;
         }
+        fprintf(stderr, "%d Group construct complete\n", myproc.rank);
         PMIX_PROC_FREE(procs, nprocs);
-        fprintf(stderr, "Execute fence across group\n");
-        PMIX_PROC_LOAD(&proc, "ourgroup", PMIX_RANK_WILDCARD);
-        rc = PMIx_Fence(&proc, 1, NULL, 0);
-        if (PMIX_SUCCESS != rc) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Fence across group failed: %d\n", myproc.nspace, myproc.rank, rc);
-            goto done;
-        }
         fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
         rc = PMIx_Group_destruct("ourgroup", NULL, 0);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_destruct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;
         }
-    }
-
-    /* call fence to sync */
-    PMIX_PROC_CONSTRUCT(&proc);
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-        goto done;
     }
 
  done:

--- a/include/pmix.h
+++ b/include/pmix.h
@@ -789,15 +789,18 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntar
  *    PMIX_TIMEOUT - return an error if the group doesn't assemble within the
  *                   specified number of seconds. Targets the scenario where a
  *                   process fails to call PMIx_Group_connect due to hanging
+ *
+ * Recognizing
  */
 PMIX_EXPORT pmix_status_t PMIx_Group_construct(const char grp[],
                                                const pmix_proc_t procs[], size_t nprocs,
-                                               const pmix_info_t info[], size_t ninfo);
+                                               const pmix_info_t directives[], size_t ndirs,
+                                               pmix_info_t **results, size_t *nresults);
 
 PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
                                                   const pmix_proc_t procs[], size_t nprocs,
                                                   const pmix_info_t info[], size_t ninfo,
-                                                  pmix_op_cbfunc_t cbfunc, void *cbdata);
+                                                  pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Explicitly invite specified processes to join a group.
  *
@@ -845,12 +848,13 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
  */
 PMIX_EXPORT pmix_status_t PMIx_Group_invite(const char grp[],
                                             const pmix_proc_t procs[], size_t nprocs,
-                                            const pmix_info_t info[], size_t ninfo);
+                                            const pmix_info_t info[], size_t ninfo,
+                                            pmix_info_t **results, size_t *nresult);
 
 PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[],
                                                const pmix_proc_t procs[], size_t nprocs,
                                                const pmix_info_t info[], size_t ninfo,
-                                               pmix_op_cbfunc_t cbfunc, void *cbdata);
+                                               pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Respond to an invitation to join a group that is being asynchronously constructed.
  *
@@ -891,13 +895,14 @@ PMIX_EXPORT pmix_status_t PMIx_Group_invite_nb(const char grp[],
 PMIX_EXPORT pmix_status_t PMIx_Group_join(const char grp[],
                                           const pmix_proc_t *leader,
                                           pmix_group_opt_t opt,
-                                          const pmix_info_t info[], size_t ninfo);
+                                          const pmix_info_t info[], size_t ninfo,
+                                          pmix_info_t **results, size_t *nresult);
 
 PMIX_EXPORT pmix_status_t PMIx_Group_join_nb(const char grp[],
                                              const pmix_proc_t *leader,
                                              pmix_group_opt_t opt,
                                              const pmix_info_t info[], size_t ninfo,
-                                             pmix_op_cbfunc_t cbfunc, void *cbdata);
+                                             pmix_info_cbfunc_t cbfunc, void *cbdata);
 
 /* Leave a PMIx Group. Calls to PMIx_Group_leave (or its non-blocking form) will cause
  * a PMIX_GROUP_LEFT event to be generated notifying all members of the group of the

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -639,7 +639,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        participate in the proposed group The default is true
 #define PMIX_GROUP_FT_COLLECTIVE            "pmix.grp.ftcoll"       // (bool) adjust internal tracking for terminated processes. Default is false
 #define PMIX_GROUP_MEMBERSHIP               "pmix.grp.mbrs"         // (pmix_data_array_t*) array of group member ID's
-#define PMIX_GROUP_ASSIGN_CONTEXT_ID        "pmix.grp.ctxid"        // (bool) request that the RM assign a unique numerical (size_t) ID to this group
+#define PMIX_GROUP_ASSIGN_CONTEXT_ID        "pmix.grp.actxid"       // (bool) request that the RM assign a unique numerical (size_t) ID to this group
+#define PMIX_GROUP_CONTEXT_ID               "pmix.grp.ctxid"        // (size_t) context ID assigned to group
 
 
 /****    PROCESS STATE DEFINITIONS    ****/

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -489,6 +489,29 @@ typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
                                                 pmix_op_cbfunc_t cbfunc, void *cbdata);
 
 
+/* Perform a "fence" operation across the specified procs, plus any special
+ * actions included in the directives. Return the result of any special action
+ * requests in the info cbfunc when the fence is completed. Actions may include:
+ *
+ * PMIX_GROUP_ASSIGN_CONTEXT_ID - request that the RM assign a unique
+ *                                numerical (size_t) ID to this group
+ *
+ * procs - pointer to array of pmix_proc_t ID's of group members
+ *
+ * nprocs - number of group members
+ *
+ * directives - array of key-value attributes specifying special actions.
+ *
+ * ndirs - size of the directives array
+ *
+ * cbfunc - callback function when the operation is completed
+ *
+ * cbdata - object to be returned in cbfunc
+ */
+typedef pmix_status_t (*pmix_server_grp_fn_t)(const pmix_proc_t procs[], size_t nprocs,
+                                              const pmix_info_t directives[], size_t ndirs,
+                                              pmix_info_cbfunc_t cbfunc, void *cbdata);
+
 typedef struct pmix_server_module_2_0_0_t {
     /* v1x interfaces */
     pmix_server_client_connected_fn_t   client_connected;
@@ -518,6 +541,8 @@ typedef struct pmix_server_module_2_0_0_t {
     pmix_server_validate_cred_fn_t      validate_credential;
     pmix_server_iof_fn_t                iof_pull;
     pmix_server_stdin_fn_t              push_stdin;
+    /* v4x interfaces */
+    pmix_server_grp_fn_t                group;
 } pmix_server_module_t;
 
 /****    HOST RM FUNCTIONS FOR INTERFACE TO PMIX SERVER    ****/

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -3163,73 +3163,97 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
 
     if (PMIX_NOTIFY_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_event_recvd_from_client(peer, buf, notifyerror_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_event_recvd_from_client(peer, buf, notifyerror_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_QUERY_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_query(peer, buf, query_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_query(peer, buf, query_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_LOG_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_log(peer, buf, op_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_log(peer, buf, op_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_ALLOC_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_alloc(peer, buf, query_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_alloc(peer, buf, query_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_JOB_CONTROL_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_job_ctrl(peer, buf, query_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_job_ctrl(peer, buf, query_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_MONITOR_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_monitor(peer, buf, query_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_monitor(peer, buf, query_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_GET_CREDENTIAL_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_get_credential(peer, buf, cred_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_get_credential(peer, buf, cred_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_VALIDATE_CRED_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_validate_credential(peer, buf, validate_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_validate_credential(peer, buf, validate_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_IOF_PULL_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_iofreg(peer, buf, iof_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_iofreg(peer, buf, iof_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_IOF_PUSH_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_iofstdin(peer, buf, op_cbfunc, cd);
+        if (PMIX_SUCCESS != (rc = pmix_server_iofstdin(peer, buf, op_cbfunc, cd))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_GROUP_CONSTRUCT_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_grpconstruct(cd, buf);
+        if (PMIX_SUCCESS != (rc = pmix_server_grpconstruct(cd, buf))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 
     if (PMIX_GROUP_DESTRUCT_CMD == cmd) {
         PMIX_GDS_CADDY(cd, peer, tag);
-        rc = pmix_server_grpdestruct(cd, buf);
+        if (PMIX_SUCCESS != (rc = pmix_server_grpdestruct(cd, buf))) {
+            PMIX_RELEASE(cd);
+        }
         return rc;
     }
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3243,9 +3243,20 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
     pmix_server_caddy_t *cd;
     pmix_buffer_t *reply;
     pmix_status_t ret;
-    pmix_group_t *grp;
+    size_t n, ctxid = SIZE_MAX;
 
     PMIX_ACQUIRE_OBJECT(scd);
+
+    pmix_output_verbose(2, pmix_server_globals.connect_output,
+                        "server:grpcbfunc processing WITH %d MEMBERS", (int)pmix_list_get_size(&trk->local_cbs));
+
+    /* see if this group was assigned a context ID */
+    for (n=0; n < scd->ninfo; n++) {
+        if (PMIX_CHECK_KEY(&scd->info[n], PMIX_GROUP_CONTEXT_ID)) {
+            PMIX_VALUE_GET_NUMBER(ret, &scd->info[n].value, ctxid, size_t);
+            break;
+        }
+    }
 
     /* loop across all procs in the tracker, sending them the reply */
     PMIX_LIST_FOREACH(cd, &trk->local_cbs, pmix_server_caddy_t) {
@@ -3260,18 +3271,17 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
             PMIX_RELEASE(reply);
             break;
         }
-        pmix_output_verbose(2, pmix_server_globals.base_output,
-                            "server:modex_cbfunc reply being sent to %s:%u",
+        /* if a ctxid was provided, pass it along */
+        PMIX_BFROPS_PACK(ret, cd->peer, reply, &ctxid, 1, PMIX_SIZE);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_ERROR_LOG(ret);
+            PMIX_RELEASE(reply);
+            break;
+        }
+        pmix_output_verbose(2, pmix_server_globals.connect_output,
+                            "server:grp_cbfunc reply being sent to %s:%u",
                             cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
         PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
-    }
-
-    /* if the grp object is here, then we are destructing the group,
-     * so remove the grp from our list */
-    if (NULL != trk->cbdata) {
-        grp = (pmix_group_t*)trk->cbdata;
-        pmix_list_remove_item(&pmix_server_globals.groups, &grp->super);
-        PMIX_RELEASE(grp);
     }
 
     /* remove the tracker from the list */
@@ -3286,14 +3296,17 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
 }
 
 
-static void grpcbfunc(pmix_status_t status, const char *data, size_t ndata, void *cbdata,
-                      pmix_release_cbfunc_t relfn, void *relcbd)
+static void grpcbfunc(pmix_status_t status,
+                      pmix_info_t *info, size_t ninfo,
+                      void *cbdata,
+                      pmix_release_cbfunc_t relfn,
+                      void *relcbd)
 {
     pmix_server_trkr_t *tracker = (pmix_server_trkr_t*)cbdata;
     pmix_shift_caddy_t *scd;
 
-    pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "server:modex_cbfunc called with %d bytes", (int)ndata);
+    pmix_output_verbose(2, pmix_server_globals.connect_output,
+                        "server:grpcbfunc called with %d info", (int)ninfo);
 
     if (NULL == tracker) {
         /* nothing to do - but be sure to give them
@@ -3314,6 +3327,8 @@ static void grpcbfunc(pmix_status_t status, const char *data, size_t ndata, void
         return;
     }
     scd->status = status;
+    scd->info = info;
+    scd->ninfo = ninfo;
     scd->tracker = tracker;
     scd->cbfunc.relfn = relfn;
     scd->cbdata = relcbd;
@@ -3330,15 +3345,14 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
     pmix_proc_t *procs;
     pmix_group_t *grp, *pgrp;
     pmix_info_t *info = NULL;
-    size_t n, ninfo, ndirs, nprocs;
-    bool flag;
+    size_t n, ninfo, nprocs;
     pmix_server_trkr_t *trk;
     struct timeval tv = {0, 0};
 
-    pmix_output_verbose(2, pmix_server_globals.iof_output,
+    pmix_output_verbose(2, pmix_server_globals.connect_output,
                         "recvd grpconstruct cmd");
 
-    if (NULL == pmix_host_server.fence_nb) {
+    if (NULL == pmix_host_server.group) {
         PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
     }
@@ -3403,19 +3417,14 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
 
     /* unpack the number of directives */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &ndirs, &cnt, PMIX_SIZE);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
-    ninfo = ndirs + 1;
-    PMIX_INFO_CREATE(info, ninfo);
-    if (NULL == info) {
-        rc = PMIX_ERR_NOMEM;
-        goto error;
-    }
-    if (0 < ndirs) {
-        cnt = ndirs;
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -3423,17 +3432,13 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
         }
         /* see if we are to enforce a timeout - we don't internally care
          * about any other directives */
-        for (n=0; n < ndirs; n++) {
+        for (n=0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
                 tv.tv_sec = info[n].value.data.uint32;
                 break;
             }
         }
     }
-
-    /* treat this like a fence - no data to collect */
-    flag = false;
-    PMIX_INFO_LOAD(&info[ninfo-1], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
 
     /* find/create the local tracker for this operation */
     if (NULL == (trk = get_tracker(grp->grpid, grp->members, grp->nmbrs, PMIX_FENCENB_CMD))) {
@@ -3444,7 +3449,7 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
             rc = PMIX_ERROR;
             goto error;
         }
-        trk->type = PMIX_FENCENB_CMD;
+        trk->type = PMIX_GROUP_CONSTRUCT_CMD;
         trk->collect_type = PMIX_COLLECT_NO;
     }
 
@@ -3481,11 +3486,11 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
     if (trk->def_complete &&
         pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
         pmix_output_verbose(2, pmix_server_globals.base_output,
-                            "local fence complete with %d procs", (int)trk->npcs);
+                            "local group op complete with %d procs", (int)trk->npcs);
 
-        pmix_host_server.fence_nb(trk->pcs, trk->npcs,
-                                  trk->info, trk->ninfo,
-                                  NULL, 0, grpcbfunc, trk);
+        pmix_host_server.group(trk->pcs, trk->npcs,
+                               trk->info, trk->ninfo,
+                               grpcbfunc, trk);
     }
 
     return PMIX_SUCCESS;
@@ -3497,6 +3502,43 @@ pmix_status_t pmix_server_grpconstruct(pmix_server_caddy_t *cd,
     return rc;
 }
 
+static void mdxcbfunc(pmix_status_t status,
+                      const char *data, size_t ndata,
+                      void *cbdata,
+                      pmix_release_cbfunc_t relfn,
+                      void *relcbd)
+{
+    pmix_server_trkr_t *tracker = (pmix_server_trkr_t*)cbdata;
+    pmix_shift_caddy_t *scd;
+
+    pmix_output_verbose(2, pmix_server_globals.base_output,
+                        "server:mdxcbfunc called");
+
+    if (NULL == tracker) {
+        /* nothing to do - but be sure to give them
+         * a release if they want it */
+        if (NULL != relfn) {
+            relfn(relcbd);
+        }
+        return;
+    }
+
+    /* need to thread-shift this callback as it accesses global data */
+    scd = PMIX_NEW(pmix_shift_caddy_t);
+    if (NULL == scd) {
+        /* nothing we can do */
+        if (NULL != relfn) {
+            relfn(cbdata);
+        }
+        return;
+    }
+    scd->status = status;
+    scd->tracker = tracker;
+    scd->cbfunc.relfn = relfn;
+    scd->cbdata = relcbd;
+    PMIX_THREADSHIFT(scd, _grpcbfunc);
+}
+
 pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
                                       pmix_buffer_t *buf)
 {
@@ -3505,8 +3547,7 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
     pmix_status_t rc;
     char *grpid;
     pmix_info_t *info = NULL;
-    size_t n, ninfo, ndirs;
-    bool flag;
+    size_t n, ninfo;
     pmix_server_trkr_t *trk;
     pmix_group_t *grp, *pgrp;
     struct timeval tv = {0, 0};
@@ -3546,19 +3587,14 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
 
     /* unpack the number of directives */
     cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, peer, buf, &ndirs, &cnt, PMIX_SIZE);
+    PMIX_BFROPS_UNPACK(rc, peer, buf, &ninfo, &cnt, PMIX_SIZE);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
         goto error;
     }
-    ninfo = ndirs + 1;
-    PMIX_INFO_CREATE(info, ninfo);
-    if (NULL == info) {
-        rc = PMIX_ERR_NOMEM;
-        goto error;
-    }
-    if (0 < ndirs) {
-        cnt = ndirs;
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(info, ninfo);
+        cnt = ninfo;
         PMIX_BFROPS_UNPACK(rc, peer, buf, info, &cnt, PMIX_INFO);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
@@ -3566,17 +3602,13 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
         }
         /* see if we are to enforce a timeout - we don't internally care
          * about any other directives */
-        for (n=0; n < ndirs; n++) {
+        for (n=0; n < ninfo; n++) {
             if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
                 tv.tv_sec = info[n].value.data.uint32;
                 break;
             }
         }
     }
-
-    /* treat this like a fence - no data to collect */
-    flag = false;
-    PMIX_INFO_LOAD(&info[ninfo-1], PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
 
     /* use the grp membership for the fence we are to
      * execute - our host RM only knows these procs by
@@ -3633,7 +3665,7 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
 
         pmix_host_server.fence_nb(grp->members, grp->nmbrs,
                                   trk->info, trk->ninfo,
-                                  NULL, 0, grpcbfunc, trk);
+                                  NULL, 0, mdxcbfunc, trk);
     }
 
     return PMIX_SUCCESS;


### PR DESCRIPTION
Begin implementation to return an assigned context ID from PMIx_Group_construct. Cleanup some errors observed when executing multiple apps using same group name.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>