### PR TITLE
v2.2/dstore: ds21 locks are aligned to the size of the cache line

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -358,7 +358,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       crt_externs.h signal.h \
                       ioLib.h sockLib.h hostLib.h limits.h \
                       sys/statfs.h sys/statvfs.h \
-                      netdb.h ucred.h zlib.h])
+                      netdb.h ucred.h zlib.h sys/auxv.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],
                      [AC_INCLUDES_DEFAULT

--- a/src/mca/common/dstore/dstore_segment.c
+++ b/src/mca/common/dstore/dstore_segment.c
@@ -28,6 +28,10 @@
 #include <fcntl.h>
 #endif
 
+#ifdef HAVE_SYS_AUXV_H
+#include <sys/auxv.h>
+#endif
+
 #include <pmix_common.h>
 
 #include "src/include/pmix_globals.h"
@@ -52,6 +56,21 @@ PMIX_EXPORT int pmix_common_dstor_getpagesize(void)
 #else
     return 65536; /* safer to overestimate than under */
 #endif
+}
+
+PMIX_EXPORT size_t pmix_common_dstor_getcacheblocksize(void)
+{
+    size_t cache_line = 0;
+
+#if defined(_SC_LEVEL1_DCACHE_LINESIZE)
+    cache_line = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+#endif
+#if (defined(HAVE_SYS_AUXV_H)) && (defined(AT_DCACHEBSIZE))
+    if (0 == cache_line) {
+        cache_line = getauxval(AT_DCACHEBSIZE);
+    }
+#endif
+    return cache_line;
 }
 
 PMIX_EXPORT void pmix_common_dstor_init_segment_info(size_t initial_segment_size,

--- a/src/mca/common/dstore/dstore_segment.h
+++ b/src/mca/common/dstore/dstore_segment.h
@@ -48,6 +48,7 @@ struct pmix_dstore_seg_desc_t {
 };
 
 PMIX_EXPORT int pmix_common_dstor_getpagesize(void);
+PMIX_EXPORT size_t pmix_common_dstor_getcacheblocksize(void);
 PMIX_EXPORT void pmix_common_dstor_init_segment_info(size_t initial_segment_size,
                         size_t meta_segment_size,
                         size_t data_segment_size);


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>
(cherry picked from commit c9a8bba66bae2ac02eb35f4f4392678e56539aaf)

Corresponds to #805