### PR TITLE
Overhaul the event caching system

### DIFF
--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -360,13 +360,15 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
 
 static void check_cached_events(pmix_rshift_caddy_t *cd)
 {
-    size_t i, n;
+    size_t n;
     pmix_notify_caddy_t *ncd;
     bool found, matched;
     pmix_event_chain_t *chain;
+    int j;
 
-    for (i=0; i < (size_t)pmix_globals.notifications.size; i++) {
-        if (NULL == (ncd = (pmix_notify_caddy_t*)pmix_ring_buffer_poke(&pmix_globals.notifications, i))) {
+    for (j=0; j < pmix_globals.max_events; j++) {
+        pmix_hotel_knock(&pmix_globals.notifications, j, (void**)&ncd);
+        if (NULL == ncd) {
             continue;
         }
         found = false;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -36,7 +36,7 @@
 
 #include "src/class/pmix_hash_table.h"
 #include "src/class/pmix_list.h"
-#include "src/class/pmix_ring_buffer.h"
+#include "src/class/pmix_hotel.h"
 #include "src/event/pmix_event.h"
 #include "src/threads/threads.h"
 
@@ -399,6 +399,11 @@ typedef struct {
     pmix_object_t super;
     pmix_event_t ev;
     pmix_lock_t lock;
+    /* timestamp receipt of the notification so we
+     * can evict the oldest one if we get overwhelmed */
+    time_t ts;
+    /* what room of the hotel they are in */
+    int room;
     pmix_status_t status;
     pmix_proc_t source;
     pmix_data_range_t range;
@@ -453,7 +458,9 @@ typedef struct {
     struct timeval event_window;
     pmix_list_t cached_events;          // events waiting in the window prior to processing
     pmix_list_t iof_requests;           // list of pmix_iof_req_t IOF requests
-    pmix_ring_buffer_t notifications;   // ring buffer of pending notifications
+    int max_events;                     // size of the notifications hotel
+    int event_eviction_time;            // max time to cache notifications
+    pmix_hotel_t notifications;         // hotel of pending notifications
     /* processes also need a place where they can store
      * their own internal data - e.g., data provided by
      * the user via the store_internal interface, as well

--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -258,6 +258,8 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_listener_t,
 static void qcon(pmix_ptl_queue_t *p)
 {
     p->peer = NULL;
+    p->buf = NULL;
+    p->tag = UINT32_MAX;
 }
 static void qdes(pmix_ptl_queue_t *p)
 {

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -52,6 +52,9 @@ extern bool pmix_init_called;
 
 void pmix_rte_finalize(void)
 {
+    int i;
+    pmix_notify_caddy_t *cd;
+
     if( --pmix_initialized != 0 ) {
         if( pmix_initialized < 0 ) {
             fprintf(stderr, "PMIx Finalize called too many times\n");
@@ -104,9 +107,10 @@ void pmix_rte_finalize(void)
     PMIX_RELEASE(pmix_globals.mypeer);
     PMIX_DESTRUCT(&pmix_globals.events);
     PMIX_LIST_DESTRUCT(&pmix_globals.cached_events);
-    {
-        pmix_notify_caddy_t *cd;
-        while (NULL != (cd=(pmix_notify_caddy_t *)pmix_ring_buffer_pop(&pmix_globals.notifications))) {
+    /* clear any notifications */
+    for (i=0; i < pmix_globals.max_events; i++) {
+        pmix_hotel_checkout_and_return_occupant(&pmix_globals.notifications, i, (void**)&cd);
+        if (NULL != cd) {
             PMIX_RELEASE(cd);
         }
     }

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -242,6 +242,22 @@ pmix_status_t pmix_register_params(void)
                                        PMIX_INFO_LVL_9, PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                        &pmix_globals.timestamp_output);
 
+    /* max size of the notification hotel */
+    pmix_globals.max_events = 512;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "max", "events",
+                                       "Maximum number of event notifications to cache",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_globals.max_events);
+
+    /* how long to cache an event */
+    pmix_globals.event_eviction_time = 120;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "event", "eviction_time",
+                                       "Maximum number of seconds to cache an event",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_globals.event_eviction_time);
+
     return PMIX_SUCCESS;
 }
 

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -314,7 +314,11 @@ void pmix_server_message_handler(struct pmix_peer_t *pr,
                                  pmix_ptl_hdr_t *hdr,
                                  pmix_buffer_t *buf, void *cbdata);
 
+void pmix_server_purge_events(pmix_peer_t *peer,
+                              pmix_proc_t *proc);
+
 PMIX_EXPORT extern pmix_server_module_t pmix_host_server;
 PMIX_EXPORT extern pmix_server_globals_t pmix_server_globals;
+
 
 #endif // PMIX_SERVER_OPS_H


### PR DESCRIPTION
Events were being cached forever, leading to a flood hitting a newly
connected client that sometimes overwhelmed the system. There is likely
still something not quite right on the client side of the event
notification system as it shouldn't be getting overwhelmed. However,
cleaning up the system a bit won't hurt and we can then take a deeper
dive into the client side code.

Ensure that all cached objects (IOF requests, event registrations,
notifications) get purged when a proc finalizes or abruptly terminates,
and when nspaces are deregistered.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>
(cherry picked from commit b7f0075fcdac8dee7baf891472855ea0530e4c2c)