### PR TITLE
Enable PMIx_Group_construct to return a context ID

### DIFF
--- a/examples/group.c
+++ b/examples/group.c
@@ -114,8 +114,8 @@ int main(int argc, char **argv)
     pmix_proc_t proc, *procs;
     uint32_t nprocs;
     mylock_t lock;
-    pmix_info_t *results;
-    size_t nresults;
+    pmix_info_t *results, info;
+    size_t nresults, cid;
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -171,12 +171,19 @@ int main(int argc, char **argv)
         PMIX_PROC_LOAD(&procs[0], myproc.nspace, 0);
         PMIX_PROC_LOAD(&procs[1], myproc.nspace, 2);
         PMIX_PROC_LOAD(&procs[2], myproc.nspace, 3);
-        rc = PMIx_Group_construct("ourgroup", procs, nprocs, NULL, 0, &results, &nresults);
+        PMIX_INFO_LOAD(&info, PMIX_GROUP_ASSIGN_CONTEXT_ID, NULL, PMIX_BOOL);
+        rc = PMIx_Group_construct("ourgroup", procs, nprocs, &info, 1, &results, &nresults);
         if (PMIX_SUCCESS != rc) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Group_construct failed: %s\n", myproc.nspace, myproc.rank, PMIx_Error_string(rc));
             goto done;
         }
-        fprintf(stderr, "%d Group construct complete\n", myproc.rank);
+        /* we should have a single results object */
+        if (NULL != results) {
+            PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
+            fprintf(stderr, "%d Group construct complete with CID %d\n", myproc.rank, (int)cid);
+        } else {
+            fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
+        }
         PMIX_PROC_FREE(procs, nprocs);
         fprintf(stderr, "%d executing Group_destruct\n", myproc.rank);
         rc = PMIx_Group_destruct("ourgroup", NULL, 0);
@@ -199,7 +206,6 @@ int main(int argc, char **argv)
     } else {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
     }
-    sleep(myproc.rank);
     fprintf(stderr, "%s:%d COMPLETE\n", myproc.nspace, myproc.rank);
     fflush(stderr);
     return(0);

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -967,6 +967,11 @@ typedef enum {
     PMIX_GROUP_ACCEPT
 } pmix_group_opt_t;
 
+typedef enum {
+    PMIX_GROUP_CONSTRUCT,
+    PMIX_GROUP_DESTRUCT
+} pmix_group_operation_t;
+
 
 /* declare a convenience macro for checking keys */
 #define PMIX_CHECK_KEY(a, b) \

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -496,6 +496,9 @@ typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
  * PMIX_GROUP_ASSIGN_CONTEXT_ID - request that the RM assign a unique
  *                                numerical (size_t) ID to this group
  *
+ * op - pmix_group_operation_t value indicating the operation to perform
+ *      Current values support construct and destruct of the group
+ *
  * procs - pointer to array of pmix_proc_t ID's of group members
  *
  * nprocs - number of group members
@@ -508,7 +511,8 @@ typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
  *
  * cbdata - object to be returned in cbfunc
  */
-typedef pmix_status_t (*pmix_server_grp_fn_t)(const pmix_proc_t procs[], size_t nprocs,
+typedef pmix_status_t (*pmix_server_grp_fn_t)(pmix_group_operation_t op,
+                                              const pmix_proc_t procs[], size_t nprocs,
                                               const pmix_info_t directives[], size_t ndirs,
                                               pmix_info_cbfunc_t cbfunc, void *cbdata);
 

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -944,10 +944,18 @@ static void info_cbfunc(pmix_status_t status,
                         void *release_cbdata)
 {
     pmix_group_tracker_t *cb = (pmix_group_tracker_t*)cbdata;
+    size_t n;
 
     /* see if anything was returned - e.g., a context id */
-
     cb->status = status;
+    /* copy/save any returned info */
+    if (NULL != info) {
+        cb->nresults = ninfo;
+        PMIX_INFO_CREATE(cb->results, cb->nresults);
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&cb->results[n], &info[n]);
+        }
+    }
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }


### PR DESCRIPTION
Update the PMIx_Group_construct[_nb] APIs to allow return of a requested
context ID for the new group.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>