### PR TITLE
Ensure we return the correct status

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -1761,6 +1761,7 @@ pmix_status_t pmix_server_register_events(pmix_peer_t *peer,
                 break;
             }
         }
+        rc = PMIX_OPERATION_SUCCEEDED;
         goto cleanup;
     }
 


### PR DESCRIPTION
When registering a default event handler, we have to return "operation
succeeded" as we have atomically completed the registration and won't be
executing a callback function.

Signed-off-by: Ralph Castain <rhc@pmix.org>