### PR TITLE
passing a bool to va_start() is undefined

### DIFF
--- a/src/util/os_path.c
+++ b/src/util/os_path.c
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -34,7 +34,7 @@
 
 static const char *path_sep = PMIX_PATH_SEP;
 
-char *pmix_os_path(bool relative, ...)
+char *pmix_os_path(int relative, ...)
 {
     va_list ap;
     char *element, *path;

--- a/src/util/os_path.h
+++ b/src/util/os_path.h
@@ -9,7 +9,7 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -64,8 +64,13 @@ BEGIN_C_DECLS
  * provided path elements, separated by the path separator character
  * appropriate to the local operating system. The path_name string has been malloc'd
  * and therefore the user is responsible for free'ing the field.
+ *
+ * Note that the "relative" argument is int instead of bool, because
+ * passing a parameter that undergoes default argument promotion to
+ * va_start() has undefined behavior (according to clang warnings on
+ * MacOS High Sierra).
 */
-PMIX_EXPORT char *pmix_os_path(bool relative, ...) __pmix_attribute_malloc__ __pmix_attribute_sentinel__ __pmix_attribute_warn_unused_result__;
+PMIX_EXPORT char *pmix_os_path(int relative, ...) __pmix_attribute_malloc__ __pmix_attribute_sentinel__ __pmix_attribute_warn_unused_result__;
 
 /**
  * Convert the path to be OS friendly. On UNIX this function will

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,9 +49,9 @@ static char **search_dirs = NULL;
  * Local functions
  */
 static int pmix_show_vhelp_internal(const char *filename, const char *topic,
-                                    bool want_error_header, va_list arglist);
+                                    int want_error_header, va_list arglist);
 static int pmix_show_help_internal(const char *filename, const char *topic,
-                                   bool want_error_header, ...);
+                                   int want_error_header, ...);
 
 pmix_show_help_fn_t pmix_show_help = pmix_show_help_internal;
 pmix_show_vhelp_fn_t pmix_show_vhelp = pmix_show_vhelp_internal;
@@ -90,7 +90,7 @@ int pmix_show_help_finalize(void)
  * not optimization.  :-)
  */
 static int array2string(char **outstring,
-                        bool want_error_header, char **lines)
+                        int want_error_header, char **lines)
 {
     int i, count;
     size_t len;
@@ -294,7 +294,7 @@ static int load_array(char ***array, const char *filename, const char *topic)
 }
 
 char *pmix_show_help_vstring(const char *filename, const char *topic,
-                             bool want_error_header, va_list arglist)
+                             int want_error_header, va_list arglist)
 {
     int rc;
     char *single_string, *output, **array = NULL;
@@ -320,7 +320,7 @@ char *pmix_show_help_vstring(const char *filename, const char *topic,
 }
 
 char *pmix_show_help_string(const char *filename, const char *topic,
-                            bool want_error_handler, ...)
+                            int want_error_handler, ...)
 {
     char *output;
     va_list arglist;
@@ -334,7 +334,7 @@ char *pmix_show_help_string(const char *filename, const char *topic,
 }
 
 static int pmix_show_vhelp_internal(const char *filename, const char *topic,
-                                    bool want_error_header, va_list arglist)
+                                    int want_error_header, va_list arglist)
 {
     char *output;
 
@@ -352,7 +352,7 @@ static int pmix_show_vhelp_internal(const char *filename, const char *topic,
 }
 
 static int pmix_show_help_internal(const char *filename, const char *topic,
-                                   bool want_error_header, ...)
+                                   int want_error_header, ...)
 {
     va_list arglist;
     int rc;

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,9 +129,14 @@ int pmix_show_help_finalize(void);
  * (typically $prefix/share/pmix), and looks up the message
  * based on the topic, and displays it.  If want_error_header is
  * true, a header and footer of asterisks are also displayed.
+ *
+ * Note that the "want_error_header" argument is int instead of bool,
+ * because passing a parameter that undergoes default argument
+ * promotion to va_start() has undefined behavior (according to clang
+ * warnings on MacOS High Sierra).
  */
 typedef int (*pmix_show_help_fn_t)(const char *filename, const char *topic,
-                                   bool want_error_header, ...);
+                                   int want_error_header, ...);
 PMIX_EXPORT extern pmix_show_help_fn_t pmix_show_help;
 
 /**
@@ -139,7 +144,7 @@ PMIX_EXPORT extern pmix_show_help_fn_t pmix_show_help;
  * a va_list form of varargs.
  */
 typedef int (*pmix_show_vhelp_fn_t)(const char *filename, const char *topic,
-                                    bool want_error_header, va_list ap);
+                                    int want_error_header, va_list ap);
 PMIX_EXPORT extern pmix_show_vhelp_fn_t pmix_show_vhelp;
 
 /**
@@ -148,7 +153,7 @@ PMIX_EXPORT extern pmix_show_vhelp_fn_t pmix_show_vhelp;
  */
 PMIX_EXPORT char* pmix_show_help_string(const char *filename,
                                         const char *topic,
-                                        bool want_error_header, ...);
+                                        int want_error_header, ...);
 
 /**
  * This function does the same thing as pmix_show_help_string(), but
@@ -156,7 +161,7 @@ PMIX_EXPORT char* pmix_show_help_string(const char *filename,
  */
 PMIX_EXPORT char* pmix_show_help_vstring(const char *filename,
                                          const char *topic,
-                                         bool want_error_header, va_list ap);
+                                         int want_error_header, va_list ap);
 
 /**
  * This function adds another search location for the files that


### PR DESCRIPTION
According to clang on MacOS, passing a bool parameter -- which
undergoes default parameter promotion -- to va_start() results in
undefined behavior.  So just change these params to int and avoid the
issue.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit 5eb327fe16e546a75b9c8f17039b6a9210348616)