### PR TITLE
Report events only to members of the failed procs nspace

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -192,15 +192,22 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             ch = PMIX_NEW(pmix_event_chain_t);                                      \
             ch->status = (e);                                                       \
             ch->range = (r);                                                        \
-            pmix_strncpy(ch->source.nspace,                                        \
-                          (p)->nptr->nspace,                                        \
-                          PMIX_MAX_NSLEN);                                          \
-            ch->source.rank = (p)->info->pname.rank;                                \
-            ch->ninfo = 0;                                                          \
-            ch->nallocated = 2;                                                     \
+            PMIX_LOAD_PROCID(&ch->source, (p)->nptr->nspace,                        \
+                             (p)->info->pname.rank);                                \
+            PMIX_PROC_CREATE(ch->affected, 1);                                      \
+            ch->naffected = 1;                                                      \
+            PMIX_LOAD_PROCID(ch->affected, (p)->nptr->nspace,                       \
+                             (p)->info->pname.rank);                                \
+            PMIX_PROC_CREATE(ch->targets, 1);                                       \
+            ch->ntargets = 1;                                                       \
+            PMIX_LOAD_PROCID(ch->targets, (p)->nptr->nspace, PMIX_RANK_WILDCARD);   \
+            ch->ninfo = 1;                                                          \
+            ch->nallocated = 3;                                                     \
             ch->final_cbfunc = (f);                                                 \
             ch->final_cbdata = ch;                                                  \
             PMIX_INFO_CREATE(ch->info, ch->nallocated);                             \
+            /* mark for non-default handlers only */                                \
+            PMIX_INFO_LOAD(&ch->info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);  \
             /* cache it */                                                          \
             pmix_list_append(&pmix_globals.cached_events, &ch->super);              \
             ch->timer_active = true;                                                \

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -88,8 +88,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         peer->recv_msg = NULL;
     }
     CLOSE_THE_SOCKET(peer->sd);
-    /* mark the peer as "gone" */
-    peer->finalized = true;
 
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
@@ -201,6 +199,9 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         }
         /* now decrease the refcount - might actually free the object */
         PMIX_RELEASE(peer->info);
+        /* mark the peer as "gone" since a release doesn't guarantee
+         * that the peer object doesn't persist */
+        peer->finalized = true;
 
         /* Release peer info */
         PMIX_RELEASE(peer);

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1076,6 +1076,10 @@ static void _deregister_client(int sd, short args, void *cbdata)
                     pmix_pnet.child_finalized(&cd->proc);
                     pmix_psensor.stop(peer, NULL);
                 }
+                /* ensure we close the socket to this peer so we don't
+                 * generate "connection lost" events should it be
+                 * subsequently "killed" by the host */
+                CLOSE_THE_SOCKET(peer->sd);
             }
             if (nptr->nlocalprocs == nptr->nfinalized) {
                 pmix_pnet.local_app_finalized(nptr);

--- a/test/simple/simpdie.c
+++ b/test/simple/simpdie.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -87,7 +87,9 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs;
-
+    pmix_status_t code[5] = {PMIX_ERR_PROC_ABORTING, PMIX_ERR_PROC_ABORTED,
+                             PMIX_ERR_PROC_REQUESTED_ABORT, PMIX_ERR_JOB_TERMINATED,
+                             PMIX_ERR_UNREACH};
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %d", myproc.nspace, myproc.rank, rc);
@@ -108,7 +110,7 @@ int main(int argc, char **argv)
     completed = false;
 
     /* register our errhandler */
-    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+    PMIx_Register_event_handler(code, 5, NULL, 0,
                                 notification_fn, errhandler_reg_callbk, NULL);
 
     /* call fence to sync */

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -614,7 +614,6 @@ int main(int argc, char **argv)
             pmix_list_append(&children, &child->super);
         }
     }
-    free(executable);
     pmix_argv_free(client_argv);
     pmix_argv_free(client_env);
 
@@ -626,14 +625,21 @@ int main(int argc, char **argv)
         nanosleep(&ts, NULL);
     }
 
-    /* see if anyone exited with non-zero status */
-    n=0;
-    PMIX_LIST_FOREACH(child, &children, wait_tracker_t) {
-        if (0 != child->exit_code) {
-            fprintf(stderr, "Child %d [%d] exited with status %d - test FAILED\n", n, child->pid, child->exit_code);
-        }
-        ++n;
+    /* see if anyone exited with non-zero status unless the test
+     * was expected to do so */
+    if (NULL == strstr(executable, "simpdie")) {
+      n=0;
+      PMIX_LIST_FOREACH(child, &children, wait_tracker_t) {
+          if (0 != child->exit_code) {
+              fprintf(stderr, "Child %d [%d] exited with status %d - test FAILED\n", n, child->pid, child->exit_code);
+          }
+          ++n;
+      }
+    } else if (1 == exit_code) {
+      exit_code = 0;
     }
+    free(executable);
+
     /* try notifying ourselves */
     ninfo = 3;
     PMIX_INFO_CREATE(info, ninfo);


### PR DESCRIPTION
Flag the event for non-default event handlers. Include the affected proc's ID.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>