### PR TITLE
Avoid sending messages to procs that have finalized

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -956,7 +956,10 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                             continue;
                         }
                     }
-                    PMIX_SERVER_QUEUE_REPLY(pr->peer, 0, bfr);
+                    PMIX_SERVER_QUEUE_REPLY(rc, pr->peer, 0, bfr);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_RELEASE(bfr);
+                    }
                 }
             }
         }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -283,6 +283,8 @@ PMIX_CLASS_DECLARATION(pmix_query_caddy_t);
  * - instanced in pmix_server_ops.c */
 typedef struct {
     pmix_list_item_t super;
+    pmix_event_t ev;
+    bool event_active;
     char *id;                       // string identifier for the collective
     pmix_cmd_t type;
     pmix_proc_t pname;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -80,6 +80,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         peer->recv_msg = NULL;
     }
     CLOSE_THE_SOCKET(peer->sd);
+    /* mark the peer as "gone" */
+    peer->finalized = true;
 
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -109,14 +109,20 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                  * complete */
                 if (PMIX_FENCENB_CMD == trk->type) {
                     if (NULL != trk->modexcbfunc) {
+                        /* protect the tracker - the host may still call back on it */
+                        PMIX_RETAIN(trk);
                         trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
                     }
                 } else if (PMIX_CONNECTNB_CMD == trk->type) {
                     if (NULL != trk->op_cbfunc) {
+                        /* protect the tracker - the host may still call back on it */
+                        PMIX_RETAIN(trk);
                         trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
                     }
                 } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
                     if (NULL != trk->op_cbfunc) {
+                        /* protect the tracker - the host may still call back on it */
+                        PMIX_RETAIN(trk);
                         trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
                     }
                 }

--- a/src/mca/ptl/ptl.h
+++ b/src/mca/ptl/ptl.h
@@ -143,11 +143,23 @@ typedef struct pmix_ptl_module_t pmix_ptl_module_t;
 
 
 /*****    MACROS FOR EXECUTING PTL FUNCTIONS    *****/
-#define PMIX_PTL_SEND_RECV(r, p, b, c, d)               \
-    (r) = (p)->nptr->compat.ptl->send_recv((struct pmix_peer_t*)(p), b, c, d)
+#define PMIX_PTL_SEND_RECV(r, p, b, c, d)                                               \
+    do {                                                                                \
+        if ((p)->finalized) {                                                           \
+            (r) = PMIX_ERR_UNREACH;                                                     \
+        } else {                                                                        \
+            (r) = (p)->nptr->compat.ptl->send_recv((struct pmix_peer_t*)(p), b, c, d);  \
+        }                                                                               \
+    } while(0)
 
-#define PMIX_PTL_SEND_ONEWAY(r, p, b, t)                \
-    (r) = (p)->nptr->compat.ptl->send((struct pmix_peer_t*)(p), b, t)
+#define PMIX_PTL_SEND_ONEWAY(r, p, b, t)                                        \
+    do {                                                                        \
+        if ((p)->finalized) {                                                   \
+            (r) = PMIX_ERR_UNREACH;                                             \
+        } else {                                                                \
+            (r) = (p)->nptr->compat.ptl->send((struct pmix_peer_t*)(p), b, t);  \
+        }                                                                       \
+    } while(0)
 
 #define PMIX_PTL_RECV(r, p, c, t)      \
     (r) = (p)->nptr->compat.ptl->recv((struct pmix_peer_t*)(p), c, t)

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -259,37 +259,42 @@ PMIX_EXPORT extern int pmix_ptl_base_output;
  * t - tag to be sent to
  * b - buffer to be sent
  */
