### PR TITLE
pmix_control: plug a memory leak in query_cbfunc()

### DIFF
--- a/src/common/pmix_control.c
+++ b/src/common/pmix_control.c
@@ -4,6 +4,8 @@
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -105,6 +107,8 @@ static void query_cbfunc(struct pmix_peer_t *peer,
     /* release the caller */
     if (NULL != cd->cbfunc) {
         cd->cbfunc(results->status, results->info, results->ninfo, cd->cbdata, relcbfunc, results);
+    } else {
+        PMIX_RELEASE(results);
     }
     PMIX_RELEASE(cd);
 }


### PR DESCRIPTION
explicitly release 'results' if there is no callback present.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>