### PR TITLE
Complete Query update for v2.1 compliance

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -981,6 +981,12 @@ typedef enum {
 #define PMIX_CHECK_KEY(a, b) \
     (0 == strncmp((a)->key, (b), PMIX_MAX_KEYLEN))
 
+#define PMIX_LOAD_KEY(a, b) \
+    do {                                            \
+        memset((a), 0, PMIX_MAX_KEYLEN+1);          \
+        pmix_strncpy((a), (b), PMIX_MAX_KEYLEN);    \
+    }while(0)
+
 /* define a convenience macro for loading nspaces */
 #define PMIX_LOAD_NSPACE(a, b)                      \
     do {                                            \


### PR DESCRIPTION
v2.1 of the PMIx Standard stipulates that the query API must cache any returned values so that subsequent queries can be locally resolved. It provides for a new attribute that indicates the cache should be refreshed for the specified values.

This implementation could be further optimized. It currently will refer the entire request to the host if _any_ included key in _qny_ query fails to locally resolve. Optimally, only the values that couldn't be resolved would be passed to the host, and the results of both the local and host requests then aggregated prior to return. Someone is welcome to implement!

Signed-off-by: Ralph Castain <rhc@open-mpi.org>