### PR TITLE
Pull gds locking of modex up to improve performance.

### DIFF
--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -72,5 +73,5 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_fetch(pmix_common_dstore_ctx_t *ds_c
 PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t *ds_ctx,
                                 struct pmix_namespace_t *nspace,
                                 pmix_list_t *cbs,
-                                pmix_byte_object_t *bo);
+                                pmix_buffer_t *buff);
 #endif

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -76,6 +77,12 @@ struct pmix_gds_globals_t {
 };
 typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 
+typedef void * pmix_gds_base_store_modex_cbdata_t;
+typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_store_modex_cbdata_t cbdata,
+                                                           struct pmix_namespace_t *nspace,
+                                                           pmix_list_t *cbs,
+                                                           pmix_byte_object_t *bo);
+
 PMIX_EXPORT extern pmix_gds_globals_t pmix_gds_globals;
 
 /* get a list of available support - caller must free results
@@ -97,6 +104,12 @@ PMIX_EXPORT pmix_gds_base_module_t* pmix_gds_base_assign_module(pmix_info_t *inf
 */
 PMIX_EXPORT pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
                                                    char ***env);
+
+PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
+                                                           pmix_list_t *cbs,
+                                                           pmix_buffer_t *xfer,
+                                                           pmix_gds_base_store_modex_cb_fn_t cb_fn,
+                                                           pmix_gds_base_store_modex_cbdata_t cbdata);
 
 END_C_DECLS
 

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -3,6 +3,7 @@
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  *
  * $COPYRIGHT$
  *
@@ -82,4 +83,94 @@ pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
     }
 
     return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
+                                               pmix_list_t *cbs,
+                                               pmix_buffer_t * buff,
+                                               pmix_gds_base_store_modex_cb_fn_t cb_fn,
+                                               pmix_gds_base_store_modex_cbdata_t cbdata)
+{
+    pmix_status_t rc = PMIX_SUCCESS;
+    pmix_namespace_t * ns = (pmix_namespace_t *)nspace;
+    pmix_buffer_t bkt;
+    pmix_byte_object_t bo, bo2;
+    int32_t cnt = 1;
+    char byte;
+    pmix_collect_t ctype;
+    bool have_ctype = false;
+
+    /* Loop over the enclosed byte object envelopes and
+     * store them in our GDS module */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+            buff, &bo, &cnt, PMIX_BYTE_OBJECT);
+    while (PMIX_SUCCESS == rc) {
+        PMIX_LOAD_BUFFER(pmix_globals.mypeer, &bkt, bo.bytes, bo.size);
+        /* unpack the data collection flag */
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                &bkt, &byte, &cnt, PMIX_BYTE);
+        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+            /* no data was returned, so we are done with this blob */
+            break;
+        }
+        if (PMIX_SUCCESS != rc) {
+            /* we have an error */
+            goto error;
+        }
+
+        // Check that this blob was accumulated with the same data collection setting
+        if (have_ctype) {
+            if (ctype != (pmix_collect_t)byte) {
+                rc = PMIX_ERR_INVALID_ARG;
+                goto error;
+            }
+        }
+        else {
+            ctype = (pmix_collect_t)byte;
+            have_ctype = true;
+        }
+
+        /* unpack the enclosed blobs from the various peers */
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                &bkt, &bo2, &cnt, PMIX_BYTE_OBJECT);
+        while (PMIX_SUCCESS == rc) {
+            /* unpack all the kval's from this peer and store them in
+             * our GDS. Note that PMIx by design holds all data at
+             * the server level until requested. If our GDS is a
+             * shared memory region, then the data may be available
+             * right away - but the client still has to be notified
+             * of its presence. */
+            rc = cb_fn(cbdata, (struct pmix_namespace_t *)ns, cbs, &bo2);
+            if (PMIX_SUCCESS != rc) {
+                goto error;
+            }
+            PMIX_BYTE_OBJECT_DESTRUCT(&bo2);
+            /* get the next blob */
+            cnt = 1;
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                    &bkt, &bo2, &cnt, PMIX_BYTE_OBJECT);
+        }
+        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+            rc = PMIX_SUCCESS;
+        } else if (PMIX_SUCCESS != rc) {
+            goto error;
+        }
+        /* unpack and process the next blob */
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                buff, &bo, &cnt, PMIX_BYTE_OBJECT);
+    }
+    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+        rc = PMIX_SUCCESS;
+    }
+
+error:
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+    }
+
+    return rc;
 }

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -108,9 +108,9 @@ static pmix_status_t ds12_store(const pmix_proc_t *proc,
  * shall store it accordingly */
 static pmix_status_t ds12_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
-                                      pmix_byte_object_t *bo)
+                                      pmix_buffer_t *buf)
 {
-    return pmix_common_dstor_store_modex(ds12_ctx, nspace, cbs, bo);
+    return pmix_common_dstor_store_modex(ds12_ctx, nspace, cbs, buf);
 }
 
 static pmix_status_t ds12_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -105,9 +105,9 @@ static pmix_status_t ds21_store(const pmix_proc_t *proc,
  * shall store it accordingly */
 static pmix_status_t ds21_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
-                                      pmix_byte_object_t *bo)
+                                      pmix_buffer_t *buf)
 {
-    return pmix_common_dstor_store_modex(ds21_ctx, nspace, cbs, bo);
+    return pmix_common_dstor_store_modex(ds21_ctx, nspace, cbs, buf);
 }
 
 static pmix_status_t ds21_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -3,6 +3,7 @@
  * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -243,7 +244,7 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  */
 typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_namespace_t *ns,
                                                                pmix_list_t *cbs,
