### PR TITLE
Overhaul the event caching system

### DIFF
--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -360,13 +360,15 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
 
 static void check_cached_events(pmix_rshift_caddy_t *cd)
 {
-    size_t i, n;
+    size_t n;
     pmix_notify_caddy_t *ncd;
     bool found, matched;
     pmix_event_chain_t *chain;
+    int j;
 
-    for (i=0; i < (size_t)pmix_globals.notifications.size; i++) {
-        if (NULL == (ncd = (pmix_notify_caddy_t*)pmix_ring_buffer_poke(&pmix_globals.notifications, i))) {
+    for (j=0; j < pmix_globals.max_events; j++) {
+        pmix_hotel_knock(&pmix_globals.notifications, j, (void**)&ncd);
+        if (NULL == ncd) {
             continue;
         }
         found = false;

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -260,6 +260,8 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_listener_t,
 static void qcon(pmix_ptl_queue_t *p)
 {
     p->peer = NULL;
+    p->buf = NULL;
+    p->tag = UINT32_MAX;
 }
 static void qdes(pmix_ptl_queue_t *p)
 {

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -52,6 +52,9 @@ extern bool pmix_init_called;
 
 void pmix_rte_finalize(void)
 {
+    int i;
+    pmix_notify_caddy_t *cd;
+
     if( --pmix_initialized != 0 ) {
         if( pmix_initialized < 0 ) {
             fprintf(stderr, "PMIx Finalize called too many times\n");
@@ -104,9 +107,10 @@ void pmix_rte_finalize(void)
     PMIX_RELEASE(pmix_globals.mypeer);
     PMIX_DESTRUCT(&pmix_globals.events);
     PMIX_LIST_DESTRUCT(&pmix_globals.cached_events);
-    {
-        pmix_notify_caddy_t *cd;
-        while (NULL != (cd=(pmix_notify_caddy_t *)pmix_ring_buffer_pop(&pmix_globals.notifications))) {
+    /* clear any notifications */
+    for (i=0; i < pmix_globals.max_events; i++) {
+        pmix_hotel_checkout_and_return_occupant(&pmix_globals.notifications, i, (void**)&cd);
+        if (NULL != cd) {
             PMIX_RELEASE(cd);
         }
     }

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -242,6 +242,22 @@ pmix_status_t pmix_register_params(void)
                                        PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                        &pmix_globals.timestamp_output);
 
+    /* max size of the notification hotel */
+    pmix_globals.max_events = 512;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "max", "events",
+                                       "Maximum number of event notifications to cache",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_globals.max_events);
+
+    /* how long to cache an event */
+    pmix_globals.event_eviction_time = 120;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "event", "eviction_time",
+                                       "Maximum number of seconds to cache an event",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_globals.event_eviction_time);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -644,6 +644,97 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_nspace(const pmix_nspace_t nspace
     return PMIX_SUCCESS;
 }
 
+void pmix_server_purge_events(pmix_peer_t *peer,
+                              pmix_proc_t *proc)
+{
+    pmix_regevents_info_t *reginfo, *regnext;
+    pmix_peer_events_info_t *prev, *pnext;
+    pmix_iof_req_t *req, *nxt;
+    int i;
+    pmix_notify_caddy_t *ncd;
+    size_t n, m, p, ntgs;
+    pmix_proc_t *tgs, *tgt;
+    pmix_dmdx_local_t *dlcd, *dnxt;
+
+    /* since the client is finalizing, remove them from any event
+     * registrations they may still have on our list */
+    PMIX_LIST_FOREACH_SAFE(reginfo, regnext, &pmix_server_globals.events, pmix_regevents_info_t) {
+        PMIX_LIST_FOREACH_SAFE(prev, pnext, &reginfo->peers, pmix_peer_events_info_t) {
+            if ((NULL != peer && prev->peer == peer) ||
+                (NULL != proc && PMIX_CHECK_PROCID(proc, &prev->peer->info->pname))) {
+                pmix_list_remove_item(&reginfo->peers, &prev->super);
+                PMIX_RELEASE(prev);
+                if (0 == pmix_list_get_size(&reginfo->peers)) {
+                    pmix_list_remove_item(&pmix_server_globals.events, &reginfo->super);
+                    PMIX_RELEASE(reginfo);
+                    break;
+                }
+            }
+        }
+    }
+
+    /* since the client is finalizing, remove them from any IOF
+     * registrations they may still have on our list */
+    PMIX_LIST_FOREACH_SAFE(req, nxt, &pmix_globals.iof_requests, pmix_iof_req_t) {
+        if ((NULL != peer && PMIX_CHECK_PROCID(&req->peer->info->pname, &peer->info->pname)) ||
+            (NULL != proc && PMIX_CHECK_PROCID(&req->peer->info->pname, proc))) {
+            pmix_list_remove_item(&pmix_globals.iof_requests, &req->super);
+            PMIX_RELEASE(req);
+        }
+    }
+
+    /* see if this proc is involved in any direct modex requests */
+    PMIX_LIST_FOREACH_SAFE(dlcd, dnxt, &pmix_server_globals.local_reqs, pmix_dmdx_local_t) {
+        if ((NULL != peer && PMIX_CHECK_PROCID(&peer->info->pname, &dlcd->proc)) ||
+            (NULL != proc && PMIX_CHECK_PROCID(proc, &dlcd->proc))) {
+                /* cleanup this request */
+            pmix_list_remove_item(&pmix_server_globals.local_reqs, &dlcd->super);
+                /* we can release the dlcd item here because we are not
+                 * releasing the tracker held by the host - we are only
+                 * releasing one item on that tracker */
+            PMIX_RELEASE(dlcd);
+        }
+    }
+
+    /* purge this client from any cached notifications */
+    for (i=0; i < pmix_globals.max_events; i++) {
+       pmix_hotel_knock(&pmix_globals.notifications, i, (void**)&ncd);
+        if (NULL != ncd && NULL != ncd->targets && 0 < ncd->ntargets) {
+            tgt = NULL;
+            for (n=0; n < ncd->ntargets; n++) {
+                if ((NULL != peer && PMIX_CHECK_PROCID(&peer->info->pname, &ncd->targets[n])) ||
+                    (NULL != proc && PMIX_CHECK_PROCID(proc, &ncd->targets[n]))) {
+                    tgt = &ncd->targets[n];
+                    break;
+                }
+            }
+            if (NULL != tgt) {
+                /* if this client was the only target, then just
+                 * evict the notification */
+                if (1 == ncd->ntargets) {
+                    pmix_hotel_checkout(&pmix_globals.notifications, i);
+                    PMIX_RELEASE(ncd);
+                } else if (PMIX_RANK_WILDCARD == tgt->rank &&
+                           NULL != proc && PMIX_RANK_WILDCARD == proc->rank) {
+                    /* we have to remove this target, but leave the rest */
+                    ntgs = ncd->ntargets - 1;
+                    PMIX_PROC_CREATE(tgs, ntgs);
+                    p=0;
+                    for (m=0; m < ncd->ntargets; m++) {
+                        if (tgt != &ncd->targets[m]) {
+                            memcpy(&tgs[p], &ncd->targets[n], sizeof(pmix_proc_t));
+                            ++p;
+                        }
+                    }
+                    PMIX_PROC_FREE(ncd->targets, ncd->ntargets);
+                    ncd->targets = tgs;
+                    ncd->ntargets = ntgs;
+                }
+            }
+        }
+    }
+}
+
 static void _deregister_nspace(int sd, short args, void *cbdata)
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
@@ -656,11 +747,15 @@ static void _deregister_nspace(int sd, short args, void *cbdata)
                         "pmix:server _deregister_nspace %s",
                         cd->proc.nspace);
 
-    /* release any job-level messaging resources */
+    /* release any job-level network resources */
     pmix_pnet.deregister_nspace(cd->proc.nspace);
 
     /* let our local storage clean up */
     PMIX_GDS_DEL_NSPACE(rc, cd->proc.nspace);
+
+    /* remove any event registrations, IOF registrations, and
+     * cached notifications targeting procs from this nspace */
+    pmix_server_purge_events(NULL, &cd->proc);
 
     /* release this nspace */
     PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
@@ -698,8 +793,8 @@ PMIX_EXPORT void PMIx_server_deregister_nspace(const pmix_nspace_t nspace,
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
-     cd = PMIX_NEW(pmix_setup_caddy_t);
-    pmix_strncpy(cd->proc.nspace, nspace, PMIX_MAX_NSLEN);
+    cd = PMIX_NEW(pmix_setup_caddy_t);
+    PMIX_LOAD_PROCID(&cd->proc, nspace, PMIX_RANK_WILDCARD);
     cd->opcbfunc = cbfunc;
     cd->cbdata = cbdata;
 
@@ -2995,9 +3090,6 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
     pmix_server_caddy_t *cd;
     pmix_proc_t proc;
     pmix_buffer_t *reply;
-    pmix_regevents_info_t *reginfo;
-    pmix_peer_events_info_t *prev;
-    pmix_iof_req_t *req, *nxt;
 
     /* retrieve the cmd */
     cnt = 1;
@@ -3077,26 +3169,8 @@ static pmix_status_t server_switchyard(pmix_peer_t *peer, uint32_t tag,
         pmix_output_verbose(2, pmix_server_globals.base_output,
                             "recvd FINALIZE");
         peer->nptr->nfinalized++;
-        /* since the client is finalizing, remove them from any event
-         * registrations they may still have on our list */
-        PMIX_LIST_FOREACH(reginfo, &pmix_server_globals.events, pmix_regevents_info_t) {
-            PMIX_LIST_FOREACH(prev, &reginfo->peers, pmix_peer_events_info_t) {
-                if (prev->peer == peer) {
-                    pmix_list_remove_item(&reginfo->peers, &prev->super);
-                    PMIX_RELEASE(prev);
-                    break;
-                }
-            }
-        }
-        /* since the client is finalizing, remove them from any IOF
-         * registrations they may still have on our list */
-        PMIX_LIST_FOREACH_SAFE(req, nxt, &pmix_globals.iof_requests, pmix_iof_req_t) {
-            if (PMIX_CHECK_NSPACE(req->peer->info->pname.nspace, peer->info->pname.nspace) &&
-                req->peer->info->pname.rank == peer->info->pname.rank) {
-                pmix_list_remove_item(&pmix_globals.iof_requests, &req->super);
-                PMIX_RELEASE(req);
-            }
-        }
+        /* purge events */
+        pmix_server_purge_events(peer, NULL);
         /* turn off the recv event - we shouldn't hear anything
          * more from this proc */
         if (peer->recv_ev_active) {

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -46,6 +46,9 @@
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>
 #endif
+#ifdef HAVE_TIME_H
+#include <time.h>
+#endif
 #include PMIX_EVENT_HEADER
 
 #include "src/class/pmix_hotel.h"
@@ -1879,9 +1882,10 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
     }
 
     /* check if any matching notifications have been cached */
-    for (i=0; i < pmix_globals.notifications.size; i++) {
-        if (NULL == (cd = (pmix_notify_caddy_t*)pmix_ring_buffer_poke(&pmix_globals.notifications, i))) {
-            break;
+    for (i=0; i < pmix_globals.max_events; i++) {
+        pmix_hotel_knock(&pmix_globals.notifications, i, (void**)&cd);
+        if (NULL == cd) {
+            continue;
         }
         found = false;
         if (NULL == codes) {
@@ -4027,7 +4031,12 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,
 
 static void ncon(pmix_notify_caddy_t *p)
 {
+    struct timespec tp;
+
     PMIX_CONSTRUCT_LOCK(&p->lock);
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    p->ts = tp.tv_sec;
+    p->room = -1;
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN+1);
     p->source.rank = PMIX_RANK_UNDEF;
     p->range = PMIX_RANGE_UNDEF;

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -337,7 +337,11 @@ void pmix_server_message_handler(struct pmix_peer_t *pr,
                                  pmix_ptl_hdr_t *hdr,
                                  pmix_buffer_t *buf, void *cbdata);
 
+void pmix_server_purge_events(pmix_peer_t *peer,
+                              pmix_proc_t *proc);
+
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;
+
 
 #endif // PMIX_SERVER_OPS_H


### PR DESCRIPTION
Events were being cached forever, leading to a flood hitting a newly
connected client that sometimes overwhelmed the system. There is likely
still something not quite right on the client side of the event
notification system as it shouldn't be getting overwhelmed. However,
cleaning up the system a bit won't hurt and we can then take a deeper
dive into the client side code.

Ensure that all cached objects (IOF requests, event registrations,
notifications) get purged when a proc finalizes or abruptly terminates,
and when nspaces are deregistered.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>