### PR TITLE
Update configure logic

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -17,11 +17,7 @@ AC_DEFUN([PMIX_HWLOC_CONFIG],[
                 [AC_HELP_STRING([--with-hwloc-header=HEADER],
                                 [The value that should be included in C files to include hwloc.h])])
 
-    AC_ARG_ENABLE([embedded-hwloc],
-                  [AC_HELP_STRING([--enable-embedded-hwloc],
-                                  [Enable use of locally embedded hwloc])])
-
-    AS_IF([test "$enable_embedded_hwloc" = "yes"],
+    AS_IF([test "$pmix_mode" = "embedded"],
           [_PMIX_HWLOC_EMBEDDED_MODE],
           [_PMIX_HWLOC_EXTERNAL])
 

--- a/config/pmix_setup_libevent.m4
+++ b/config/pmix_setup_libevent.m4
@@ -19,11 +19,7 @@ AC_DEFUN([PMIX_LIBEVENT_CONFIG],[
                 [AC_HELP_STRING([--with-libevent-header=HEADER],
                                 [The value that should be included in C files to include event.h])])
 
-    AC_ARG_ENABLE([embedded-libevent],
-                  [AC_HELP_STRING([--enable-embedded-libevent],
-                                  [Enable use of locally embedded libevent])])
-
-    AS_IF([test "$enable_embedded_libevent" = "yes"],
+    AS_IF([test "$pmix_mode" = "embedded"],
           [_PMIX_LIBEVENT_EMBEDDED_MODE],
           [_PMIX_LIBEVENT_EXTERNAL])
 


### PR DESCRIPTION
Remove the --enable-embedded-libevent and --enable-embedded-hwloc flags as they are confusing users. Instead, we will use the --enable-embedded-mode to handle both of these options.

Signed-off-by: Ralph Castain <rhc@pmix.org>