### PR TITLE
Restore prior sizes for max nslen and keylen

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -81,8 +81,8 @@ extern "C" {
 /****  PMIX CONSTANTS    ****/
 
 /* define maximum value and key sizes */
-#define PMIX_MAX_NSLEN     63
-#define PMIX_MAX_KEYLEN    63
+#define PMIX_MAX_NSLEN     255
+#define PMIX_MAX_KEYLEN    511
 
 /* define abstract types for namespaces and keys */
 typedef char pmix_nspace_t[PMIX_MAX_NSLEN+1];


### PR DESCRIPTION
Remain compliant with the standard, but handling different max length
values requires a fairly significant change beyond what we have time to
implement at this point.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>