### PR TITLE
Ensure that epilogs get run

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2017 Research Organization for Information Science
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  *                         and Technology (RIST). All rights reserved.
@@ -360,32 +360,38 @@ void pmix_execute_epilog(pmix_epilog_t *epi)
     pmix_cleanup_dir_t *cd, *cdnext;
     struct stat statbuf;
     int rc;
+    char **tmp;
+    size_t n;
 
     /* start with any specified files */
     PMIX_LIST_FOREACH_SAFE(cf, cfnext, &epi->cleanup_files, pmix_cleanup_file_t) {
         /* check the effective uid/gid of the file and ensure it
          * matches that of the peer - we do this to provide at least
          * some minimum level of protection */
-        rc = stat(cf->path, &statbuf);
-        if (0 != rc) {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "File %s failed to stat: %d", cf->path, rc);
-            continue;
+        tmp = pmix_argv_split(cf->path, ',');
+        for (n=0; NULL != tmp[n]; n++) {
+            rc = stat(tmp[n], &statbuf);
+            if (0 != rc) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "File %s failed to stat: %d", tmp[n], rc);
+                continue;
+            }
+            if (statbuf.st_uid != epi->uid ||
+                statbuf.st_gid != epi->gid) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "File %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
+                                    cf->path,
+                                    (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
+                                    (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
+                continue;
+            }
+            rc = unlink(tmp[n]);
+            if (0 != rc) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "File %s failed to unlink: %d", tmp[n], rc);
+            }
         }
-        if (statbuf.st_uid != epi->uid ||
-            statbuf.st_gid != epi->gid) {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "File %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
-                                cf->path,
-                                (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
-                                (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
-            continue;
-        }
-        rc = unlink(cf->path);
-        if (0 != rc) {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "File %s failed to unlink: %d", cf->path, rc);
-        }
+        pmix_argv_free(tmp);
         pmix_list_remove_item(&epi->cleanup_files, &cf->super);
         PMIX_RELEASE(cf);
     }
@@ -395,27 +401,31 @@ void pmix_execute_epilog(pmix_epilog_t *epi)
         /* check the effective uid/gid of the file and ensure it
          * matches that of the peer - we do this to provide at least
          * some minimum level of protection */
-        rc = stat(cd->path, &statbuf);
-        if (0 != rc) {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "Directory %s failed to stat: %d", cd->path, rc);
-            continue;
+        tmp = pmix_argv_split(cf->path, ',');
+        for (n=0; NULL != tmp[n]; n++) {
+            rc = stat(tmp[n], &statbuf);
+            if (0 != rc) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "Directory %s failed to stat: %d", tmp[n], rc);
+                continue;
+            }
+            if (statbuf.st_uid != epi->uid ||
+                statbuf.st_gid != epi->gid) {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "Directory %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
+                                    cd->path,
+                                    (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
+                                    (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
+                continue;
+            }
+            if ((statbuf.st_mode & S_IRWXU) == S_IRWXU) {
+                dirpath_destroy(tmp[n], cd, epi);
+            } else {
+                pmix_output_verbose(10, pmix_globals.debug_output,
+                                    "Directory %s lacks permissions", tmp[n]);
+            }
         }
-        if (statbuf.st_uid != epi->uid ||
-            statbuf.st_gid != epi->gid) {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "Directory %s uid/gid doesn't match: uid %lu(%lu) gid %lu(%lu)",
-                                cd->path,
-                                (unsigned long)statbuf.st_uid, (unsigned long)epi->uid,
-                                (unsigned long)statbuf.st_gid, (unsigned long)epi->gid);
-            continue;
-        }
-        if ((statbuf.st_mode & S_IRWXU) == S_IRWXU) {
-            dirpath_destroy(cd->path, cd, epi);
-        } else {
-            pmix_output_verbose(10, pmix_globals.debug_output,
-                                "Directory %s lacks permissions", cd->path);
-        }
+        pmix_argv_free(tmp);
         pmix_list_remove_item(&epi->cleanup_dirs, &cd->super);
         PMIX_RELEASE(cd);
     }

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -62,6 +62,12 @@ static void _timeout(int sd, short args, void *cbdata)
     PMIX_RELEASE(trk);
 }
 
+static void lcfn(pmix_status_t status, void *cbdata)
+{
+    pmix_peer_t *peer = (pmix_peer_t*)cbdata;
+    PMIX_RELEASE(peer);
+}
+
 void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
 {
     pmix_server_trkr_t *trk, *tnxt;
@@ -71,6 +77,8 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
     struct timeval tv = {1200, 0};
+    pmix_proc_t proc;
+    pmix_status_t rc;
 
     /* stop all events */
     if (peer->recv_ev_active) {
@@ -201,10 +209,25 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
         }
         /* now decrease the refcount - might actually free the object */
         PMIX_RELEASE(peer->info);
+
+        /* be sure to let the host know that the tool or client
+         * is gone - otherwise, it won't know to cleanup the
+         * resources it allocated to it */
+        if (NULL != pmix_host_server.client_finalized && !peer->finalized) {
+            pmix_strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+            proc.rank = peer->info->pname.rank;
+            /* now tell the host server */
+            rc = pmix_host_server.client_finalized(&proc, peer->info->server_object,
+                                                   lcfn, peer);
+            if (PMIX_SUCCESS == rc) {
+                /* we will release the peer when the server calls us back */
+                peer->finalized = true;
+                return;
+            }
+        }
         /* mark the peer as "gone" since a release doesn't guarantee
          * that the peer object doesn't persist */
         peer->finalized = true;
-
         /* Release peer info */
         PMIX_RELEASE(peer);
      } else {


### PR DESCRIPTION
Run epilogs when deregistering clients and/or nspaces, and when a
process (e.g., tool) unexpectedly drops its connection.

Signed-off-by: Ralph Castain <rhc@open-mpi.org>