### PR TITLE
Extend the server's support for query and update examples

### DIFF
--- a/examples/bad_exit.c
+++ b/examples/bad_exit.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+/* this is a callback function for the PMIx_Query
+ * API. The query will callback with a status indicating
+ * if the request could be fully satisfied, partially
+ * satisfied, or completely failed. The info parameter
+ * contains an array of the returned data, with the
+ * info->key field being the key that was provided in
+ * the query call. Thus, you can correlate the returned
+ * data in the info->value field to the requested key.
+ *
+ * Once we have dealt with the returned data, we must
+ * call the release_fn so that the PMIx library can
+ * cleanup */
+static void cbfunc(pmix_status_t status,
+                   pmix_info_t *info, size_t ninfo,
+                   void *cbdata,
+                   pmix_release_cbfunc_t release_fn,
+                   void *release_cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+    size_t n;
+    char *tmp;
+    pmix_status_t rc;
+
+    lock->status = status;
+
+    fprintf(stderr, "Query returned %d values status %s\n", (int)ninfo, PMIx_Error_string(status));
+    /* print out the returned keys and pmix_info_t structs */
+    for (n=0; n < ninfo; n++) {
+        fprintf(stderr, "KEY: %s\n", info[n].key);
+        rc = PMIx_Data_print(&tmp, NULL, &info[n].value, info[n].value.type);
+        if (PMIX_SUCCESS != rc) {
+            lock->status = rc;
+            goto done;
+        }
+        rc = PMIx_Data_print(&tmp, NULL, &info[n].value, info[n].value.type);
+        if (PMIX_SUCCESS != rc) {
+            lock->status = rc;
+            goto done;
+        }
+        fprintf(stderr, "Key %s Type %s(%d)\n", info[n].key, PMIx_Data_type_string(info[n].value.type), info[n].value.type);
+        free(tmp);
+    }
+
+  done:
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    /* release the block */
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pid_t pid;
+    char hostname[1024];
+    pmix_value_t *val;
+    uint16_t localrank;
+    size_t n;
+    pmix_query_t query;
+    mylock_t mylock;
+    bool refresh = false;
+    int delay = 0;
+
+    if (1 < argc) {
+        delay=atoi(argv[1]);
+    }
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    /* get our local rank */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    localrank = val->data.uint16;
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
+            myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
+
+#if PMIX_VERSION_MAJOR >= 4
+    n = 1;
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NUM_PSETS);
+    PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_PSET_NAMES);
+    if (refresh) {
+        PMIX_INFO_CREATE(query.qualifiers, 1);
+        query.nqual = 1;
+        PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_QUERY_REFRESH_CACHE, &refresh, PMIX_BOOL);
+    }
+    /* setup the caddy to retrieve the data */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    /* execute the query */
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(&query, 1, cbfunc, (void*)&mylock))) {
+        fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+#endif
+
+  sleep(delay);
+
+  done:
+    if (0 == myproc.rank) {
+        exit(1);
+    }
+    sleep(2);
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
@@ -35,7 +35,7 @@
 #include <sys/param.h>
 
 #include <pmix.h>
-
+#include "examples.h"
 
 static pmix_proc_t myproc;
 

--- a/examples/examples.h
+++ b/examples/examples.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <pthread.h>
+
+#include <pmix_common.h>
+
+typedef struct {
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+    volatile bool active;
+    pmix_status_t status;
+    int count;
+    size_t evhandler_ref;
+} mylock_t;
+
+#define DEBUG_CONSTRUCT_LOCK(l)                     \
+    do {                                            \
+        pthread_mutex_init(&(l)->mutex, NULL);      \
+        pthread_cond_init(&(l)->cond, NULL);        \
+        (l)->active = true;                         \
+        (l)->status = PMIX_SUCCESS;                 \
+        (l)->count = 0;                             \
+        (l)->evhandler_ref = 0;                     \
+    } while(0)
+
+#define DEBUG_DESTRUCT_LOCK(l)              \
+    do {                                    \
+        pthread_mutex_destroy(&(l)->mutex); \
+        pthread_cond_destroy(&(l)->cond);   \
+    } while(0)
+
+#define DEBUG_WAIT_THREAD(lck)                                      \
+    do {                                                            \
+        pthread_mutex_lock(&(lck)->mutex);                          \
+        while ((lck)->active) {                                     \
+            pthread_cond_wait(&(lck)->cond, &(lck)->mutex);         \
+        }                                                           \
+        pthread_mutex_unlock(&(lck)->mutex);                        \
+    } while(0)
+
+#define DEBUG_WAKEUP_THREAD(lck)                        \
+    do {                                                \
+        pthread_mutex_lock(&(lck)->mutex);              \
+        (lck)->active = false;                          \
+        pthread_cond_broadcast(&(lck)->cond);           \
+        pthread_mutex_unlock(&(lck)->mutex);            \
+    } while(0)
+
+/* define a structure for collecting returned
+ * info from a query */
+typedef struct {
+    mylock_t lock;
+    pmix_info_t *info;
+    size_t ninfo;
+} myquery_data_t;
+
+#define DEBUG_CONSTRUCT_MYQUERY(q)                  \
+    do {                                            \
+        DEBUG_CONSTRUCT_LOCK(&((q)->lock));         \
+        (q)->info = NULL;                           \
+        (q)->ninfo = 0;                             \
+    } while(0)
+
+#define DEBUG_DESTRUCT_MYQUERY(q)                   \
+    do {                                            \
+        DEBUG_DESTRUCT_LOCK(&((q)->lock));          \
+        if (NULL != (q)->info) {                    \
+            PMIX_INFO_FREE((q)->info, (q)->ninfo);  \
+        }                                           \
+    } while(0)
+
+/* define a structure for releasing when a given
+ * nspace terminates */
+typedef struct {
+    mylock_t lock;
+    char *nspace;
+    int exit_code;
+    bool exit_code_given;
+} myrel_t;
+
+
+#define DEBUG_CONSTRUCT_MYREL(r)                \
+    do {                                        \
+        DEBUG_CONSTRUCT_LOCK(&((r)->lock));     \
+        (r)->nspace = NULL;                     \
+        (r)->exit_code = 0;                     \
+        (r)->exit_code_given = false;           \
+    } while(0)
+
+#define DEBUG_DESTRUCT_MYREL(r)                 \
+    do {                                        \
+        DEBUG_DESTRUCT_LOCK(&((r)->lock));      \
+        if (NULL != (r)->nspace) {              \
+            free((r)->nspace);                  \
+        }                                       \
+    } while(0)

--- a/examples/fault.c
+++ b/examples/fault.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2016 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -28,11 +28,12 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
+#include <pthread.h>
 
 #include <pmix.h>
+#include "examples.h"
 
 static pmix_proc_t myproc;
-static bool completed;
 
 static void notification_fn(size_t evhdlr_registration_id,
                             pmix_status_t status,
@@ -42,22 +43,67 @@ static void notification_fn(size_t evhdlr_registration_id,
                             pmix_event_notification_cbfunc_fn_t cbfunc,
                             void *cbdata)
 {
-    fprintf(stderr, "Client %s:%d NOTIFIED with status %d\n", myproc.nspace, myproc.rank, status);
-    completed = true;
+    myrel_t *lock;
+    bool found;
+    int exit_code;
+    size_t n;
+    pmix_proc_t *affected = NULL;
+
+    /* find our return object */
+    lock = NULL;
+    found = false;
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            lock = (myrel_t*)info[n].value.data.ptr;
+            /* not every RM will provide an exit code, but check if one was given */
+        } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
+            exit_code = info[n].value.data.integer;
+            found = true;
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            affected = info[n].value.data.proc;
+        }
+    }
+    /* if the object wasn't returned, then that is an error */
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+        /* let the event handler progress */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    /* tell the event handler state machine that we are the last step */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    fprintf(stderr, "DEBUGGER DAEMON NOTIFIED TERMINATED - AFFECTED %s\n",
+            (NULL == affected) ? "NULL" : affected->nspace);
+
+    if (found) {
+        lock->exit_code = exit_code;
+        lock->exit_code_given = true;
+    }
+    DEBUG_WAKEUP_THREAD(&lock->lock);
 }
 
 static void op_callbk(pmix_status_t status,
                       void *cbdata)
 {
+    mylock_t *lock = (mylock_t*)cbdata;
     fprintf(stderr, "Client %s:%d OP CALLBACK CALLED WITH STATUS %d\n", myproc.nspace, myproc.rank, status);
+    DEBUG_WAKEUP_THREAD(lock);
 }
 
