### PR TITLE
Protect hotel ops against negative room numbers

### DIFF
--- a/src/class/pmix_hotel.h
+++ b/src/class/pmix_hotel.h
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) 2012-2016 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -190,6 +190,7 @@ static inline pmix_status_t pmix_hotel_checkin(pmix_hotel_t *hotel,
 
     /* Do we have any rooms available? */
     if (PMIX_UNLIKELY(hotel->last_unoccupied_room < 0)) {
+        *room_num = -1;
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
@@ -247,6 +248,10 @@ static inline void pmix_hotel_checkout(pmix_hotel_t *hotel, int room_num)
 
     /* Bozo check */
     assert(room_num < hotel->num_rooms);
+    if (0 > room_num) {
+        /* occupant wasn't checked in */
+        return;
+    }
 
     /* If there's an occupant in the room, check them out */
     room = &(hotel->rooms[room_num]);
@@ -285,6 +290,11 @@ static inline void pmix_hotel_checkout_and_return_occupant(pmix_hotel_t *hotel, 
 
     /* Bozo check */
     assert(room_num < hotel->num_rooms);
+    if (0 > room_num) {
+        /* occupant wasn't checked in */
+        *occupant = NULL;
+        return;
+    }
 
     /* If there's an occupant in the room, check them out */
     room = &(hotel->rooms[room_num]);
@@ -339,6 +349,10 @@ static inline void pmix_hotel_knock(pmix_hotel_t *hotel, int room_num, void **oc
     assert(room_num < hotel->num_rooms);
 
     *occupant = NULL;
+    if (0 > room_num) {
+        /* occupant wasn't checked in */
+        return;
+    }
 
     /* If there's an occupant in the room, have them come to the door */
     room = &(hotel->rooms[room_num]);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1043,7 +1043,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                                 --cd->nleft;
                                 /* if the event was cached and this is the last one,
                                  * then evict this event from the cache */
-                                if (-1 != cd->room && 0 == cd->nleft) {
+                                if (0 == cd->nleft) {
                                     pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
                                     PMIX_RELEASE(cd);
                                 }


### PR DESCRIPTION
We use a negative number to indicate that the object has not yet been
checked into a hotel, so protect the checkout routines against that
scenario.

Signed-off-by: Ralph Castain <rhc@pmix.org>