### PR TITLE
Enable passing of error message in event

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -357,6 +357,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_EVENT_DO_NOT_CACHE             "pmix.evnocache"        // (bool) instruct the PMIx server not to cache the event
 #define PMIX_EVENT_SILENT_TERMINATION       "pmix.evsilentterm"     // (bool) do not generate an event when this job normally terminates
 #define PMIX_EVENT_PROXY                    "pmix.evproxy"          // (pmix_proc_t*) PMIx server that sourced the event
+#define PMIX_EVENT_TEXT_MESSAGE             "pmix.evtext"           // (char*) text message suitable for output by recipient - e.g., describing
+                                                                    //         the cause of the event
 
 /* fault tolerance-related events */
 #define PMIX_EVENT_TERMINATE_SESSION        "pmix.evterm.sess"      // (bool) RM intends to terminate session

--- a/src/client/pmix_client_spawn.c
+++ b/src/client/pmix_client_spawn.c
@@ -240,27 +240,25 @@ static void wait_cbfunc(struct pmix_peer_t *pr,
         PMIX_ERROR_LOG(rc);
         ret = rc;
     }
-    if (PMIX_SUCCESS == ret) {
-        /* unpack the namespace */
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
-                           buf, &n2, &cnt, PMIX_STRING);
+    /* unpack the namespace */
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
+                       buf, &n2, &cnt, PMIX_STRING);
+    if (PMIX_SUCCESS != rc && PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
+        PMIX_ERROR_LOG(rc);
+        ret = rc;
+    }
+    pmix_output_verbose(1, pmix_globals.debug_output,
+                    "pmix:client recv '%s'", n2);
+
+    if (NULL != n2) {
+        /* protect length */
+        pmix_strncpy(nspace, n2, PMIX_MAX_NSLEN);
+        free(n2);
+        PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, buf);
+        /* extract and process any job-related info for this nspace */
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            ret = rc;
-        }
-        pmix_output_verbose(1, pmix_globals.debug_output,
-                        "pmix:client recv '%s'", n2);
-
-        if (NULL != n2) {
-            /* protect length */
-            pmix_strncpy(nspace, n2, PMIX_MAX_NSLEN);
-            free(n2);
-            PMIX_GDS_STORE_JOB_INFO(rc, pmix_globals.mypeer, nspace, buf);
-            /* extract and process any job-related info for this nspace */
-            if (PMIX_SUCCESS != rc) {
-                PMIX_ERROR_LOG(rc);
-            }
         }
     }
 


### PR DESCRIPTION
Required when notifying that a job abnormally terminated so we can
provide a more detailed explanation of the cause

Always pass back the spawned nspace, if provided.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>