-static void errhandler_reg_callbk(pmix_status_t status,
+static void evhandler_reg_callbk(pmix_status_t status,
                                   size_t errhandler_ref,
                                   void *cbdata)
 {
+    mylock_t *lock = (mylock_t*)cbdata;
+
     fprintf(stderr, "Client %s:%d ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu\n",
                myproc.nspace, myproc.rank, status, (unsigned long)errhandler_ref);
+    DEBUG_WAKEUP_THREAD(lock);
 }
 
 int main(int argc, char **argv)
@@ -67,6 +113,10 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs;
+    pmix_info_t *info;
+    mylock_t mylock;
+    myrel_t myrel;
+    pmix_status_t code[2] = {PMIX_ERR_PROC_ABORTED, PMIX_ERR_JOB_TERMINATED};
 
     /* init us */
     if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
@@ -87,11 +137,27 @@ int main(int argc, char **argv)
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
     fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
-    completed = false;
 
-    /* register our errhandler */
-    PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, errhandler_reg_callbk, NULL);
+    /* register another handler specifically for when the target
+     * job completes */
+    DEBUG_CONSTRUCT_MYREL(&myrel);
+    PMIX_INFO_CREATE(info, 2);
+    PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    /* only call me back when one of us terminates */
+    PMIX_INFO_LOAD(&info[1], PMIX_NSPACE, myproc.nspace, PMIX_STRING);
+
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Register_event_handler(code, 2, info, 2,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS != mylock.status) {
+        rc = mylock.status;
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_INFO_FREE(info, 2);
+        goto done;
+    }
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    PMIX_INFO_FREE(info, 2);
 
     /* call fence to sync */
     PMIX_PROC_CONSTRUCT(&proc);
