### PR TITLE
ptl/usock: Guard against assumption that zero-length credential is NULL

### DIFF
--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -15,6 +15,7 @@
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -478,6 +479,10 @@ static void connection_handler(int sd, short args, void *cbdata)
             cred = ptr;
             ptr += credlen;
             len -= credlen;
+        } else {
+            /* set cred pointer to NULL to guard against validation
+             * methods that assume a zero length credential is NULL */
+            cred = NULL;
         }
     }
 


### PR DESCRIPTION
Signed-off-by: Scott Miller <scott.miller1@ibm.com>
(backported from commit 90b2259d803c4a8e7d7c7225a6d4291ca4e1a604)

Conflicts:
	src/mca/ptl/usock/ptl_usock_component.c