### PR TITLE
 dstor: fix detection of invalidated key

### DIFF
--- a/src/mca/common/dstore/dstore_file.h
+++ b/src/mca/common/dstore/dstore_file.h
@@ -10,11 +10,11 @@ typedef size_t (*pmix_common_dstore_key_size_fn)(char *key, size_t data_size);
 typedef size_t (*pmix_common_dstore_ext_slot_size_fn)(void);
 typedef int (*pmix_common_dstore_put_key_fn)(uint8_t *addr, char *key, void *buf,
                                               size_t size);
-typedef int (*pmix_common_dstore_is_invalid_fn)(uint8_t *addr);
-typedef int (*pmix_common_dstore_is_extslot_fn)(uint8_t *addr);
+typedef bool (*pmix_common_dstore_is_invalid_fn)(uint8_t *addr);
+typedef bool (*pmix_common_dstore_is_extslot_fn)(uint8_t *addr);
 typedef void (*pmix_common_dstore_set_invalid_fn)(uint8_t *addr);
 typedef size_t (*pmix_common_dstore_key_hash_fn)(const char *key);
-typedef int (*pmix_common_dstore_key_match_fn)(uint8_t *addr, const char *key,
+typedef bool (*pmix_common_dstore_key_match_fn)(uint8_t *addr, const char *key,
                                                   size_t key_hash);
 
 typedef struct {

--- a/src/mca/gds/ds12/gds_ds12_file.c
+++ b/src/mca/gds/ds12/gds_ds12_file.c
@@ -128,9 +128,9 @@ static int pmix_ds12_put_key(uint8_t *addr, char *key, void *buf, size_t size)
     return PMIX_SUCCESS;
 }
 
-static int pmix_ds12_is_invalid(uint8_t *addr)
+static bool pmix_ds12_is_invalid(uint8_t *addr)
 {
-    int ret = (0 == strncmp(ESH_REGION_INVALIDATED, ESH_KNAME_PTR_V12(addr),
+    bool ret = (0 == strncmp(ESH_REGION_INVALIDATED, ESH_KNAME_PTR_V12(addr),
                             ESH_KNAME_LEN_V12(ESH_KNAME_PTR_V12(addr))));
     return ret;
 }
@@ -141,17 +141,17 @@ static void pmix_ds12_set_invalid(uint8_t *addr)
             ESH_KNAME_LEN_V12(ESH_REGION_INVALIDATED));
 }
 
-static int pmix_ds12_is_ext_slot(uint8_t *addr)
+static bool pmix_ds12_is_ext_slot(uint8_t *addr)
 {
-    int ret;
+    bool ret;
     ret = (0 == strncmp(ESH_REGION_EXTENSION, ESH_KNAME_PTR_V12(addr),
                         ESH_KNAME_LEN_V12(ESH_KNAME_PTR_V12(addr))));
     return ret;
 }
 
-static int pmix_ds12_kname_match(uint8_t *addr, const char *key, size_t key_hash)
+static bool pmix_ds12_kname_match(uint8_t *addr, const char *key, size_t key_hash)
 {
-    int ret = 0;
+    bool ret = 0;
 
     ret =  (0 == strncmp(ESH_KNAME_PTR_V12(addr),
                          key, ESH_KNAME_LEN_V12(key)));

--- a/src/mca/gds/ds12/gds_ds20_file.c
+++ b/src/mca/gds/ds12/gds_ds20_file.c
@@ -117,9 +117,9 @@ static int pmix_ds20_put_key(uint8_t *addr, char *key, void *buf, size_t size)
     return PMIX_SUCCESS;
 }
 
-static int pmix_ds20_is_invalid(uint8_t *addr)
+static bool pmix_ds20_is_invalid(uint8_t *addr)
 {
-    int ret = (0 == strncmp(ESH_REGION_INVALIDATED, ESH_KNAME_PTR_V20(addr),
+    bool ret = (0 == strncmp(ESH_REGION_INVALIDATED, ESH_KNAME_PTR_V20(addr),
                             ESH_KNAME_LEN_V20(ESH_KNAME_PTR_V20(addr))));
     return ret;
 }
@@ -130,17 +130,17 @@ static void pmix_ds20_set_invalid(uint8_t *addr)
             ESH_KNAME_LEN_V20(ESH_REGION_INVALIDATED));
 }
 
-static int pmix_ds20_is_ext_slot(uint8_t *addr)
+static bool pmix_ds20_is_ext_slot(uint8_t *addr)
 {
-    int ret;
+    bool ret;
     ret = (0 == strncmp(ESH_REGION_EXTENSION, ESH_KNAME_PTR_V20(addr),
                         ESH_KNAME_LEN_V20(ESH_KNAME_PTR_V20(addr))));
     return ret;
 }
 
-static int pmix_ds20_kname_match(uint8_t *addr, const char *key, size_t key_hash)
+static bool pmix_ds20_kname_match(uint8_t *addr, const char *key, size_t key_hash)
 {
-    int ret = 0;
+    bool ret = 0;
 
     ret = (0 == strncmp(ESH_KNAME_PTR_V20(addr),
                         key, ESH_KNAME_LEN_V20(key)));

--- a/src/mca/gds/ds21/gds_ds21_file.c
+++ b/src/mca/gds/ds21/gds_ds21_file.c
@@ -66,7 +66,7 @@ static int pmix_ds21_is_invalid(uint8_t *addr)
 {
     size_t sz;
     memcpy(&sz, addr, sizeof(size_t));
-    return (sz & ESH_REGION_INVALIDATED_FLG);
+    return !!(sz & ESH_REGION_INVALIDATED_FLG);
 }
 
 static void pmix_ds21_set_invalid(uint8_t *addr)

--- a/src/mca/gds/ds21/gds_ds21_file.c
+++ b/src/mca/gds/ds21/gds_ds21_file.c
@@ -62,7 +62,7 @@ __pmix_attribute_extension__ ({                             \
 #define EXT_SLOT_SIZE_V21()                                 \
     (ESH_KEY_SIZE_V21("", sizeof(size_t)))
 
-static int pmix_ds21_is_invalid(uint8_t *addr)
+static bool pmix_ds21_is_invalid(uint8_t *addr)
 {
     size_t sz;
     memcpy(&sz, addr, sizeof(size_t));
@@ -77,7 +77,7 @@ static void pmix_ds21_set_invalid(uint8_t *addr)
     memcpy(addr, &sz, sizeof(size_t));
 }
 
-static int pmix_ds21_is_ext_slot(uint8_t *addr)
+static bool pmix_ds21_is_ext_slot(uint8_t *addr)
 {
     size_t sz;
     memcpy(&sz, addr, sizeof(size_t));
@@ -94,9 +94,9 @@ static size_t pmix_ds21_key_hash(const char *key)
     return hash;
 }
 
-static int pmix_ds21_kname_match(uint8_t *addr, const char *key, size_t key_hash)
+static bool pmix_ds21_kname_match(uint8_t *addr, const char *key, size_t key_hash)
 {
-    int ret = 0;
+    bool ret = 0;
     size_t hash;
     memcpy(&hash, (char*)addr + sizeof(size_t), sizeof(size_t));
     if( key_hash != hash ) {


### PR DESCRIPTION
- fix detection of invalidated key
- moved the return code of compare and check flag operations to boolean type