### PR TITLE
Fix race conditions in tracked requests

### DIFF
--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -285,6 +285,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
     bool event_active;
+    bool lost_connection;           // tracker went thru lost connection procedure
     char *id;                       // string identifier for the collective
     pmix_cmd_t type;
     pmix_proc_t pname;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -64,7 +64,7 @@ static void _timeout(int sd, short args, void *cbdata)
 
 void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
 {
-    pmix_server_trkr_t *trk;
+    pmix_server_trkr_t *trk, *tnxt;
     pmix_server_caddy_t *rinfo, *rnext;
     pmix_regevents_info_t *reginfoptr, *regnext;
     pmix_peer_events_info_t *pr, *pnext;
@@ -98,7 +98,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
          * participating - note that the proc would not
          * have been added to any collective tracker until
          * after it successfully connected */
-        PMIX_LIST_FOREACH(trk, &pmix_server_globals.collectives, pmix_server_trkr_t) {
+        PMIX_LIST_FOREACH_SAFE(trk, tnxt, &pmix_server_globals.collectives, pmix_server_trkr_t) {
             /* see if this proc is participating in this tracker */
             PMIX_LIST_FOREACH_SAFE(rinfo, rnext, &trk->local_cbs, pmix_server_caddy_t) {
                 if (!PMIX_CHECK_PROCID(&rinfo->peer->info->pname, &peer->info->pname)) {
@@ -114,7 +114,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                      * is nobody waiting for a response */
                     pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
                     PMIX_RELEASE(trk);
-                    continue;
+                    break;
                 }
                 /* if there are other participants waiting for a response,
                  * we need to let them know that this proc has disappeared

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2204,7 +2204,8 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     PMIX_ACQUIRE_OBJECT(scd);
 
     if (NULL == tracker) {
-        /* give them a release if they want it */
+        /* give them a release if they want it - this should
+         * never happen, but protect against the possibility */
         if (NULL != scd->cbfunc.relfn) {
             scd->cbfunc.relfn(scd->cbdata);
         }
@@ -2212,24 +2213,12 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
         return;
     }
 
-    /* if all local cbs have been removed, then this is
-     * a "stale" tracker being returned to us by the
-     * host - i.e., one or more of the local procs
-     * died during the collective and so we locally
-     * cleaned up. In this case, just release the
-     * tracker to avoid memory leaks */
-    if (0 == pmix_list_get_size(&tracker->local_cbs)) {
-        /* if the timer is active, clear it */
-        if (tracker->event_active) {
-            pmix_event_del(&tracker->ev);
-        }
-        PMIX_RELEASE(tracker);
-        /* give them a release if they want it */
-        if (NULL != scd->cbfunc.relfn) {
-            scd->cbfunc.relfn(scd->cbdata);
-        }
-        PMIX_RELEASE(scd);
-        return;
+    /* if we get here, then there are processes waiting
+     * for a response */
+
+    /* if the timer is active, clear it */
+    if (tracker->event_active) {
+        pmix_event_del(&tracker->ev);
     }
 
     /* pass the blobs being returned */
@@ -2316,7 +2305,12 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     xfer.bytes_used = 0;
     PMIX_DESTRUCT(&xfer);
 
-    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    if (!tracker->lost_connection) {
+        /* if this tracker has gone thru the "lost_connection" procedure,
+         * then it has already been removed from the list - otherwise,
+         * remove it now */
+        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    }
     PMIX_RELEASE(tracker);
     PMIX_LIST_DESTRUCT(&nslist);
 
@@ -2364,7 +2358,10 @@ static void get_cbfunc(pmix_status_t status, const char *data, size_t ndata, voi
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "server:get_cbfunc called with %d bytes", (int)ndata);
 
-    /* no need to thread-shift here as no global data is accessed */
+    /* no need to thread-shift here as no global data is accessed
+     * and we are called from another internal function
+     * (see pmix_server_get.c:pmix_pending_resolve) that
+     * has already been thread-shifted */
 
     if (NULL == cd) {
         /* nothing to do - but be sure to give them
@@ -2435,19 +2432,12 @@ static void _cnct(int sd, short args, void *cbdata)
         return;
     }
 
-    /* if all local cbs have been removed, then this is
-     * a "stale" tracker being returned to us by the
-     * host - i.e., one or more of the local procs
-     * died during the collective and so we locally
-     * cleaned up. In this case, just release the
-     * tracker to avoid memory leaks */
-    if (0 == pmix_list_get_size(&tracker->local_cbs)) {
-        /* if the timer is active, clear it */
-        if (tracker->event_active) {
-            pmix_event_del(&tracker->ev);
-        }
-        PMIX_RELEASE(tracker);
-        return;
+    /* if we get here, then there are processes waiting
+     * for a response */
+
+    /* if the timer is active, clear it */
+    if (tracker->event_active) {
+        pmix_event_del(&tracker->ev);
     }
 
     /* find the unique nspaces that are participating */
@@ -2573,7 +2563,12 @@ static void _cnct(int sd, short args, void *cbdata)
     if (NULL != nspaces) {
       pmix_argv_free(nspaces);
     }
-    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    if (!tracker->lost_connection) {
+        /* if this tracker has gone thru the "lost_connection" procedure,
+         * then it has already been removed from the list - otherwise,
+         * remove it now */
+        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    }
     PMIX_RELEASE(tracker);
 
     /* we are done */
@@ -2614,20 +2609,14 @@ static void _discnct(int sd, short args, void *cbdata)
         return;
     }
 
-    /* if all local cbs have been removed, then this is
-     * a "stale" tracker being returned to us by the
-     * host - i.e., one or more of the local procs
-     * died during the collective and so we locally
-     * cleaned up. In this case, just release the
-     * tracker to avoid memory leaks */
-    if (0 == pmix_list_get_size(&tracker->local_cbs)) {
-        /* if the timer is active, clear it */
-        if (tracker->event_active) {
-            pmix_event_del(&tracker->ev);
-        }
-        PMIX_RELEASE(tracker);
-        return;
+    /* if we get here, then there are processes waiting
+     * for a response */
+
+    /* if the timer is active, clear it */
+    if (tracker->event_active) {
+        pmix_event_del(&tracker->ev);
     }
+
     /* loop across all local procs in the tracker, sending them the reply */
     PMIX_LIST_FOREACH(cd, &tracker->local_cbs, pmix_server_caddy_t) {
         /* setup the reply */
@@ -2656,7 +2645,12 @@ static void _discnct(int sd, short args, void *cbdata)
   cleanup:
     /* cleanup the tracker -- the host RM is responsible for
      * telling us when to remove the nspace from our data */
-    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    if (!tracker->lost_connection) {
+        /* if this tracker has gone thru the "lost_connection" procedure,
+         * then it has already been removed from the list - otherwise,
+         * remove it now */
+        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
+    }
     PMIX_RELEASE(tracker);
 
     /* we are done */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3685,6 +3685,7 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
 static void tcon(pmix_server_trkr_t *t)
 {
     t->event_active = false;
+    t->lost_connection = false;
     t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN+1);
     t->pname.rank = PMIX_RANK_UNDEF;

--- a/test/simple/simpdmodex.c
+++ b/test/simple/simpdmodex.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
     (void)asprintf(&tmp, "%s-%d-remote", myproc.nspace, myproc.rank);
     value.type = PMIX_STRING;
     value.data.string = "1234";
-    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_REMOTE, tmp, &value))) {
+    if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, tmp, &value))) {
         pmix_output(0, "Client ns %s rank %d: PMIx_Put internal failed: %d", myproc.nspace, myproc.rank, rc);
         goto done;
     }


### PR DESCRIPTION
When a process that is participating in a tracked request (e.g., collectives or direct modex) fails, a race condition exists between the lost-connection procedure and the host callback. Resolve this by checking and removing the proc from the trackers, and check the lists upon host callback prior to removing them from the list.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>