### PR TITLE
Sync some missing attributes from v2.2 standard

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -396,6 +396,49 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_TIME_REMAINING                 "pmix.time.remaining"   // (char*) query number of seconds (uint32_t) remaining in allocation
                                                                     //         for the specified nspace
 
+/* information retrieval attributes */
+#define PMIX_SESSION_INFO                   "pmix.ssn.info"         // (bool) Return information about the specified session. If information
+                                                                    //        about a session other than the one containing the requesting
+                                                                    //        process is desired, then the attribute array must contain a
+                                                                    //        PMIX_SESSION_ID attribute identifying the desired target.
+#define PMIX_JOB_INFO                       "pmix.job.info"         // (bool) Return information about the specified job or namespace. If
+                                                                    //        information about a job or namespace other than the one containing
+                                                                    //        the requesting process is desired, then the attribute array must
+                                                                    //        contain a PMIX_JOBID or PMIX_NSPACE attribute identifying the
+                                                                    //        desired target. Similarly, if information is requested about a
+                                                                    //        job or namespace in a session other than the one containing the
+                                                                    //        requesting process, then an attribute identifying the target
+                                                                    //        session must be provided.
+#define PMIX_APP_INFO                       "pmix.app.info"         // (bool) Return information about the specified application. If information
+                                                                    //        about an application other than the one containing the requesting
+                                                                    //        process is desired, then the attribute array must contain a
+                                                                    //        PMIX_APPNUM attribute identifying the desired target. Similarly,
+                                                                    //        if information is requested about an application in a job or session
+                                                                    //        other than the one containing the requesting process, then attributes
+                                                                    //        identifying the target job and/or session must be provided.
+#define PMIX_NODE_INFO                      "pmix.node.info"        // (bool) Return information about the specified node. If information about a
+                                                                    //        node other than the one containing the requesting process is desired,
+                                                                    //        then the attribute array must contain either the PMIX_NODEID or
+                                                                    //        PMIX_HOSTNAME attribute identifying the desired target.
+
+/* information storage attributes */
+#define PMIX_SESSION_INFO_ARRAY             "pmix.ssn.arr"          // (pmix_data_array_t) Provide an array of pmix_info_t containing
+                                                                    //        session-level information. The PMIX_SESSION_ID attribute is required
+                                                                    //        to be included in the array.
+#define PMIX_JOB_INFO_ARRAY                 "pmix.job.arr"          // (pmix_data_array_t) Provide an array of pmix_info_t containing job-level
+                                                                    //        information. Information is registered one job (aka namespace) at a time
+                                                                    //        via the PMIx_server_register_nspace API. Thus, there is no requirement that
+                                                                    //        the array contain either the PMIX_NSPACE or PMIX_JOBID attributes, though
+                                                                    //        either or both of them may be included.
+#define PMIX_APP_INFO_ARRAY                 "pmix.app.arr"          // (pmix_data_array_t) Provide an array of pmix_info_t containing app-level
+                                                                    //        information. The PMIX_NSPACE or PMIX_JOBID attributes of the job containing
+                                                                    //        the appplication, plus its PMIX_APPNUM attribute, are required to be
+                                                                    //        included in the array.
+#define PMIX_NODE_INFO_ARRAY                "pmix.node.arr"         // (pmix_data_array_t) Provide an array of pmix_info_t containing node-level
+                                                                    //        information. At a minimum, either the PMIX_NODEID or PMIX_HOSTNAME
+                                                                    //        attribute is required to be included in the array, though both may be
+                                                                    //        included.
+
 /* log attributes */
 #define PMIX_LOG_STDERR                     "pmix.log.stderr"       // (char*) log string to stderr
 #define PMIX_LOG_STDOUT                     "pmix.log.stdout"       // (char*) log string to stdout
@@ -737,7 +780,11 @@ typedef uint8_t pmix_persistence_t;
  * command directives via pmix_info_t arrays */
 typedef uint32_t pmix_info_directives_t;
 #define PMIX_INFO_REQD          0x00000001
-
+#define PMIX_INFO_ARRAY_END     0x00000002      // mark the end of an array created by PMIX_INFO_CREATE
+/* the top 16-bits are reserved for internal use by
+ * implementers - these may be changed inside the
+ * PMIx library */
+#define PMIX_INFO_DIR_RESERVED 0xffff0000
 
 /* define a set of directives for allocation requests */
 typedef uint8_t pmix_alloc_directive_t;
@@ -1197,6 +1244,7 @@ struct pmix_info_t {
 #define PMIX_INFO_IS_OPTIONAL(m)    \
     !((m)->flags & PMIX_INFO_REQD)
 
+
 /* define a special macro for checking if a boolean
  * info is true - when info structs are provided, a
  * type of PMIX_UNDEF is taken to imply a boolean "true"
@@ -1288,6 +1336,12 @@ typedef struct pmix_app {
         (m) = (pmix_app_t*)calloc((n), sizeof(pmix_app_t));     \
     } while (0)
 
+#define PMIX_APP_INFO_CREATE(m, n)                  \
+    do {                                            \
+        (m)->ninfo = (n);                           \
+        PMIX_INFO_CREATE((m)->info, (m)->ninfo);    \
+    } while(0)
+
 #define PMIX_APP_RELEASE(m)                     \
     do {                                        \
         PMIX_APP_DESTRUCT((m));                 \
@@ -1358,6 +1412,12 @@ typedef struct pmix_query {
     do {                                                            \
         (m) = (pmix_query_t*)calloc((n) , sizeof(pmix_query_t));    \
     } while (0)
+
+#define PMIX_QUERY_QUALIFIERS_CREATE(m, n)                  \
+    do {                                                    \
+        (m)->nqual = (n);                                   \
+        PMIX_INFO_CREATE((m)->qualifiers, (m)->nqual);      \
+    } while(0)
 
 #define PMIX_QUERY_RELEASE(m)       \
     do {                            \


### PR DESCRIPTION
Based on a line-by-line comparison between the standard doc and pmix_common.h.in.

Signed-off-by: Ralph Castain <rhc@pmix.org>