### PR TITLE
Update the job_ctrl return code

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -2568,7 +2568,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
         PMIX_LIST_DESTRUCT(&cachefiles);
         if (cnt == (int)cd->ninfo) {
             /* nothing more to do */
-            rc = PMIX_SUCCESS;
+            rc = PMIX_OPERATION_SUCCEEDED;
             goto exit;
         }
     }


### PR DESCRIPTION
Return OPERATION_SUCCEEDED for cleanup registrations

Signed-off-by: Ralph Castain <rhc@open-mpi.org>

(cherry picked from commit pmix/pmix@516fe69ef2ac99df032fde1c02a572524dec56ee)