### PR TITLE
fix potential memory barrier bug with __atomic builtin atomics

### DIFF
--- a/src/atomics/sys/gcc_builtin/atomic.h
+++ b/src/atomics/sys/gcc_builtin/atomic.h
@@ -16,6 +16,7 @@
  * Copyright (c) 2016-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018      Triad National Security, LLC. All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -58,7 +59,14 @@ static inline void pmix_atomic_mb(void)
 
 static inline void pmix_atomic_rmb(void)
 {
+#if OPAL_ASSEMBLY_ARCH == OPAL_X86_64
+    /* work around a bug in older gcc versions where ACQUIRE seems to get
+     * treated as a no-op instead of being equivalent to
+     * __asm__ __volatile__("": : :"memory") */
+    __atomic_thread_fence (__ATOMIC_SEQ_CST);
+#else
     __atomic_thread_fence (__ATOMIC_ACQUIRE);
+#endif
 }
 
 static inline void pmix_atomic_wmb(void)


### PR DESCRIPTION
(from: https://github.com/open-mpi/ompi/pull/6048)

I'm porting Nathan Hjelm's fix for OMPI Issue 6014
(https://github.com/open-mpi/ompi/issues/6014) to PMIx.

Signed-off-by: Geoffrey Paulsen <gpaulsen@us.ibm.com>
(cherry picked from commit 4cf3d97d33190b18b7910f822d0cf90bc321c43d)