### PR TITLE
Properly cache IO for pending registrants

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -1050,16 +1050,18 @@ typedef struct pmix_byte_object {
         }                               \
     } while(0)
 
-#define PMIX_BYTE_OBJECT_FREE(m, n)         \
-    do {                                    \
-        size_t _n;                          \
-        for (_n=0; _n < n; _n++) {          \
-            if (NULL != (m)[_n].bytes) {    \
-                free((m)[_n].bytes);        \
-            }                               \
-        }                                   \
-        free((m));                          \
-        (m) = NULL;                         \
+#define PMIX_BYTE_OBJECT_FREE(m, n)             \
+    do {                                        \
+        size_t _n;                              \
+        if (NULL != (m)) {                      \
+            for (_n=0; _n < n; _n++) {          \
+                if (NULL != (m)[_n].bytes) {    \
+                    free((m)[_n].bytes);        \
+                }                               \
+            }                                   \
+            free((m));                          \
+            (m) = NULL;                         \
+        }                                       \
     } while(0)
 
 #define PMIX_BYTE_OBJECT_LOAD(b, d, s)      \

--- a/src/runtime/pmix_params.c
+++ b/src/runtime/pmix_params.c
@@ -21,7 +21,7 @@
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2015-2018 Mellanox Technologies, Inc.
  *                         All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -257,6 +257,14 @@ pmix_status_t pmix_register_params(void)
                                        PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
                                        PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
                                        &pmix_globals.event_eviction_time);
+
+    /* max number of IOF messages to cache */
+    pmix_server_globals.max_iof_cache = 1024 * 1024;
+    (void) pmix_mca_base_var_register ("pmix", "pmix", "max", "iof_cache",
+                                       "Maximum number of IOF messages to cache",
+                                       PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                       PMIX_INFO_LVL_1, PMIX_MCA_BASE_VAR_SCOPE_ALL,
+                                       &pmix_server_globals.max_iof_cache);
 
     return PMIX_SUCCESS;
 }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
@@ -87,18 +87,8 @@ static char *gds_mode = NULL;
 static pid_t mypid;
 
 // local functions for connection support
-static void iof_eviction_cbfunc(struct pmix_hotel_t *hotel,
-                                int room_num,
-                                void *occupant)
-{
-    pmix_setup_caddy_t *cache = (pmix_setup_caddy_t*)occupant;
-    PMIX_RELEASE(cache);
-}
-
 pmix_status_t pmix_server_initialize(void)
 {
-    pmix_status_t rc;
-
     /* setup the server-specific globals */
     PMIX_CONSTRUCT(&pmix_server_globals.clients, pmix_pointer_array_t);
     pmix_pointer_array_init(&pmix_server_globals.clients, 1, INT_MAX, 1);
@@ -109,15 +99,7 @@ pmix_status_t pmix_server_initialize(void)
     PMIX_CONSTRUCT(&pmix_server_globals.local_reqs, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.nspaces, pmix_list_t);
     PMIX_CONSTRUCT(&pmix_server_globals.groups, pmix_list_t);
-    PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_hotel_t);
-    rc = pmix_hotel_init(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE,
-                         pmix_globals.evbase, PMIX_IOF_MAX_STAY,
-                         iof_eviction_cbfunc);
-    if (PMIX_SUCCESS != rc) {
-       PMIX_ERROR_LOG(rc);
-       PMIX_RELEASE_THREAD(&pmix_global_lock);
-       return rc;
-    }
+    PMIX_CONSTRUCT(&pmix_server_globals.iof, pmix_list_t);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
                         "pmix:server init called");
@@ -445,7 +427,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     int i;
     pmix_peer_t *peer;
     pmix_namespace_t *ns;