@@ -109,17 +175,16 @@ int main(int argc, char **argv)
         exit(1);
     }
     /* everyone simply waits */
-    while (!completed) {
-        struct timespec ts;
-        ts.tv_sec = 0;
-        ts.tv_nsec = 100000;
-        nanosleep(&ts, NULL);
-    }
+    DEBUG_WAIT_THREAD(&myrel.lock);
+    DEBUG_DESTRUCT_MYREL(&myrel);
 
  done:
     /* finalize us */
     fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
-    PMIx_Deregister_event_handler(1, op_callbk, NULL);
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIx_Deregister_event_handler(1, op_callbk, &mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
 
     if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
         fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+/* this is a callback function for the PMIx_Query
+ * API. The query will callback with a status indicating
+ * if the request could be fully satisfied, partially
+ * satisfied, or completely failed. The info parameter
+ * contains an array of the returned data, with the
+ * info->key field being the key that was provided in
+ * the query call. Thus, you can correlate the returned
+ * data in the info->value field to the requested key.
+ *
+ * Once we have dealt with the returned data, we must
+ * call the release_fn so that the PMIx library can
+ * cleanup */
+static void cbfunc(pmix_status_t status,
+                   pmix_info_t *info, size_t ninfo,
+                   void *cbdata,
+                   pmix_release_cbfunc_t release_fn,
+                   void *release_cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+    size_t n;
+    char *tmp;
+    pmix_status_t rc;
+
+    lock->status = status;
+
+    fprintf(stderr, "Query returned %d values status %s\n", (int)ninfo, PMIx_Error_string(status));
+    /* print out the returned keys and pmix_info_t structs */
+    for (n=0; n < ninfo; n++) {
+        fprintf(stderr, "KEY: %s\n", info[n].key);
+        rc = PMIx_Data_print(&tmp, NULL, &info[n].value, info[n].value.type);
+        if (PMIX_SUCCESS != rc) {
+            lock->status = rc;
+            goto done;
+        }
+        rc = PMIx_Data_print(&tmp, NULL, &info[n].value, info[n].value.type);
+        if (PMIX_SUCCESS != rc) {
+            lock->status = rc;
+            goto done;
+        }
+        fprintf(stderr, "Key %s Type %s(%d)\n", info[n].key, PMIx_Data_type_string(info[n].value.type), info[n].value.type);
+        free(tmp);
+    }
+
+  done:
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != release_fn) {
+        release_fn(release_cbdata);
+    }
+
+    /* release the block */
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pid_t pid;
+    char hostname[1024];
+    pmix_value_t *val;
+    uint16_t localrank;
+    size_t n;
+    pmix_query_t query;
+    mylock_t mylock;
+    bool refresh = false;
+
+    if (1 < argc) {
+        if (NULL != strstr(argv[1], "true")) {
+            refresh = true;
+        }
+    }
+
+    pid = getpid();
+    gethostname(hostname, 1024);
+
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. This includes any
+     * debugger flag instructing us to stop-in-init. If such a directive
+     * is included, then the process will be stopped in this call until
+     * the "debugger release" notification arrives */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(0);
+    }
+    /* get our local rank */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    localrank = val->data.uint16;
+    PMIX_VALUE_RELEASE(val);
+
+    fprintf(stderr, "Client ns %s rank %d pid %lu: Running on host %s localrank %d\n",
+            myproc.nspace, myproc.rank, (unsigned long)pid, hostname , (int)localrank);
+
+#if PMIX_VERSION_MAJOR >= 4
+    n = 1;
+    PMIX_QUERY_CONSTRUCT(&query);
+    PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_NUM_PSETS);
+    PMIX_ARGV_APPEND(rc, query.keys, PMIX_QUERY_PSET_NAMES);
+    if (refresh) {
+        PMIX_INFO_CREATE(query.qualifiers, 1);
+        query.nqual = 1;
+        PMIX_INFO_LOAD(&query.qualifiers[0], PMIX_QUERY_REFRESH_CACHE, &refresh, PMIX_BOOL);
+    }
+    /* setup the caddy to retrieve the data */
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    /* execute the query */
+    if (PMIX_SUCCESS != (rc = PMIx_Query_info_nb(&query, 1, cbfunc, (void*)&mylock))) {
+        fprintf(stderr, "PMIx_Query_info failed: %d\n", rc);
+        goto done;
+    }
+    DEBUG_WAIT_THREAD(&mylock);
+    DEBUG_DESTRUCT_LOCK(&mylock);
+
+#endif
+
+  done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/examples/jctrl.c
+++ b/examples/jctrl.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -32,6 +32,7 @@
 #include <signal.h>
 
 #include <pmix.h>
