### PR TITLE
autogen.sh: remove outdated sym link

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,1 +1,0 @@
-autogen.pl


### PR DESCRIPTION
AFAIK, autogen.sh has never been used in PMIx (i.e., it's always been
autogen.pl in PMIx) -- this is just a holdover from its Open MPI
roots.  So remove this outdated sym link.

Signed-off-by: Jeff Squyres <jsquyres@cisco.com>