### PR TITLE
Fixes PMIx_generate_regex ordering

### DIFF
--- a/src/mca/preg/base/preg_base_frame.c
+++ b/src/mca/preg/base/preg_base_frame.c
@@ -14,6 +14,7 @@
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2015-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -98,6 +99,7 @@ static void rvcon(pmix_regex_value_t *p)
     p->prefix = NULL;
     p->suffix = NULL;
     p->num_digits = 0;
+    p->skip = false;
     PMIX_CONSTRUCT(&p->ranges, pmix_list_t);
 }
 static void rvdes(pmix_regex_value_t *p)

--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
@@ -152,9 +152,22 @@ static pmix_status_t generate_node_regex(const char *input,
             suffix = NULL;
             numdigits = (int)strlen(&vptr[startnum]);
         }
+
         /* is this value already on our list? */
         found = false;
         PMIX_LIST_FOREACH(vreg, &vids, pmix_regex_value_t) {
+            // The regex must preserve ordering of the values.
+            // If we disqualified this entry in a previous check then exclude it
+            // from future checks as well. This will prevent a later entry from
+            // being 'pulled forward' accidentally. For example, given:
+            // "a28n01,a99n02,a28n02"
+            // Without this 'skip' the loop would have 'a28n02' combine with
+            // 'a28n01' jumping over the 'a99n02' entry, and thus not preserving
+            // the order of the list when the regex is unpacked.
+            if( vreg->skip ) {
+                continue;
+            }
+
             if (0 < strlen(prefix) && NULL == vreg->prefix) {
                 continue;
             }
@@ -163,6 +176,7 @@ static pmix_status_t generate_node_regex(const char *input,
             }
             if (0 < strlen(prefix) && NULL != vreg->prefix
                 && 0 != strcmp(prefix, vreg->prefix)) {
+                vreg->skip = true;
                 continue;
             }
             if (NULL == suffix && NULL != vreg->suffix) {
@@ -173,9 +187,11 @@ static pmix_status_t generate_node_regex(const char *input,
             }
             if (NULL != suffix && NULL != vreg->suffix &&
                 0 != strcmp(suffix, vreg->suffix)) {
+                vreg->skip = true;
                 continue;
             }
             if (numdigits != vreg->num_digits) {
+                vreg->skip = true;
                 continue;
             }
             /* found a match - flag it */

--- a/src/mca/preg/preg_types.h
+++ b/src/mca/preg/preg_types.h
@@ -13,6 +13,7 @@
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -51,6 +52,7 @@ typedef struct {
     char *suffix;
     int num_digits;
     pmix_list_t ranges;
+    bool skip;
 } pmix_regex_value_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_regex_value_t);
 


### PR DESCRIPTION
 * The problem is that `PMIx_generate_regex` must preserve ordering of the
   list passed into it. This allows for a proper mapping of nodes-to-ranks
   to occur inside of PMIx (which is then exposed to the application).
   - If the hostnames contain multiple sets of digits then the list
     can be reordered causing the mapping to be incorrect.
 * This patch prevents the regex from 'matching' an earlier prefix/suffix
   if that would mean skipping over another match just before it.
 * Fixes #1049