### PR TITLE
Ensure clients still receive a socket termination when the server dies

### DIFF
--- a/src/event/pmix_event.h
+++ b/src/event/pmix_event.h
@@ -198,9 +198,15 @@ void pmix_event_timeout_cb(int fd, short flags, void *arg);
             ch->naffected = 1;                                                      \
             PMIX_LOAD_PROCID(ch->affected, (p)->nptr->nspace,                       \
                              (p)->info->pname.rank);                                \
-            PMIX_PROC_CREATE(ch->targets, 1);                                       \
-            ch->ntargets = 1;                                                       \
-            PMIX_LOAD_PROCID(ch->targets, (p)->nptr->nspace, PMIX_RANK_WILDCARD);   \
+            /* if I'm a client or tool and this is my server, then we don't */      \
+            /* set the targets - otherwise, we do */                                \
+            if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&                        \
+                !PMIX_CHECK_PROCID(&pmix_client_globals.myserver->info->pname,      \
+                                  &(p)->info->pname)) {                             \
+                PMIX_PROC_CREATE(ch->targets, 1);                                       \
+                ch->ntargets = 1;                                                       \
+                PMIX_LOAD_PROCID(ch->targets, (p)->nptr->nspace, PMIX_RANK_WILDCARD);   \
+            }                                                                       \
             ch->ninfo = 1;                                                          \
             ch->nallocated = 3;                                                     \
             ch->final_cbfunc = (f);                                                 \

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -89,7 +89,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     }
     CLOSE_THE_SOCKET(peer->sd);
 
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
+        !PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
         /* if I am a server, then we need to ensure that
          * we properly account for the loss of this client
          * from any local collectives in which it was

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2011,6 +2011,10 @@ static void connection_cleanup(int sd, short args, void *cbdata)
 {
     pmix_server_caddy_t *cd = (pmix_server_caddy_t*)cbdata;
 
+    /* ensure that we know the peer has finalized else we
+     * will generate an event - yes, it should have been
+     * done, but it is REALLY important that it be set */
+    cd->peer->finalized = true;
     pmix_ptl_base_lost_connection(cd->peer, PMIX_SUCCESS);
     /* cleanup the caddy */
     PMIX_RELEASE(cd);
@@ -2048,10 +2052,6 @@ static void op_cbfunc2(pmix_status_t status, void *cbdata)
         PMIX_RELEASE(reply);
     }
 
-    /* ensure that we know the peer has finalized else we
-     * will generate an event - yes, it should have been
-     * done, but it is REALLY important that it be set */
-    cd->peer->finalized = true;
     /* cleanup any lingering references to this peer - note
      * that we cannot call the lost_connection function
      * directly as we need the connection to still

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1155,6 +1155,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         /* wait for the ack to return */
         PMIX_WAIT_THREAD(&tev.lock);
         PMIX_DESTRUCT_LOCK(&tev.lock);
+
         if (tev.active) {
             pmix_event_del(&tev.ev);
         }
@@ -1195,6 +1196,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
                 PMIX_RELEASE(peer);
             }
         }
+
         PMIX_DESTRUCT(&pmix_server_globals.clients);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.collectives);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.remote_pnd);
@@ -1212,6 +1214,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
 
     /* finalize the class/object system */
     pmix_class_finalize();
+
     return PMIX_SUCCESS;
 }
 


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@open-mpi.org>