### PR TITLE
Travis CI Script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+sudo: false
+dist: xenial
+
+cache:
+  apt: true
+
+env:
+  global:
+    # TODO: -Werror
+    # TODOL -fsanitize=address -fsanitize=undefined
+    - CFLAGS: "-Wall -Wextra"
+    - CXXFLAGS: "-Wall -Wextra"
+
+addons:
+  apt:
+    packages:
+      - gfortran
+      - perl
+      - libevent-dev
+
+jobs:
+  fast_finish: true
+  include:
+    - script:
+        - ./autogen.pl
+        - ./configure
+        - make all
+        - make check

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/pmix/pmix.svg?branch=master)](https://travis-ci.org/pmix/pmix)
+
 The Process Management Interface (PMI) has been used for quite some time as a means of exchanging wireup information needed for interprocess communication. Two versions (PMI-1 and PMI-2) have been released as part of the MPICH effort. While PMI-2 demonstrates better scaling properties than its PMI-1 predecessor, attaining rapid launch and wireup of the roughly 1M processes executing across 100k nodes expected for exascale operations remains challenging.
 
 PMI Exascale (PMIx) represents an attempt to resolve these questions by providing an extended version of the PMI standard specifically designed to support clusters up to and including exascale sizes. The overall objective of the project is not to branch the existing pseudo-standard definitions - in fact, PMIx fully supports both of the existing PMI-1 and PMI-2 APIs - but rather to (a) augment and extend those APIs to eliminate some current restrictions that impact scalability, and (b) provide a reference implementation of the PMI-server that demonstrates the desired level of scalability.


### PR DESCRIPTION
Draft for adding travis-ci for memory checks: #1025 https://github.com/open-mpi/ompi/issues/6242

## Open Questions

- [x] are there automated unit tests? `make check` or `cd test && make all`? They seem to need an installed `help-pmix-runtime.txt` but can one test those without the need to install to a system path first (aka: avoid `sudo`)?

## To Do

- [x] add badge
- [x] add libevent
- [ ] general flags: `-Werror -Wall -Wextra` and maybe `-pedantic -Wshadow`
- [ ] add `-fsanitize=address` for tests in an entry