-                                                               pmix_byte_object_t *bo);
+                                                               pmix_buffer_t *buff);
 
 /**
  * define a convenience macro for storing modex byte objects

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
@@ -66,7 +66,12 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
 
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
                                       pmix_list_t *cbs,
-                                      pmix_byte_object_t *bo);
+                                      pmix_buffer_t *buff);
+
+static pmix_status_t _hash_store_modex(void * cbdata,
+                                       struct pmix_namespace_t *ns,
+                                       pmix_list_t *cbs,
+                                       pmix_byte_object_t *bo);
 
 static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                                 pmix_scope_t scope, bool copy,
@@ -1183,7 +1188,14 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
  * shall store it accordingly */
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
                                       pmix_list_t *cbs,
-                                      pmix_byte_object_t *bo)
+                                      pmix_buffer_t *buf) {
+    return pmix_gds_base_store_modex(nspace, cbs, buf, _hash_store_modex, NULL);
+}
+
+static pmix_status_t _hash_store_modex(void * cbdata,
+                                       struct pmix_namespace_t *nspace,
+                                       pmix_list_t *cbs,
+                                       pmix_byte_object_t *bo)
 {
     pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_hash_trkr_t *trk, *t;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -7,7 +7,7 @@
  *                         All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -2171,16 +2171,12 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
 {
     pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
     pmix_server_trkr_t *tracker = scd->tracker;
-    pmix_buffer_t xfer, *reply, bkt;
-    pmix_byte_object_t bo, bo2;
+    pmix_buffer_t xfer, *reply;
     pmix_server_caddy_t *cd;
     pmix_status_t rc = PMIX_SUCCESS, ret;
     pmix_nspace_caddy_t *nptr;
     pmix_list_t nslist;
-    int32_t cnt = 1;
-    char byte;
     bool found;
-    pmix_collect_t ctype;
 
     PMIX_ACQUIRE_OBJECT(scd);
 
@@ -2224,69 +2220,12 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         }
     }
 
-    /* Loop over the enclosed byte object envelopes and
-     * store them in our GDS module */
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
-                       &xfer, &bo, &cnt, PMIX_BYTE_OBJECT);
-    while (PMIX_SUCCESS == rc) {
-        PMIX_LOAD_BUFFER(pmix_globals.mypeer, &bkt, bo.bytes, bo.size);
-        /* unpack the data collection flag */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
-                           &bkt, &byte, &cnt, PMIX_BYTE);
-        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
-            /* no data was returned, so we are done with this blob */
-            break;
-        }
+    PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
+        PMIX_GDS_STORE_MODEX(rc, nptr->ns, &tracker->local_cbs, &xfer);
         if (PMIX_SUCCESS != rc) {
-            /* we have an error */
-            break;
-        }
-
-        // Check that this blob was accumulated with the same data collection setting
-        ctype = (pmix_collect_t)byte;
-        if (ctype != tracker->collect_type) {
-            rc = PMIX_ERR_INVALID_ARG;
-            break;
-        }
-        /* unpack the enclosed blobs from the various peers */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
-                           &bkt, &bo2, &cnt, PMIX_BYTE_OBJECT);
-        while (PMIX_SUCCESS == rc) {
-            /* unpack all the kval's from this peer and store them in
-             * our GDS. Note that PMIx by design holds all data at
-             * the server level until requested. If our GDS is a
-             * shared memory region, then the data may be available
-             * right away - but the client still has to be notified
-             * of its presence. */
-            PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
-                PMIX_GDS_STORE_MODEX(rc, nptr->ns, &tracker->local_cbs, &bo2);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    break;
-                }
-            }
-            PMIX_BYTE_OBJECT_DESTRUCT(&bo2);
-            /* get the next blob */
-            cnt = 1;
-            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
-                               &bkt, &bo2, &cnt, PMIX_BYTE_OBJECT);
-        }
-        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
-            rc = PMIX_SUCCESS;
-        } else if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            goto finish_collective;
+            break;
         }
-        /* unpack and process the next blob */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
-                           &xfer, &bo, &cnt, PMIX_BYTE_OBJECT);
-    }
-    if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
-        rc = PMIX_SUCCESS;
     }
 
   finish_collective:


### PR DESCRIPTION
Move the GDS (in particular the dstore) locks up to avoid
the over head of locking and unlocking for each key
set in the modex data.

Signed-off-by: Scott Miller <scott.miller1@ibm.com>
(cherry picked from commit 4323836d2858146252e666584912baf0a7678c52)

Conflicts:
	src/mca/common/dstore/dstore_common.h
	src/server/pmix_server.c