-#define PMIX_SERVER_QUEUE_REPLY(p, t, b)                                                \
-    do {                                                                                \
-        pmix_ptl_send_t *snd;                                                           \
-        uint32_t nbytes;                                                                \
-        pmix_output_verbose(5, pmix_ptl_base_output,                                    \
+#define PMIX_SERVER_QUEUE_REPLY(r, p, t, b)                                                 \
+    do {                                                                                    \
+        pmix_ptl_send_t *snd;                                                               \
+        uint32_t nbytes;                                                                    \
+        pmix_output_verbose(5, pmix_ptl_base_output,                                        \
                             "[%s:%d] queue callback called: reply to %s:%d on tag %d size %d",  \
-                            __FILE__, __LINE__,                                         \
-                            (p)->info->pname.nspace,                                    \
-                            (p)->info->pname.rank, (t), (int)(b)->bytes_used);          \
-        snd = PMIX_NEW(pmix_ptl_send_t);                                                \
-        snd->hdr.pindex = htonl(pmix_globals.pindex);                                   \
-        snd->hdr.tag = htonl(t);                                                        \
-        nbytes = (b)->bytes_used;                                                       \
-        snd->hdr.nbytes = htonl(nbytes);                                                \
-        snd->data = (b);                                                                \
-        /* always start with the header */                                              \
-        snd->sdptr = (char*)&snd->hdr;                                                  \
-        snd->sdbytes = sizeof(pmix_ptl_hdr_t);                                          \
-        /* if there is no message on-deck, put this one there */                        \
-        if (NULL == (p)->send_msg) {                                                    \
-            (p)->send_msg = snd;                                                        \
-        } else {                                                                        \
-            /* add it to the queue */                                                   \
-            pmix_list_append(&(p)->send_queue, &snd->super);                            \
-        }                                                                               \
-        /* ensure the send event is active */                                           \
-        if (!(p)->send_ev_active && 0 <= (p)->sd) {                                     \
-            (p)->send_ev_active = true;                                                 \
-            PMIX_POST_OBJECT(snd);                                                      \
-            pmix_event_add(&(p)->send_event, 0);                                        \
-        }                                                                               \
+                            __FILE__, __LINE__,                                             \
+                            (p)->info->pname.nspace,                                        \
+                            (p)->info->pname.rank, (t), (int)(b)->bytes_used);              \
+        if ((p)->finalized) {                                                               \
+            (r) = PMIX_ERR_UNREACH;                                                         \
+        } else {                                                                            \
+            snd = PMIX_NEW(pmix_ptl_send_t);                                                \
+            snd->hdr.pindex = htonl(pmix_globals.pindex);                                   \
+            snd->hdr.tag = htonl(t);                                                        \
+            nbytes = (b)->bytes_used;                                                       \
+            snd->hdr.nbytes = htonl(nbytes);                                                \
+            snd->data = (b);                                                                \
+            /* always start with the header */                                              \
+            snd->sdptr = (char*)&snd->hdr;                                                  \
+            snd->sdbytes = sizeof(pmix_ptl_hdr_t);                                          \
+            /* if there is no message on-deck, put this one there */                        \
+            if (NULL == (p)->send_msg) {                                                    \
+                (p)->send_msg = snd;                                                        \
+            } else {                                                                        \
+                /* add it to the queue */                                                   \
+                pmix_list_append(&(p)->send_queue, &snd->super);                            \
+            }                                                                               \
+            /* ensure the send event is active */                                           \
+            if (!(p)->send_ev_active && 0 <= (p)->sd) {                                     \
+                (p)->send_ev_active = true;                                                 \
+                PMIX_POST_OBJECT(snd);                                                      \
+                pmix_event_add(&(p)->send_event, 0);                                        \
+            }                                                                               \
+            (r) = PMIX_SUCCESS;                                                             \
+        }                                                                                   \
     } while (0)
 
 #define CLOSE_THE_SOCKET(s)                     \

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2191,7 +2191,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     pmix_shift_caddy_t *scd = (pmix_shift_caddy_t*)cbdata;
     pmix_server_trkr_t *tracker = scd->tracker;
     pmix_buffer_t xfer, *reply;
-    pmix_server_caddy_t *cd;
+    pmix_server_caddy_t *cd, *nxt;
     pmix_status_t rc = PMIX_SUCCESS, ret;
     pmix_nspace_caddy_t *nptr;
     pmix_list_t nslist;
@@ -2249,7 +2249,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
 
   finish_collective:
     /* loop across all procs in the tracker, sending them the reply */
-    PMIX_LIST_FOREACH(cd, &tracker->local_cbs, pmix_server_caddy_t) {
+    PMIX_LIST_FOREACH_SAFE(cd, nxt, &tracker->local_cbs, pmix_server_caddy_t) {
         reply = PMIX_NEW(pmix_buffer_t);
         if (NULL == reply) {
             rc = PMIX_ERR_NOMEM;
@@ -2268,6 +2268,9 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         if (PMIX_SUCCESS != rc) {
             PMIX_RELEASE(reply);
         }
+        /* remove this entry */
+        pmix_list_remove_item(&tracker->local_cbs, &cd->super);
+        PMIX_RELEASE(cd);
     }
 
   cleanup:
@@ -2282,6 +2285,10 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
 
     pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
+    if (NULL != tracker) {
+        /* not done with it yet - restore it to the list */
+        pmix_list_append(&pmix_server_globals.collectives, &tracker->super);
+    }
     PMIX_LIST_DESTRUCT(&nslist);
 
     /* we are done */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3684,6 +3684,7 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
 /*****    INSTANCE SERVER LIBRARY CLASSES    *****/
 static void tcon(pmix_server_trkr_t *t)
 {
+    t->event_active = false;
     t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN+1);
     t->pname.rank = PMIX_RANK_UNDEF;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1950,7 +1950,10 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
                 break;
             }
         }
-        PMIX_SERVER_QUEUE_REPLY(peer, 0, relay);
+        PMIX_SERVER_QUEUE_REPLY(ret, peer, 0, relay);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_RELEASE(relay);
+        }
     }
     if (!enviro_events) {
         if (NULL != codes) {
@@ -3232,7 +3235,10 @@ static void grp_timeout(int sd, short args, void *cbdata)
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "server:grp_timeout reply being sent to %s:%u",
                         cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
-    PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+    PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
+    if (PMIX_SUCCESS != ret) {
+        PMIX_RELEASE(reply);
+    }
 
   error:
     cd->event_active = false;
@@ -3299,7 +3305,10 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
         pmix_output_verbose(2, pmix_server_globals.connect_output,
                             "server:grp_cbfunc reply being sent to %s:%u",
                             cd->peer->info->pname.nspace, cd->peer->info->pname.rank);
-        PMIX_SERVER_QUEUE_REPLY(cd->peer, cd->hdr.tag, reply);
+        PMIX_SERVER_QUEUE_REPLY(ret, cd->peer, cd->hdr.tag, reply);
+        if (PMIX_SUCCESS != ret) {
+            PMIX_RELEASE(reply);
+        }
     }
 
     /* remove the tracker from the list */


### PR DESCRIPTION
Ensure we mark that a proc has finalized. Check the finalized flag prior
to each message sent from server to client

Signed-off-by: Ralph Castain <rhc@open-mpi.org>