### PR TITLE
server: have query_cbfunc invoke the release callback when available

### DIFF
--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2783,6 +2783,9 @@ static void query_cbfunc(pmix_status_t status,
     }
     PMIX_RELEASE(qcd);
     PMIX_RELEASE(cd);
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
 }
 
 static void cred_cbfunc(pmix_status_t status,


### PR DESCRIPTION
Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>