### PR TITLE
event: fix notify_event_cache() eviction algorithm

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -134,11 +134,11 @@ static pmix_status_t notify_event_cache(pmix_notify_caddy_t *cd)
             }
             /* check the age */
             if (0 == j) {
-                etime = cd->ts;
+                etime = pk->ts;
                 idx = j;
             } else {
-                if (difftime(cd->ts, etime) < 0) {
-                    etime = cd->ts;
+                if (difftime(pk->ts, etime) < 0) {
+                    etime = pk->ts;
                     idx = j;
                 }
             }


### PR DESCRIPTION
Correctly compute the oldest notification that should be
evicted in order to make room for the new one.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>