### PR TITLE
Fix double callback data release when rc != PMIX_SUCCESS

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1999,7 +1999,9 @@ static void op_cbfunc(pmix_status_t status, void *cbdata)
     }
 
     /* cleanup */
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 static void connection_cleanup(int sd, short args, void *cbdata)
@@ -2171,7 +2173,9 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
      * it still being present - tell the originator the result */
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
     /* cleanup */
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 /* fence modex calls return here when the host RM has completed
@@ -2630,7 +2634,9 @@ static void regevents_cbfunc(pmix_status_t status, void *cbdata)
     }
     // send reply
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 static void notifyerror_cbfunc (pmix_status_t status, void *cbdata)
@@ -2654,7 +2660,9 @@ static void notifyerror_cbfunc (pmix_status_t status, void *cbdata)
     }
     // send reply
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 
@@ -2707,7 +2715,9 @@ static void query_cbfunc(pmix_status_t status,
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
     PMIX_RELEASE(qcd);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 static void cred_cbfunc(pmix_status_t status,
@@ -2767,7 +2777,9 @@ static void cred_cbfunc(pmix_status_t status,
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
     PMIX_RELEASE(qcd);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 static void validate_cbfunc(pmix_status_t status,
@@ -2814,7 +2826,9 @@ static void validate_cbfunc(pmix_status_t status,
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
     PMIX_RELEASE(qcd);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>

Fixes #929 

This PR fixes the double release when rc != PMIX_SUCCESS, it happens into callback [function ](https://github.com/pmix/pmix/blob/master/src/server/pmix_server.c#L2633), and second time in [server_switchyard](https://github.com/pmix/pmix/blob/master/src/server/pmix_server.c#L3093).