+#include "examples.h"
 
 static pmix_proc_t myproc;
 
@@ -63,13 +64,15 @@ static void evhandler_reg_callbk(pmix_status_t status,
                                  size_t evhandler_ref,
                                  void *cbdata)
 {
-    volatile int *active = (volatile int*)cbdata;
+    mylock_t *lock = (mylock_t*)cbdata;
 
     if (PMIX_SUCCESS != status) {
         fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
                    myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
     }
-    *active = status;
+    lock->status = status;
+    lock->evhandler_ref = evhandler_ref;
+    DEBUG_WAKEUP_THREAD(lock);
 }
 
 static void infocbfunc(pmix_status_t status,
@@ -78,26 +81,27 @@ static void infocbfunc(pmix_status_t status,
                        pmix_release_cbfunc_t release_fn,
                        void *release_cbdata)
 {
-    volatile int *active = (volatile int*)cbdata;
+    mylock_t *lock = (mylock_t*)cbdata;
 
     /* release the caller */
     if (NULL != release_fn) {
         release_fn(release_cbdata);
     }
 
-    *active = status;
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
 }
 
 int main(int argc, char **argv)
 {
-    int rc;
+    pmix_status_t rc;
     pmix_value_t value;
     pmix_value_t *val = &value;
     pmix_proc_t proc;
     uint32_t nprocs, n;
     pmix_info_t *info, *iptr;
     bool flag;
-    volatile int active;
+    mylock_t mylock;
     pmix_data_array_t *dptr;
 
     /* init us - note that the call to "init" includes the return of
@@ -111,15 +115,16 @@ int main(int argc, char **argv)
 
     /* register our default event handler - again, this isn't strictly
      * required, but is generally good practice */
-    active = -1;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
     PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, evhandler_reg_callbk, (void*)&active);
-    while (-1 == active) {
-        sleep(1);
-    }
-    if (0 != active) {
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    /* wait for registration to complete */
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace, myproc.rank);
-        exit(active);
+        goto done;
     }
 
     /* job-related info is found in our nspace, assigned to the
@@ -159,18 +164,19 @@ int main(int argc, char **argv)
 
     /* since this is informational and not a requested operation, the target parameter
      * doesn't mean anything and can be ignored */
