### PR TITLE
Use affected procs for filtering notifications

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1590,6 +1590,10 @@ typedef struct pmix_info {
 #define PMIX_INFO_IS_OPTIONAL(m)    \
     !((m)->flags & PMIX_INFO_REQD)
 
+/* macro for testing end of the array */
+#define PMIX_INFO_IS_END(m)         \
+    (m)->flags & PMIX_INFO_ARRAY_END
+
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
  * type of PMIX_UNDEF is taken to imply a boolean "true"

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -158,6 +158,24 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     if (0 == nqueries || NULL == queries) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* do a quick check of the qualifiers array to ensure
+     * the nqual field has been set */
+    for (n=0; n < nqueries; n++) {
+        if (NULL != queries[n].qualifiers && 0 == queries[n].nqual) {
+            /* look for the info marked as "end" */
+            p = 0;
+            while (!(PMIX_INFO_IS_END(&queries[n].qualifiers[p])) && p < SIZE_MAX) {
+                ++p;
+            }
+            if (SIZE_MAX == p) {
+                /* nothing we can do */
+                PMIX_RELEASE_THREAD(&pmix_global_lock);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            queries[n].nqual = p;
+        }
     }
 
     /* setup the list of local results */

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -165,9 +165,8 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
     pmix_cmd_t cmd = PMIX_NOTIFY_CMD;
     pmix_cb_t *cb;
     pmix_event_chain_t *chain;
-    size_t n, nleft;
+    size_t n;
     pmix_notify_caddy_t *cd;
-    pmix_namespace_t *nptr, *tmp;
 
     pmix_output_verbose(2, pmix_client_globals.event_output,
                         "[%s:%d] client: notifying server %s:%d of status %s for range %s",
@@ -253,31 +252,6 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
         cd->ntargets = chain->ntargets;
         PMIX_PROC_CREATE(cd->targets, cd->ntargets);
         memcpy(cd->targets, chain->targets, cd->ntargets * sizeof(pmix_proc_t));
-        /* compute the number of targets that need to be notified */
-        nleft = 0;
-        for (n=0; n < cd->ntargets; n++) {
-            /* if this is a single proc, then increment by one */
-            if (PMIX_RANK_VALID >= cd->targets[n].rank) {
-                ++nleft;
-            } else {
-                /* look up the nspace for this proc */
-                nptr = NULL;
-                PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
-                    if (PMIX_CHECK_NSPACE(tmp->nspace, cd->targets[n].nspace)) {
-                        nptr = tmp;
-                        break;
-                    }
-                }
-                /* if we don't yet know it, then nothing to do */
-                if (NULL == nptr) {
-                    nleft = SIZE_MAX;
-                    break;
-                }
-                /* might notify all local members */
-                nleft += nptr->nlocalprocs;
-            }
-        }
-        cd->nleft = nleft;
     }
     if (NULL != chain->affected) {
         cd->naffected = chain->naffected;
@@ -984,32 +958,33 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     if (matched) {
                         continue;
                     }
+                    /* check if the affected procs (if given) match those they
+                     * wanted to know about */
+                    if (!pmix_notify_check_affected(cd->affected, cd->naffected,
+                                                    pr->affected, pr->naffected)) {
+                        continue;
+                    }
                     /* check the range */
+                    if (NULL == cd->targets) {
+                        rngtrk.procs = &cd->source;
+                        rngtrk.nprocs = 1;
+                    } else {
+                        rngtrk.procs = cd->targets;
+                        rngtrk.nprocs = cd->ntargets;
+                    }
                     rngtrk.range = cd->range;
                     PMIX_LOAD_PROCID(&proc, pr->peer->info->pname.nspace, pr->peer->info->pname.rank);
                     if (!pmix_notify_check_range(&rngtrk, &proc)) {
                         continue;
                     }
-                    /* if we were given specific targets, check if this is one */
                     if (NULL != cd->targets) {
-                        matched = false;
-                        for (n=0; n < cd->ntargets; n++) {
-                            if (PMIX_CHECK_PROCID(&pr->peer->info->pname, &cd->targets[n])) {
-                                matched = true;
-                                /* track the number of targets we have left to notify */
-                                --cd->nleft;
-                                /* if the event was cached and this is the last one,
-                                 * then evict this event from the cache */
-                                if (0 == cd->nleft) {
-                                    pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
-                                    PMIX_RELEASE(cd);
-                                }
-                                break;
-                            }
-                        }
-                        if (!matched) {
-                            /* do not notify this one */
-                            continue;
+                        /* track the number of targets we have left to notify */
+                        --cd->nleft;
+                        /* if the event was cached and this is the last one,
+                         * then evict this event from the cache */
+                        if (0 == cd->nleft) {
+                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
+                            PMIX_RELEASE(cd);
                         }
                     }
                     pmix_output_verbose(2, pmix_server_globals.event_output,
@@ -1174,37 +1149,34 @@ bool pmix_notify_check_range(pmix_range_trkr_t *rng,
         return true;
     }
     if (PMIX_RANGE_NAMESPACE == rng->range) {
-        if (0 == strncmp(pmix_globals.myid.nspace, proc->nspace, PMIX_MAX_NSLEN)) {
-            return true;
+        for (n=0; n < rng->nprocs; n++) {
+            if (PMIX_CHECK_NSPACE(rng->procs[n].nspace, proc->nspace)) {
+                return true;
+            }
         }
         return false;
     }
     if (PMIX_RANGE_PROC_LOCAL == rng->range) {
-        if (0 == strncmp(pmix_globals.myid.nspace, proc->nspace, PMIX_MAX_NSLEN) &&
-            pmix_globals.myid.rank == proc->rank) {
-            return true;
+        for (n=0; n < rng->nprocs; n++) {
+            if (PMIX_CHECK_PROCID(&rng->procs[n], proc)) {
+                return true;
+            }
         }
         return false;
     }
     if (PMIX_RANGE_CUSTOM == rng->range) {
-        if (NULL != rng->procs) {
-            /* see if this proc was included */
-            for (n=0; n < rng->nprocs; n++) {
-                if (0 != strncmp(rng->procs[n].nspace, proc->nspace, PMIX_MAX_NSLEN)) {
-                    continue;
-                }
-                if (PMIX_RANK_WILDCARD == rng->procs[n].rank ||
-                    rng->procs[n].rank == proc->rank) {
-                    return true;
-                }
+        /* see if this proc was included */
+        for (n=0; n < rng->nprocs; n++) {
+            if (0 != strncmp(rng->procs[n].nspace, proc->nspace, PMIX_MAX_NSLEN)) {
+                continue;
             }
-            /* if we get here, then this proc isn't in range */
-            return false;
-        } else {
-            /* if they didn't give us a list, then assume
-             * everyone included */
-            return true;
+            if (PMIX_RANK_WILDCARD == rng->procs[n].rank ||
+                rng->procs[n].rank == proc->rank) {
+                return true;
+            }
         }
+        /* if we get here, then this proc isn't in range */
+        return false;
     }
 
     /* if it is anything else, then reject it */
@@ -1227,12 +1199,7 @@ bool pmix_notify_check_affected(pmix_proc_t *interested, size_t ninterested,
     /* check if the two overlap */
     for (n=0; n < naffected; n++) {
         for (m=0; m < ninterested; m++) {
-            if (0 != strncmp(affected[n].nspace, interested[m].nspace, PMIX_MAX_NSLEN)) {
-                continue;
-            }
-            if (PMIX_RANK_WILDCARD == interested[m].rank ||
-                PMIX_RANK_WILDCARD == affected[n].rank ||
-                affected[n].rank == interested[m].rank) {
+            if (PMIX_CHECK_PROCID(&affected[n], &interested[m])) {
                 return true;
             }
         }

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -297,11 +297,7 @@ static pmix_status_t _add_hdlr(pmix_rshift_caddy_t *cd, pmix_list_t *xfer)
         PMIX_INFO_CREATE(cd2->info, cd2->ninfo);
         n=0;
         PMIX_LIST_FOREACH(ixfer, xfer, pmix_info_caddy_t) {
-            pmix_strncpy(cd2->info[n].key, ixfer->info[n].key, PMIX_MAX_KEYLEN);
-            PMIX_BFROPS_VALUE_LOAD(pmix_client_globals.myserver,
-                                   &cd2->info[n].value,
-                                   &ixfer->info[n].value.data,
-                                   ixfer->info[n].value.type);
+            PMIX_INFO_XFER(&cd2->info[n], ixfer->info);
             ++n;
         }
     }
@@ -526,12 +522,21 @@ static void reg_event_hdlr(int sd, short args, void *cbdata)
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
                 cd->affected = cd->info[n].value.data.proc;
                 cd->naffected = 1;
+                ixfer = PMIX_NEW(pmix_info_caddy_t);
+                ixfer->info = &cd->info[n];
+                ixfer->ninfo = 1;
+                pmix_list_append(&xfer, &ixfer->super);
             } else if (0 == strncmp(cd->info[n].key, PMIX_EVENT_AFFECTED_PROCS, PMIX_MAX_KEYLEN)) {
                 cd->affected = (pmix_proc_t*)cd->info[n].value.data.darray->array;
                 cd->naffected = cd->info[n].value.data.darray->size;
+                ixfer = PMIX_NEW(pmix_info_caddy_t);
+                ixfer->info = &cd->info[n];
+                ixfer->ninfo = 1;
+                pmix_list_append(&xfer, &ixfer->super);
             } else {
                 ixfer = PMIX_NEW(pmix_info_caddy_t);
                 ixfer->info = &cd->info[n];
+                ixfer->ninfo = 1;
                 pmix_list_append(&xfer, &ixfer->super);
             }
         }

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -39,10 +39,11 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
                                       pmix_list_t *ilist)
 {
     pmix_pnet_base_active_module_t *active;
-    pmix_status_t rc;
+    pmix_status_t rc = PMIX_SUCCESS;
     pmix_namespace_t *nptr, *ns;
     size_t n;
     char *nregex, *pregex;
+    char *params[2] = {"PMIX_MCA_", NULL};
 
     if (!pmix_pnet_globals.initialized) {
         return PMIX_ERR_INIT;
@@ -75,22 +76,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
             pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
         }
 
-        /* if the info param is NULL, then we make one pass thru the actives
-         * in case someone specified an allocation or collection of envars
-         * via MCA param */
-        if (NULL == info) {
-            PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
-                if (NULL != active->module->allocate) {
-                    if (PMIX_SUCCESS == (rc = active->module->allocate(nptr, NULL, ilist))) {
-                        break;
-                    }
-                    if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
-                        /* true error */
-                        return rc;
-                    }
-                }
-            }
-        } else {
+        if (NULL != info) {
             /* check for description of the node and proc maps */
             nregex = NULL;
             pregex = NULL;
@@ -131,7 +117,10 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
         }
     }
 
-    return PMIX_SUCCESS;
+    /* add any local PMIx MCA params */
+    rc = pmix_pnet_base_harvest_envars(params, NULL, ilist);
+
+    return rc;
 }
 
 /* can only be called by a server */

--- a/src/server/pmix_server_ops.h
+++ b/src/server/pmix_server_ops.h
@@ -131,6 +131,8 @@ typedef struct {
     pmix_list_item_t super;
     pmix_peer_t *peer;
     bool enviro_events;
+    pmix_proc_t *affected;
+    size_t naffected;
 } pmix_peer_events_info_t;
 PMIX_CLASS_DECLARATION(pmix_peer_events_info_t);
 


### PR DESCRIPTION
Add a macro to check for end of pmix_info_t array marker.

Check input to spawn and query functions to ensure the number of app
directives and qualifiers is set.

Ensure launchers pickup PMIx MCA params to forward to their child jobs.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit ffd647db3849f5b486bc7f6ba6e7aeed319810d5)