### PR TITLE
plug a memory leak in pmix_value_destruct()

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2500,6 +2500,8 @@ static inline void pmix_value_destruct(pmix_value_t * m) {
         }
     } else if (PMIX_ENVAR == (m)->type) {
         PMIX_ENVAR_DESTRUCT(&(m)->data.envar);
+    } else if (PMIX_PROC == (m)->type) {
+        PMIX_PROC_RELEASE((m)->data.proc);
     }
 }
 


### PR DESCRIPTION
Release the pmix_proc_t array when the value is a PMIX_PROC

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>