-    active = -1;
-    if (PMIX_SUCCESS != (rc = PMIx_Job_control_nb(NULL, 0, info, 2, infocbfunc, (void*)&active))) {
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != (rc = PMIx_Job_control_nb(NULL, 0, info, 2, infocbfunc, (void*)&mylock))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Job_control_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
+        DEBUG_DESTRUCT_LOCK(&mylock);
         goto done;
     }
-    while (-1 == active) {
-        sleep(1);
-    }
+    DEBUG_WAIT_THREAD(&mylock);
     PMIX_INFO_FREE(info, 2);
-    if (0 != active) {
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Job_control_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
-        exit(active);
+        goto done;
     }
 
     /* now request that this process be monitored using heartbeats */
@@ -185,20 +191,21 @@ int main(int argc, char **argv)
     PMIX_INFO_LOAD(&info[2], PMIX_MONITOR_HEARTBEAT_DROPS, &n, PMIX_UINT32);
 
     /* make the request */
-    active = -1;
+    DEBUG_CONSTRUCT_LOCK(&mylock);
     if (PMIX_SUCCESS != (rc = PMIx_Process_monitor_nb(iptr, PMIX_MONITOR_HEARTBEAT_ALERT,
-                                                      info, 3, infocbfunc, (void*)&active))) {
+                                                      info, 3, infocbfunc, (void*)&mylock))) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
+        DEBUG_DESTRUCT_LOCK(&mylock);
         goto done;
     }
-    while (-1 == active) {
-        sleep(1);
-    }
+    DEBUG_WAIT_THREAD(&mylock);
     PMIX_INFO_FREE(iptr, 1);
     PMIX_INFO_FREE(info, 3);
-    if (0 != active) {
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != rc) {
         fprintf(stderr, "Client ns %s rank %d: PMIx_Process_monitor_nb failed: %d\n", myproc.nspace, myproc.rank, rc);
-        exit(active);
+        goto done;
     }
 
     /* send a heartbeat */

--- a/examples/launcher.c
+++ b/examples/launcher.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -15,9 +15,10 @@
 #include <time.h>
 
 #include <pmix_tool.h>
+#include "examples.h"
 
