### PR TITLE
Fix typo in PMIX_SYSTEM_EVENT macro

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -662,7 +662,7 @@ typedef int pmix_status_t;
 
 /* define a macro for identifying system event values */
 #define PMIX_SYSTEM_EVENT(a)   \
-    (230 > (a) && -331 < (a))
+    ((a) <= PMIX_ERR_NODE_DOWN && PMIX_ERR_SYS_OTHER <= (a))
 
 /* used by event handlers */
 #define PMIX_EVENT_NO_ACTION_TAKEN                  -331


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>