### PR TITLE
v2.1/psensor/file: add missing PMIX_EXPORT on mca_psensor_file_component

### DIFF
--- a/src/mca/psensor/file/psensor_file.h
+++ b/src/mca/psensor/file/psensor_file.h
@@ -29,7 +29,7 @@ typedef struct {
     pmix_list_t trackers;
 } pmix_psensor_file_component_t;
 
-extern pmix_psensor_file_component_t mca_psensor_file_component;
+PMIX_EXPORT extern pmix_psensor_file_component_t mca_psensor_file_component;
 extern pmix_psensor_base_module_t pmix_psensor_file_module;
 
 


### PR DESCRIPTION
Add missing `PMIX_EXPORT` decoration on `mca_psensor_file_component` so that it can be resolved at runtime by `dlsym`. It was already added to master by af64c7d.

See open-mpi/ompi#6056.