-static volatile bool completed = false;
-static volatile pmix_status_t exit_code = PMIX_SUCCESS;
+static pmix_proc_t myproc;
+
 
 static void notification_fn(size_t evhdlr_registration_id,
                             pmix_status_t status,
@@ -27,46 +28,114 @@ static void notification_fn(size_t evhdlr_registration_id,
                             pmix_event_notification_cbfunc_fn_t cbfunc,
                             void *cbdata)
 {
-    exit_code = status;
-    completed = true;
-    /* perform our required duty by notifying the library
-     * that we are done with the notification */
+    myrel_t *lock = NULL;
+    size_t n;
+    pmix_status_t jobstatus = 0;
+    pmix_proc_t affected;
+    char *msg = NULL;
+
+    memset(&affected, 0, sizeof(pmix_proc_t));
+
+    /* we should always have info returned to us - if not, there is
+     * nothing we can do */
+    if (NULL != info) {
+        for (n=0; n < ninfo; n++) {
+            if (0 == strncmp(info[n].key, PMIX_JOB_TERM_STATUS, PMIX_MAX_KEYLEN)) {
+                jobstatus = info[n].value.data.status;
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+                memcpy(&affected, info[n].value.data.proc, sizeof(pmix_proc_t));
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+                lock = (myrel_t*)info[n].value.data.ptr;
+            } else if (0 == strncmp(info[n].key, PMIX_EVENT_TEXT_MESSAGE, PMIX_MAX_KEYLEN)) {
+                msg = info[n].value.data.string;
+            }
+        }
+    }
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WAS NOT RETURNED IN EVENT NOTIFICATION\n");
+        goto done;
+    }
+    /* save the status */
+    lock->lock.status = jobstatus;
+    if (NULL != msg) {
+        lock->nspace = strdup(msg);
+    }
+    /* release the lock */
+    DEBUG_WAKEUP_THREAD(&lock->lock);
+
+  done:
+    /* we _always_ have to execute the evhandler callback or
+     * else the event progress engine will hang */
     if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
     }
 }
 
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lock->status = status;
+    lock->evhandler_ref = evhandler_ref;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
-    pmix_proc_t myproc;
-    pmix_info_t *info;
+    pmix_info_t info;
     pmix_app_t *app;
     size_t ninfo, napps;
     bool flag;
+    myrel_t myrel;
+    mylock_t mylock;
+    pmix_status_t code[6] = {PMIX_ERR_PROC_ABORTING, PMIX_ERR_PROC_ABORTED,
+                             PMIX_ERR_PROC_REQUESTED_ABORT, PMIX_ERR_JOB_TERMINATED,
+                             PMIX_ERR_UNREACH, PMIX_ERR_LOST_CONNECTION_TO_SERVER};
+    pmix_nspace_t appspace;
 
     /* we need to attach to a "system" PMIx server so we
      * can ask it to spawn applications for us. There can
      * only be one such connection on a node, so we will
      * instruct the tool library to only look for it */
-    ninfo = 1;
-    PMIX_INFO_CREATE(info, ninfo);
     flag = true;
-    PMIX_INFO_LOAD(&info[0], PMIX_CONNECT_TO_SYSTEM, &flag, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info, PMIX_CONNECT_TO_SYSTEM, &flag, PMIX_BOOL);
 
     /* initialize the library and make the connection */
