### PR TITLE
Remove the "restrict" keyword to avoid requiring C99 for apps

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2710,8 +2710,8 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
  * @param len Size of the dest array - 1
  *
  */
-static inline void pmix_strncpy(char *restrict dest,
-                                const char *restrict src,
+static inline void pmix_strncpy(char *dest,
+                                const char *src,
                                 size_t len)
 {
     size_t i;


### PR DESCRIPTION
Signed-off-by: Ralph Castain <rhc@pmix.org>