### PR TITLE
Default the v2.0 GDS to "ds12,hash"

### DIFF
--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1258,7 +1258,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         proc_type = proc_type | PMIX_PROC_V20;
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
-        gds = NULL;
+        gds = "ds12,hash";
     } else {
         int major;
         major = strtoul(version, NULL, 10);


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>