-    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, info, ninfo))) {
+    if (PMIX_SUCCESS != (rc = PMIx_tool_init(&myproc, &info, 1))) {
         fprintf(stderr, "PMIx_tool_init failed: %d\n", rc);
         exit(rc);
     }
-    if (0 < ninfo) {
-        PMIX_INFO_FREE(info, ninfo);
-    }
 
-    /* register a default event handler so we can be notified when
+    DEBUG_CONSTRUCT_MYREL(&myrel);
+
+    /* register an event handler so we can be notified when
      * our spawned job completes, or if it fails (even at launch) */
-    PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, NULL, NULL);
+    DEBUG_CONSTRUCT_LOCK(&mylock);
+    PMIX_INFO_LOAD(&info, PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+    PMIx_Register_event_handler(code, 6, &info, 1,
+                                notification_fn, evhandler_reg_callbk, (void*)&mylock);
+    DEBUG_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    DEBUG_DESTRUCT_LOCK(&mylock);
+    if (PMIX_SUCCESS != rc) {
+        fprintf(stderr, "[%s:%d] Default handler registration failed\n", myproc.nspace, myproc.rank);
+        goto done;
+    }
 
     /* parse the cmd line and create our array of app structs
      * describing the application we want launched */
@@ -74,32 +143,30 @@ int main(int argc, char **argv)
     PMIX_APP_CREATE(app, napps);
     /* setup the executable */
     app[0].cmd = strdup("app");
-    app[0].argc = 1;
     app[0].argv = (char**)malloc(2*sizeof(char*));
     app[0].argv[0] = strdup("app");
     app[0].argv[1] = NULL;
+    app[0].maxprocs = 128;
     /* can also provide environmental params in the app.env field */
 
     /* provide directives so the apps do what the user requested - just
      * some random examples provided here*/
-    ninfo = 3;
-    PMIX_INFO_CREATE(app[0].info, ninfo);
-    PMIX_INFO_LOAD(&app[0].info[0], PMIX_NP, 128, PMIX_UINT64);
-    PMIX_INFO_LOAD(&app[0].info[1], PMIX_MAPBY, "slot", PMIX_STRING);
+    app[0].ninfo = 2;
+    PMIX_INFO_CREATE(app[0].info, app[0].ninfo);
+    PMIX_INFO_LOAD(&app[0].info[0], PMIX_MAPBY, "slot", PMIX_STRING);
     /* include a directive that we be notified upon completion of the job */
-    PMIX_INFO_LOAD(&app[0].info[2], PMIX_NOTIFY_COMPLETION, &flag, PMIX_BOOL);
+    PMIX_INFO_LOAD(&app[0].info[1], PMIX_NOTIFY_COMPLETION, &flag, PMIX_BOOL);
 
     /* spawn the application */
     PMIx_Spawn(NULL, 0, app, napps, appspace);
     /* cleanup */
     PMIX_APP_FREE(app, napps);
 
-    while (!complete) {
-        /* just cycle in sleep so we don't eat cpu */
-        usleep(100);
-    }
+    DEBUG_WAIT_THREAD(&myrel.lock);
+    DEBUG_DESTRUCT_MYREL(&myrel);
 
-    PMIx_tool_finalize(NULL, 0);
+  done:
+    PMIx_tool_finalize();
 
-    return(exit_code);
+    return(0);
 }

--- a/examples/log.c
+++ b/examples/log.c
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#define _GNU_SOURCE
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+#include <signal.h>
+
+#include <pmix.h>
+#include "examples.h"
+
+static pmix_proc_t myproc;
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    pmix_info_t *info, *directives;
+    bool flag;
+    pmix_proc_t proc;
+    bool syslog=false, global=false;
+
+    /* check for CLI directives */
+    if (1 < argc) {
+        if (0 == strcmp(argv[argc-1], "--syslog")) {
+            syslog = true;
+        } else if (0 == strcmp(argv[argc-1], "--global-syslog")) {
+            global = true;
+        }
+    }
+    /* init us - note that the call to "init" includes the return of
+     * any job-related info provided by the RM. */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Init failed: %d\n", myproc.nspace, myproc.rank, rc);
+        exit(0);
+    }
+    fprintf(stderr, "Client ns %s rank %d: Running\n", myproc.nspace, myproc.rank);
+
+    /* have rank 0 do the logs - doesn't really matter who does it */
+    if (0 == myproc.rank) {
+        /* always output a log message to stderr */
+        PMIX_INFO_CREATE(info, 1);
+        PMIX_INFO_LOAD(&info[0], PMIX_LOG_STDERR, "stderr log message\n", PMIX_STRING);
+        PMIX_INFO_CREATE(directives, 1);
+        PMIX_INFO_LOAD(&directives[0], PMIX_LOG_GENERATE_TIMESTAMP, NULL, PMIX_BOOL);
+        rc = PMIx_Log(info, 1, directives, 1);
+        if (PMIX_SUCCESS != rc) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Log stderr failed: %s\n",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+            goto fence;
+        }
+        /* if requested, output one to syslog */
+        if (syslog) {
+            fprintf(stderr, "LOG TO LOCAL SYSLOG\n");
+            PMIX_INFO_CREATE(info, 1);
+            PMIX_INFO_LOAD(&info[0], PMIX_LOG_LOCAL_SYSLOG, "SYSLOG message\n", PMIX_STRING);
+            rc = PMIx_Log(info, 1, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Log syslog failed: %s\n",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+                goto fence;
+            }
+        }
+        if (global) {
+            fprintf(stderr, "LOG TO GLOBAL SYSLOG\n");
+            PMIX_INFO_CREATE(info, 1);
+            PMIX_INFO_LOAD(&info[0], PMIX_LOG_GLOBAL_SYSLOG, "GLOBAL SYSLOG message\n", PMIX_STRING);
+            rc = PMIx_Log(info, 1, NULL, 0);
+            if (PMIX_SUCCESS != rc) {
+                fprintf(stderr, "Client ns %s rank %d: PMIx_Log GLOBAL syslog failed: %s\n",
+                        myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+                goto fence;
+            }
+        }
+    }
+
+  fence:
+    fprintf(stderr, "%s:%d Calling Fence\n", myproc.nspace, myproc.rank);
+    /* call fence to synchronize with our peers - no need to
+     * collect any info as we didn't "put" anything */
+    PMIX_INFO_CREATE(info, 1);
+    flag = false;
+    PMIX_INFO_LOAD(info, PMIX_COLLECT_DATA, &flag, PMIX_BOOL);
+    PMIX_PROC_LOAD(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, info, 1))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Fence failed: %d\n", myproc.nspace, myproc.rank, rc);
+        goto done;
+    }
+    PMIX_INFO_FREE(info, 1);
+
+
+  done:
+    /* finalize us */
+    fprintf(stderr, "Client ns %s rank %d: Finalizing\n", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %d\n", myproc.nspace, myproc.rank, rc);
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(0);
+}

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -140,7 +140,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     pmix_buffer_t *msg;
     pmix_status_t rc;
     pmix_cb_t cb;