-    pmix_setup_caddy_t *cd;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (pmix_globals.init_cntr <= 0) {
@@ -473,14 +454,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
 
     pmix_ptl_base_stop_listening();
 
-    /* cleanout any IOF */
-    for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
-        pmix_hotel_checkout_and_return_occupant(&pmix_server_globals.iof, i, (void**)&cd);
-        if (NULL != cd) {
-            PMIX_RELEASE(cd);
-        }
-    }
-    PMIX_DESTRUCT(&pmix_server_globals.iof);
     for (i=0; i < pmix_server_globals.clients.size; i++) {
         if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, i))) {
             /* ensure that we do the specified cleanup - if this is an
@@ -504,6 +477,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_finalize(void)
     }
     PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
     PMIX_LIST_DESTRUCT(&pmix_server_globals.groups);
+    PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
 
     pmix_hwloc_cleanup();
 
@@ -1712,7 +1686,7 @@ static void _iofdeliver(int sd, short args, void *cbdata)
     pmix_buffer_t *msg;
     bool found = false;
     bool cached = false;
-    int ignore;
+    pmix_iof_cache_t *iof;
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "PMIX:SERVER delivering IOF from %s on channel %0x",
@@ -1726,8 +1700,7 @@ static void _iofdeliver(int sd, short args, void *cbdata)
             continue;
         }
         /* see if the source matches the request */
-        if (0 != strncmp(cd->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
-            (PMIX_RANK_WILDCARD != req->pname.rank && cd->procs->rank != req->pname.rank)) {
+        if (!PMIX_CHECK_PROCID(cd->procs, &req->pname)) {
             continue;
         }
         /* never forward back to the source! This can happen if the source
@@ -1736,8 +1709,7 @@ static void _iofdeliver(int sd, short args, void *cbdata)
         if (NULL == req->peer->info || req->peer->finalized) {
             continue;
         }
-        if (0 == strncmp(cd->procs->nspace, req->peer->info->pname.nspace, PMIX_MAX_NSLEN) &&
-            cd->procs->rank == req->peer->info->pname.rank) {
+        if (PMIX_CHECK_PROCID(cd->procs, &req->peer->info->pname)) {
             continue;
         }
         found = true;
@@ -1778,15 +1750,21 @@ static void _iofdeliver(int sd, short args, void *cbdata)
 
     /* if nobody has registered for this yet, then cache it */
     if (!found) {
-        /* add this output to our hotel so it is cached until someone
-         * registers to receive it */
-        if (PMIX_SUCCESS != (rc = pmix_hotel_checkin(&pmix_server_globals.iof, cd, &ignore))) {
-            /* we can't cache it for some reason */
-            PMIX_ERROR_LOG(rc);
-            PMIX_RELEASE(cd);
-            return;
+        pmix_output_verbose(2, pmix_server_globals.iof_output,
+                            "PMIx:SERVER caching IOF");
+        if (pmix_server_globals.max_iof_cache == pmix_list_get_size(&pmix_server_globals.iof)) {
+            /* remove the oldest cached message */
+            iof = (pmix_iof_cache_t*)pmix_list_remove_first(&pmix_server_globals.iof);
+            PMIX_RELEASE(iof);
         }
-        cached = true;
+        /* add this output to our cache so it is cached until someone
+         * registers to receive it */
+        iof = PMIX_NEW(pmix_iof_cache_t);
+        memcpy(&iof->source, cd->procs, sizeof(pmix_proc_t));
+        iof->channel = cd->channels;
+        iof->bo = cd->bo;
+        cd->bo = NULL;  // protect the data
+        pmix_list_append(&pmix_server_globals.iof, &iof->super);
     }
 
 

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1121,10 +1121,9 @@ static void spcbfunc(pmix_status_t status,
 {
     pmix_setup_caddy_t *cd = (pmix_setup_caddy_t*)cbdata;
     pmix_iof_req_t *req;
-    pmix_setup_caddy_t *occupant;
-    int i;
     pmix_buffer_t *msg;
     pmix_status_t rc;
+    pmix_iof_cache_t *iof, *ionext;
 
     /* if it was successful, and there are IOF requests, then
      * register them now */
@@ -1142,60 +1141,60 @@ static void spcbfunc(pmix_status_t status,
         req->channels = cd->channels;
         pmix_list_append(&pmix_globals.iof_requests, &req->super);
         /* process any cached IO */
-        for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
-            pmix_hotel_knock(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1, (void**)&occupant);
-            if (NULL != occupant) {
-                if (!(occupant->channels & req->channels)) {
-                    continue;
-                }
-                /* if the source matches the request, then forward this along */
-                if (0 != strncmp(occupant->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
-                    (PMIX_RANK_WILDCARD != req->pname.rank && occupant->procs->rank != req->pname.rank)) {
-                    continue;
-                }
-                /* never forward back to the source! This can happen if the source
-                 * is a launcher */
-                if (0 == strncmp(occupant->procs->nspace, req->peer->info->pname.nspace, PMIX_MAX_NSLEN) &&
-                    occupant->procs->rank == req->peer->info->pname.rank) {
-                    continue;
-                }
-                /* setup the msg */
-                if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                    rc = PMIX_ERR_OUT_OF_RESOURCE;
-                    break;
-                }
-                /* provide the source */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->procs, 1, PMIX_PROC);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* provide the channel */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, &occupant->channels, 1, PMIX_IOF_CHANNEL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* pack the data */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->bo, 1, PMIX_BYTE_OBJECT);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* send it to the requestor */
-                PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                }
-                /* remove it from the hotel since it has now been forwarded */
-                pmix_hotel_checkout(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1);
-                PMIX_RELEASE(occupant);
+        PMIX_LIST_FOREACH_SAFE(iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
+            /* if the channels don't match, then ignore it */
+            if (!(iof->channel & req->channels)) {
+                continue;
             }
+            /* if the source does not match the request, then ignore it */
+            if (!PMIX_CHECK_PROCID(&iof->source, &req->pname)) {
+                continue;
+            }
+            /* never forward back to the source! This can happen if the source
+             * is a launcher */
+            if (PMIX_CHECK_PROCID(&iof->source, &req->peer->info->pname)) {
+                continue;
+            }
+            pmix_output_verbose(2, pmix_server_globals.iof_output,
+                                "PMIX:SERVER:SPAWN delivering cached IOF from %s:%d to %s:%d",
+                                iof->source.nspace, iof->source.rank,
+                                req->pname.nspace, req->pname.rank);
+            /* setup the msg */
+            if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+                PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                rc = PMIX_ERR_OUT_OF_RESOURCE;
+                break;
+            }
+            /* provide the source */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->source, 1, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* provide the channel */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* pack the data */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* send it to the requestor */
+            PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+            }
+            /* remove it from the list since it has now been forwarded */
+            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+            PMIX_RELEASE(iof);
         }
     }
 
@@ -1294,7 +1293,8 @@ pmix_status_t pmix_server_spawn(pmix_peer_t *peer,
                 }
             }
         }
