### PR TITLE
v2.2: Fix double callback data release when rc != PMIX_SUCCESS

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1586,7 +1586,9 @@ static void lookup_cbfunc(pmix_status_t status, pmix_pdata_t pdata[], size_t nda
      * it still being present - tell the originator the result */
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
     /* cleanup */
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 /* fence modex calls return here when the host RM has completed
@@ -1978,7 +1980,9 @@ static void regevents_cbfunc(pmix_status_t status, void *cbdata)
     }
     // send reply
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 static void notifyerror_cbfunc (pmix_status_t status, void *cbdata)
@@ -2002,7 +2006,9 @@ static void notifyerror_cbfunc (pmix_status_t status, void *cbdata)
     }
     // send reply
     PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 
@@ -2055,7 +2061,9 @@ static void query_cbfunc(pmix_status_t status,
         PMIX_INFO_FREE(qcd->info, qcd->ninfo);
     }
     PMIX_RELEASE(qcd);
-    PMIX_RELEASE(cd);
+    if (PMIX_SUCCESS == status) {
+        PMIX_RELEASE(cd);
+    }
 }
 
 /* the switchyard is the primary message handling function. It's purpose


### PR DESCRIPTION
Corresponds to #941