### PR TITLE
Remove events once all targets notified

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -109,6 +109,9 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_RANK_LOCAL_PEERS   UINT32_MAX-4        // all peers (i.e., all procs within the same nspace) on local node
 /* define an invalid value */
 #define PMIX_RANK_INVALID   UINT32_MAX-3
+/* define a boundary for valid ranks */
+#define PMIX_RANK_VALID         UINT32_MAX-50
+
 
 /****  PMIX ENVIRONMENTAL PARAMETERS  ****/
 /* There are a few environmental parameters used by PMIx for

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -388,15 +388,11 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
         if (!found) {
             continue;
         }
-       /* if we were given specific targets, check if we are one */
+        /* if we were given specific targets, check if we are one */
         if (NULL != ncd->targets) {
             matched = false;
             for (n=0; n < ncd->ntargets; n++) {
-                if (0 != strncmp(pmix_globals.myid.nspace, ncd->targets[n].nspace, PMIX_MAX_NSLEN)) {
-                    continue;
-                }
-                if (PMIX_RANK_WILDCARD == ncd->targets[n].rank ||
-                    pmix_globals.myid.rank == ncd->targets[n].rank) {
+                if (PMIX_CHECK_PROCID(&pmix_globals.myid, &ncd->targets[n])) {
                     matched = true;
                     break;
                 }
@@ -446,6 +442,12 @@ static void check_cached_events(pmix_rshift_caddy_t *cd)
                 }
             }
         }
+        /* check this event out of the cache since we
+         * are processing it */
+        pmix_hotel_checkout(&pmix_globals.notifications, ncd->room);
+        /* release the storage */
+        PMIX_RELEASE(ncd);
+
         /* we don't want this chain to propagate, so indicate it
          * should only be run as a single-shot */
         chain->endchain = true;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -420,6 +420,7 @@ typedef struct {
      */
     pmix_proc_t *targets;
     size_t ntargets;
+    size_t nleft;   // number of targets left to be notified
     /* When generating a notification, the originator can
      * specify the range of procs affected by this event.
      * For example, when creating a JOB_TERMINATED event,

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
@@ -197,7 +197,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
              * we are just seeing their connection go away
              * when they terminate - so do not generate
              * an event. If not, then we do */
-            PMIX_REPORT_EVENT(err, peer, PMIX_RANGE_NAMESPACE, _notify_complete);
+            PMIX_REPORT_EVENT(err, peer, PMIX_RANGE_PROC_LOCAL, _notify_complete);
         }
         /* now decrease the refcount - might actually free the object */
         PMIX_RELEASE(peer->info);
@@ -234,7 +234,7 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         PMIX_DESTRUCT(&buf);
         /* if I called finalize, then don't generate an event */
         if (!pmix_globals.mypeer->finalized) {
-            PMIX_REPORT_EVENT(err, pmix_client_globals.myserver, PMIX_RANGE_LOCAL, _notify_complete);
+            PMIX_REPORT_EVENT(err, pmix_client_globals.myserver, PMIX_RANGE_PROC_LOCAL, _notify_complete);
         }
     }
 }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -1648,6 +1648,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
     pmix_cmd_t cmd = PMIX_NOTIFY_CMD;
     pmix_proc_t *affected = NULL;
     size_t naffected = 0;
+    pmix_range_trkr_t rngtrk;
+    pmix_proc_t proc;
 
     pmix_output_verbose(2, pmix_server_globals.event_output,
                         "recvd register events for peer %s:%d",
@@ -1882,6 +1884,8 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
     }
 
     /* check if any matching notifications have been cached */
+    rngtrk.procs = NULL;
+    rngtrk.nprocs = 0;
     for (i=0; i < pmix_globals.max_events; i++) {
         pmix_hotel_knock(&pmix_globals.notifications, i, (void**)&cd);
         if (NULL == cd) {
@@ -1904,7 +1908,13 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
         if (!found) {
             continue;
         }
-       /* if we were given specific targets, check if this is one */
+        /* check the range */
+        rngtrk.range = cd->range;
+        PMIX_LOAD_PROCID(&proc, peer->info->pname.nspace, peer->info->pname.rank);
+        if (!pmix_notify_check_range(&rngtrk, &proc)) {
+            continue;
+        }
+        /* if we were given specific targets, check if this is one */
         found = false;
         if (NULL != cd->targets) {
             matched = false;

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -926,6 +926,7 @@ static void lkcbfn(int sd, short args, void *cbdata)
 
     lk->cbfunc(PMIX_SUCCESS, lk->pd, lk->n, lk->cbdata);
     PMIX_PDATA_FREE(lk->pd, lk->n);
+    free(lk);
 }
 
 static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
@@ -937,7 +938,7 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
     size_t i, n;
     pmix_pdata_t *pd = NULL;
     pmix_status_t ret = PMIX_ERR_NOT_FOUND;
-    lkobj_t lk;
+    lkobj_t *lk;
 
     pmix_output(0, "SERVER: LOOKUP");
 
@@ -971,11 +972,12 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
     }
     PMIX_LIST_DESTRUCT(&results);
     if (PMIX_SUCCESS == ret) {
-        lk.pd = pd;
-        lk.n = n;
-        lk.cbfunc = cbfunc;
-        lk.cbdata = cbdata;
-        PMIX_THREADSHIFT(&lk, lkcbfn);
+        lk = (lkobj_t*)malloc(sizeof(lkobj_t));
+        lk->pd = pd;
+        lk->n = n;
+        lk->cbfunc = cbfunc;
+        lk->cbdata = cbdata;
+        PMIX_THREADSHIFT(lk, lkcbfn);
     }
 
     return ret;


### PR DESCRIPTION
If the event generator specified targets, then track how many targets we
are to notify. Once we have notified them, then evict the event from the
cache hotel to clear room for the next one.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>