-    size_t n, m, p;
+    size_t n, p;
     pmix_list_t results;
     pmix_kval_t *kv, *kvnxt;
     pmix_proc_t proc;
@@ -172,21 +172,19 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     memset(proc.nspace, 0, PMIX_MAX_NSLEN+1);
     proc.rank = PMIX_RANK_INVALID;
     for (n=0; n < nqueries; n++) {
-        for (m=0; m < queries[n].nqual; m++) {
-            if (NULL != queries[n].qualifiers) {
-                for (p=0; p < queries[n].nqual; p++) {
-                    if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_QUERY_REFRESH_CACHE)) {
-                        PMIX_LIST_DESTRUCT(&results);
-                        goto query;
-                    } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
-                        PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
-                        proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
-                    } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
-                        PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
-                    } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
-                        proc.rank = queries[n].qualifiers[p].value.data.rank;
-                    }
+        for (p=0; p < queries[n].nqual; p++) {
+            if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_QUERY_REFRESH_CACHE)) {
+                if (PMIX_INFO_TRUE(&queries[n].qualifiers[p])) {
+                    PMIX_LIST_DESTRUCT(&results);
+                    goto query;
                 }
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
+                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
+                proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
+                PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
+            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
+                proc.rank = queries[n].qualifiers[p].value.data.rank;
             }
         }
         /* we get here if a refresh isn't required - first try a local
@@ -255,6 +253,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     /* regardless of the result of the query, we return
      * PMIX_SUCCESS here to indicate that the operation
      * was accepted for processing */
+    PMIX_RELEASE_THREAD(&pmix_global_lock);
     return PMIX_SUCCESS;
 
 
@@ -270,10 +269,10 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
         }
         pmix_output_verbose(2, pmix_globals.debug_output,
                             "pmix:query handed to RM");
-        pmix_host_server.query(&pmix_globals.myid,
-                               queries, nqueries,
-                               cbfunc, cbdata);
-        return PMIX_SUCCESS;
+        rc = pmix_host_server.query(&pmix_globals.myid,
+                                    queries, nqueries,
+                                    cbfunc, cbdata);
+        return rc;
     }
 
     /* if we aren't connected, don't attempt to send */


### PR DESCRIPTION
The client first checks to see if it has the requested info and then
passes the request up to the server. Have the server check its own cache
before passing it along to the host.

Update the examples

Signed-off-by: Ralph Castain <rhc@open-mpi.org>