### PR TITLE
Update configure logic for clock_gettime

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -645,6 +645,11 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     pmix_show_title "Library and Function tests"
 
+    # Darwin doesn't need -lutil, as it's something other than this -lutil.
+    PMIX_SEARCH_LIBS_CORE([openpty], [util])
+
+    PMIX_SEARCH_LIBS_CORE([gethostbyname], [nsl])
+
     PMIX_SEARCH_LIBS_CORE([socket], [socket])
 
     # IRIX and CentOS have dirname in -lgen, usually in libc
@@ -652,6 +657,9 @@ AC_DEFUN([PMIX_SETUP_CORE],[
 
     # Darwin doesn't need -lm, as it's a symlink to libSystem.dylib
     PMIX_SEARCH_LIBS_CORE([ceil], [m])
+
+    # -lrt might be needed for clock_gettime
+    PMIX_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
     AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp])
 

--- a/config/pmix_search_libs.m4
+++ b/config/pmix_search_libs.m4
@@ -1,7 +1,7 @@
 dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2013-2014 Cisco Systems, Inc.  All rights reserved.
-dnl Copyright (c) 2014      Intel, Inc. All rights reserved.
+dnl Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 dnl $COPYRIGHT$
 dnl
 dnl Additional copyrights may follow
@@ -21,7 +21,13 @@ dnl
 # PMIX_SEARCH_LIBS_COMPONENT.  The reason why is because this macro
 # calls PMIX_WRAPPER_FLAGS_ADD -- see big comment in
 # pmix_setup_wrappers.m4 for an explanation of why this is bad).
+# NOTE: PMIx doesn't have wrapper compilers, so this is not an issue
+# here - we leave the note just for downstream compatibility
 AC_DEFUN([PMIX_SEARCH_LIBS_CORE],[
+
+    PMIX_VAR_SCOPE_PUSH([LIBS_save add])
+    LIBS_save=$LIBS
+
     AC_SEARCH_LIBS([$1], [$2],
         [pmix_have_$1=1
          $3],
@@ -31,4 +37,33 @@ AC_DEFUN([PMIX_SEARCH_LIBS_CORE],[
     AC_DEFINE_UNQUOTED([PMIX_HAVE_]m4_toupper($1), [$pmix_have_$1],
          [whether $1 is found and available])
 
+    PMIX_VAR_SCOPE_POP
+])dnl
+
+# PMIX SEARCH_LIBS_COMPONENT(prefix, func, list-of-libraries,
+#                            action-if-found, action-if-not-found,
+#                            other-libraries)
+#
+# Same as PMIX SEARCH_LIBS_CORE, above, except that we don't call PMIX
+# WRAPPER_FLAGS_ADD.  Instead, we add it to the ${prefix}_LIBS
+# variable (i.e., $prefix is usually "framework_component", such as
+# "fbtl_posix").
+AC_DEFUN([PMIX_SEARCH_LIBS_COMPONENT],[
+
+    PMIX_VAR_SCOPE_PUSH([LIBS_save add])
+    LIBS_save=$LIBS
+
+    AC_SEARCH_LIBS([$2], [$3],
+        [ # Found it!  See if anything was added to LIBS
+         add=`printf '%s\n' "$LIBS" | sed -e "s/$LIBS_save$//"`
+         AS_IF([test -n "$add"],
+             [PMIX_FLAGS_APPEND_UNIQ($1_LIBS, [$add])])
+         $1_have_$2=1
+         $4],
+        [$1_have_$2=0
+         $5], [$6])
+
+        AC_DEFINE_UNQUOTED([PMIX_HAVE_]m4_toupper($1), [$$1_have_$2],
+            [whether $1 is found and available])
+    PMIX_VAR_SCOPE_POP
 ])dnl

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -4187,11 +4187,17 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_setup_caddy_t,
 
 static void ncon(pmix_notify_caddy_t *p)
 {
-    struct timespec tp;
-
     PMIX_CONSTRUCT_LOCK(&p->lock);
-    clock_gettime(CLOCK_MONOTONIC, &tp);
+#if defined(__linux__) && OPAL_HAVE_CLOCK_GETTIME
+    struct timespec tp;
+    (void) clock_gettime(CLOCK_MONOTONIC, &tp);
     p->ts = tp.tv_sec;
+#else
+    /* Fall back to gettimeofday() if we have nothing else */
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    p->ts = tv.tv_sec;
+#endif
     p->room = -1;
     memset(p->source.nspace, 0, PMIX_MAX_NSLEN+1);
     p->source.rank = PMIX_RANK_UNDEF;


### PR DESCRIPTION
Port some configure changes from upstream. Protect the one place where
we call clock_gettime from systems where it isn't available.

Signed-off-by: Ralph Castain <rhc@pmix.org>