### PR TITLE
iof: plug a memory leak in the pmix_iof_req_t destructor

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -238,6 +238,9 @@ static void iofreqdes(pmix_iof_req_t *p)
     if (NULL != p->peer) {
         PMIX_RELEASE(p->peer);
     }
+    if (NULL != p->pname.nspace) {
+        free(p->pname.nspace);
+    }
 }
 PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_iof_req_t,
                                 pmix_list_item_t,


### PR DESCRIPTION
Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>