-        /* we will construct any required iof request tracker upon completion of the spawn */
+        /* we will construct any required iof request tracker upon completion of the spawn
+         * as we need the nspace of the spawned application! */
     }
     /* add the directive to the end */
     if (PMIX_PROC_IS_TOOL(peer)) {
@@ -2971,9 +2971,8 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
     pmix_iof_req_t *req;
     bool notify, match;
     size_t n;
-    int i;
-    pmix_setup_caddy_t *occupant;
     pmix_buffer_t *msg;
+    pmix_iof_cache_t *iof, *ionext;
 
     pmix_output_verbose(2, pmix_server_globals.iof_output,
                         "recvd IOF PULL request from client");
@@ -3070,54 +3069,60 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
             pmix_list_append(&pmix_globals.iof_requests, &req->super);
         }
         /* process any cached IO */
-        for (i=0; i < PMIX_IOF_HOTEL_SIZE; i++) {
-            pmix_hotel_knock(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1, (void**)&occupant);
-            if (NULL != occupant) {
-                if (!(occupant->channels & req->channels)) {
-                    continue;
-                }
-                /* if the source matches the request, then forward this along */
-                if (0 != strncmp(occupant->procs->nspace, req->pname.nspace, PMIX_MAX_NSLEN) ||
-                    (PMIX_RANK_WILDCARD != req->pname.rank && occupant->procs->rank != req->pname.rank)) {
-                    continue;
-                }
-                /* setup the msg */
-                if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
-                    PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
-                    rc = PMIX_ERR_OUT_OF_RESOURCE;
-                    break;
-                }
-                /* provide the source */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->procs, 1, PMIX_PROC);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* provide the channel */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, &occupant->channels, 1, PMIX_IOF_CHANNEL);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* pack the data */
-                PMIX_BFROPS_PACK(rc, req->peer, msg, occupant->bo, 1, PMIX_BYTE_OBJECT);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                    break;
-                }
-                /* send it to the requestor */
-                PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_RELEASE(msg);
-                }
-                /* remove it from the hotel since it has now been forwarded */
-                pmix_hotel_checkout(&pmix_server_globals.iof, PMIX_IOF_HOTEL_SIZE-i-1);
-                PMIX_RELEASE(occupant);
+        PMIX_LIST_FOREACH_SAFE(iof, ionext, &pmix_server_globals.iof, pmix_iof_cache_t) {
+            /* if the channels don't match, then ignore it */
+            if (!(iof->channel & req->channels)) {
+                continue;
             }
+            /* if the source does not match the request, then ignore it */
+            if (!PMIX_CHECK_PROCID(&iof->source, &req->pname)) {
+                continue;
+            }
+            /* never forward back to the source! This can happen if the source
+             * is a launcher */
+            if (PMIX_CHECK_PROCID(&iof->source, &req->peer->info->pname)) {
+                continue;
+            }
+            pmix_output_verbose(2, pmix_server_globals.iof_output,
+                                "PMIX:SERVER:IOFREQ delivering cached IOF from %s:%d to %s:%d",
+                                iof->source.nspace, iof->source.rank,
+                                req->peer->info->pname.nspace, req->peer->info->pname.rank);
+            /* setup the msg */
+            if (NULL == (msg = PMIX_NEW(pmix_buffer_t))) {
+                PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
+                rc = PMIX_ERR_OUT_OF_RESOURCE;
+                break;
+            }
+            /* provide the source */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->source, 1, PMIX_PROC);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* provide the channel */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, &iof->channel, 1, PMIX_IOF_CHANNEL);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* pack the data */
+            PMIX_BFROPS_PACK(rc, req->peer, msg, iof->bo, 1, PMIX_BYTE_OBJECT);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+                break;
+            }
+            /* send it to the requestor */
+            PMIX_PTL_SEND_ONEWAY(rc, req->peer, msg, PMIX_PTL_TAG_IOF);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(msg);
+            }
+            /* remove it from the list since it has now been forwarded */
+            pmix_list_remove_item(&pmix_server_globals.iof, &iof->super);
+            PMIX_RELEASE(iof);
         }
     }
     if (notify) {
@@ -4212,3 +4217,15 @@ PMIX_CLASS_INSTANCE(pmix_group_t,
 PMIX_CLASS_INSTANCE(pmix_group_caddy_t,
                     pmix_list_item_t,
                     NULL, NULL);
+
+static void iocon(pmix_iof_cache_t *p)
+{
+    p->bo = NULL;
+}
+static void iodes(pmix_iof_cache_t *p)
+{
+    PMIX_BYTE_OBJECT_FREE(p->bo, 1);  // macro protects against NULL
+}
+PMIX_CLASS_INSTANCE(pmix_iof_cache_t,
+                    pmix_list_item_t,
+                    iocon, iodes);

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -1098,7 +1098,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     struct timeval tv = {5, 0};
     int n;
     pmix_peer_t *peer;
-    pmix_setup_caddy_t *cd;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
     if (1 != pmix_globals.init_cntr) {
@@ -1183,14 +1182,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         pmix_ptl_base_stop_listening();
 
-        /* cleanout any IOF */
-        for (n=0; n < PMIX_IOF_HOTEL_SIZE; n++) {
-            pmix_hotel_checkout_and_return_occupant(&pmix_server_globals.iof, n, (void**)&cd);
-            if (NULL != cd) {
-                PMIX_RELEASE(cd);
-            }
-        }
-        PMIX_DESTRUCT(&pmix_server_globals.iof);
         for (n=0; n < pmix_server_globals.clients.size; n++) {
             if (NULL != (peer = (pmix_peer_t*)pmix_pointer_array_get_item(&pmix_server_globals.clients, n))) {
                 PMIX_RELEASE(peer);
@@ -1204,6 +1195,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
+        PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
     }
 
     /* shutdown services */


### PR DESCRIPTION
Evict the oldest cached output to make room for the newest. Provide an
MCA param for sizing the max iof cache - default it to 1M messages since
memory is only allocated on an as-needed basis. Add some debugging
output when pmix_server_iof_verbose is on so we can see the cache in
operation.

Fixes https://github.com/pmix/prrte/issues/183

Signed-off-by: Ralph Castain <rhc@open-mpi.org>