### PR TITLE
Fix group construct/destruct

### DIFF
--- a/examples/group.c
+++ b/examples/group.c
@@ -181,8 +181,8 @@ int main(int argc, char **argv)
         if (NULL != results) {
             cid = 0;
             PMIX_VALUE_GET_NUMBER(rc, &results[0].value, cid, size_t);
-            fprintf(stderr, "%d Group construct complete with status %s CID %d\n",
-                    myproc.rank, PMIx_Error_string(rc), (int)cid);
+            fprintf(stderr, "%d Group construct complete with status %s KEY %s CID %d\n",
+                    myproc.rank, PMIx_Error_string(rc), results[0].key, (int)cid);
         } else {
             fprintf(stderr, "%d Group construct complete, but no CID returned\n", myproc.rank);
         }

--- a/include/pmix_server.h
+++ b/include/pmix_server.h
@@ -496,6 +496,8 @@ typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
  * PMIX_GROUP_ASSIGN_CONTEXT_ID - request that the RM assign a unique
  *                                numerical (size_t) ID to this group
  *
+ * grp - user-assigned string ID of this group
+ *
  * op - pmix_group_operation_t value indicating the operation to perform
  *      Current values support construct and destruct of the group
  *
@@ -511,7 +513,7 @@ typedef pmix_status_t (*pmix_server_stdin_fn_t)(const pmix_proc_t *source,
  *
  * cbdata - object to be returned in cbfunc
  */
-typedef pmix_status_t (*pmix_server_grp_fn_t)(pmix_group_operation_t op,
+typedef pmix_status_t (*pmix_server_grp_fn_t)(pmix_group_operation_t op, char grp[],
                                               const pmix_proc_t procs[], size_t nprocs,
                                               const pmix_info_t directives[], size_t ndirs,
                                               pmix_info_cbfunc_t cbfunc, void *cbdata);

--- a/src/client/pmix_client_group.c
+++ b/src/client/pmix_client_group.c
@@ -292,7 +292,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_construct_nb(const char grp[],
     if (embed && NULL != iptr) {
         PMIX_INFO_FREE(iptr, num);
     }
-    if (NULL != msg) {
+    if (PMIX_SUCCESS != rc && NULL != msg) {
         PMIX_RELEASE(msg);
     }
     return rc;
@@ -452,7 +452,7 @@ PMIX_EXPORT pmix_status_t PMIx_Group_destruct_nb(const char grp[],
     if (embed && NULL != iptr) {
         PMIX_INFO_FREE(iptr, num);
     }
-    if (NULL != msg) {
+    if (PMIX_SUCCESS != rc && NULL != msg) {
         PMIX_RELEASE(msg);
     }
     return rc;


### PR DESCRIPTION
Avoid double-destruct of message. Break race condition when
operation-succeeded is returned

Signed-off-by: Ralph Castain <rhc@open-mpi.org>