### PR TITLE
Complete implementation of stdin forwarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,6 +134,8 @@ test/simple/stability
 test/simple/gwclient
 test/simple/gwtest
 test/simple/simpjctrl
+test/simple/simpio
+test/simple/data-*
 
 # coverity
 cov-int

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -867,6 +867,8 @@ typedef int pmix_status_t;
 #define PMIX_GROUP_LEADER_SELECTED                  -167
 #define PMIX_GROUP_LEADER_FAILED                    -168
 #define PMIX_GROUP_CONTEXT_ID_ASSIGNED              -169
+#define PMIX_ERR_IOF_FAILURE                        -171
+#define PMIX_ERR_IOF_COMPLETE                       -172
 
 /* system failures */
 #define PMIX_ERR_NODE_DOWN                          -231

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -102,6 +102,8 @@ typedef struct {
     bool always_readable;
     pmix_proc_t *targets;
     size_t ntargets;
+    pmix_info_t *directives;
+    size_t ndirs;
 } pmix_iof_read_event_t;
 PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_iof_read_event_t);
 
@@ -190,8 +192,9 @@ pmix_iof_fd_always_ready(int fd)
     } while(0);
 
 
-#define PMIX_IOF_READ_EVENT(rv, p, np, fid, cbfunc, actv)               \
+#define PMIX_IOF_READ_EVENT(rv, p, np, d, nd, fid, cbfunc, actv)        \
     do {                                                                \
+        size_t _ii;                                                     \
         pmix_iof_read_event_t *rev;                                     \
         PMIX_OUTPUT_VERBOSE((1, pmix_client_globals.iof_output,         \
                             "defining read event at: %s %d",            \
@@ -200,6 +203,13 @@ pmix_iof_fd_always_ready(int fd)
         (rev)->ntargets = (np);                                         \
         PMIX_PROC_CREATE((rev)->targets, (rev)->ntargets);              \
         memcpy((rev)->targets, (p), (np) * sizeof(pmix_proc_t));        \
+        if (NULL != (d)) {                                              \
+            PMIX_INFO_CREATE((rev)->directives, (nd));                  \
+            (rev)->ndirs = (nd);                                        \
+            for (_ii=0; _ii < (nd); _ii++) {                            \
+                PMIX_INFO_XFER(&((rev)->directives[_ii]), &((d)[_ii])); \
+            }                                                           \
+        }                                                               \
         rev->fd = (fid);                                                \
         rev->always_readable = pmix_iof_fd_always_ready(fid);           \
         *(rv) = rev;                                                    \

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -293,7 +293,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
             PMIX_RELEASE(cb);
             goto cleanup;
         }
-    } else {
+    } else if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -285,7 +285,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
     bool event_active;
-    bool lost_connection;           // tracker went thru lost connection procedure
+    bool host_called;               // tracker has been passed up to host
     bool local;                     // operation is strictly local
     char *id;                       // string identifier for the collective
     pmix_cmd_t type;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -55,13 +55,6 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(chain);
 }
 
-static void _timeout(int sd, short args, void *cbdata)
-{
-    pmix_server_trkr_t *trk = (pmix_server_trkr_t*)cbdata;
-
-    PMIX_RELEASE(trk);
-}
-
 static void lcfn(pmix_status_t status, void *cbdata)
 {
     pmix_peer_t *peer = (pmix_peer_t*)cbdata;
@@ -76,7 +69,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
-    struct timeval tv = {1200, 0};
     pmix_proc_t proc;
     pmix_status_t rc;
 
@@ -114,59 +106,60 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 /* remove it from the list */
                 pmix_list_remove_item(&trk->local_cbs, &rinfo->super);
                 PMIX_RELEASE(rinfo);
-                trk->lost_connection = true;  // mark that a peer's connection was lost
-                if (0 == pmix_list_get_size(&trk->local_cbs)) {
-                    /* this tracker is complete, so release it - there
-                     * is nobody waiting for a response */
-                    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
-                    /* do NOT release the tracker here as the host may
-                     * have a copy they will return later. However, they
-                     * might never call back, so set a LONG timeout to
-                     * we avoid a memory leak if they don't */
-                    pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                           _timeout, trk);
-                    pmix_event_evtimer_add(&trk->ev, &tv);
-                    trk->event_active = true;
-                    break;
+                /* if the host has already been called for this tracker,
+                 * then do nothing here - just wait for the host to return
+                 * from the operation */
+                if (trk->host_called) {
+                    continue;
                 }
-                /* if there are other participants waiting for a response,
-                 * we need to let them know that this proc has disappeared
-                 * as otherwise the collective will never complete */
-                if (PMIX_FENCENB_CMD == trk->type) {
-                    if (NULL != trk->modexcbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
-                    }
-                } else if (PMIX_CONNECTNB_CMD == trk->type) {
-                    if (NULL != trk->op_cbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
-                    }
-                } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
-                    if (NULL != trk->op_cbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                if (trk->def_complete && trk->nlocal == pmix_list_get_size(&trk->local_cbs)) {
+                    /* if this is a local-only collective, then resolve it now */
+                    if (trk->local) {
+                        /* everyone else has called in - we need to let them know
+                         * that this proc has disappeared
+                         * as otherwise the collective will never complete */
+                        if (PMIX_FENCENB_CMD == trk->type) {
+                            if (NULL != trk->modexcbfunc) {
+                                trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
+                            }
+                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                            if (NULL != trk->op_cbfunc) {
+                                trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                            }
+                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                            if (NULL != trk->op_cbfunc) {
+                                trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                            }
+                        }
+                    } else {
+                        /* if the host has not been called, then we need to see if
+                         * the collective is locally complete without this lost
+                         * participant. If so, then we need to pass the call
+                         * up to the host as otherwise the global collective will hang */
+                        if (PMIX_FENCENB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs,
+                                                           trk->info, trk->ninfo,
+                                                           NULL, 0, trk->modexcbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        }
                     }
                 }
             }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2299,11 +2299,6 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     /* if we get here, then there are processes waiting
      * for a response */
 
-    /* if the timer is active, clear it */
-    if (tracker->event_active) {
-        pmix_event_del(&tracker->ev);
-    }
-
     /* pass the blobs being returned */
     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
     PMIX_LOAD_BUFFER(pmix_globals.mypeer, &xfer, scd->data, scd->ndata);
@@ -2388,12 +2383,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     xfer.bytes_used = 0;
     PMIX_DESTRUCT(&xfer);
 
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
     PMIX_LIST_DESTRUCT(&nslist);
 
@@ -2646,12 +2636,7 @@ static void _cnct(int sd, short args, void *cbdata)
     if (NULL != nspaces) {
       pmix_argv_free(nspaces);
     }
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
 
     /* we are done */
@@ -2728,12 +2713,7 @@ static void _discnct(int sd, short args, void *cbdata)
   cleanup:
     /* cleanup the tracker -- the host RM is responsible for
      * telling us when to remove the nspace from our data */
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
 
     /* we are done */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -797,6 +797,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
         /* now unload the blob and pass it upstairs */
         PMIX_UNLOAD_BUFFER(&bucket, data, sz);
         PMIX_DESTRUCT(&bucket);
+        trk->host_called = true;
         rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs,
                                        trk->info, trk->ninfo,
                                        data, sz, trk->modexcbfunc, trk);
@@ -1449,6 +1450,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd,
      * across all participants has been completed */
     if (trk->def_complete &&
         pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        trk->host_called = true;
         rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, cbfunc, trk);
         if (PMIX_SUCCESS != rc) {
             /* remove this contributor from the list - they will be notified
@@ -1598,6 +1600,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * across all participants has been completed */
     if (trk->def_complete &&
         pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        trk->host_called = true;
         rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, cbfunc, trk);
         if (PMIX_SUCCESS != rc) {
             /* remove this contributor from the list - they will be notified
@@ -3380,9 +3383,11 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
     if (PMIX_SUCCESS != (rc = pmix_host_server.push_stdin(&source, cd->procs, cd->nprocs,
                                                           cd->info, cd->ninfo, cd->bo,
                                                           stdcbfunc, cd))) {
-        goto error;
+        if (PMIX_OPERATION_SUCCEEDED != rc) {
+            goto error;
+        }
     }
-    return PMIX_SUCCESS;
+    return rc;
 
   error:
     PMIX_RELEASE(cd);
@@ -4080,7 +4085,7 @@ pmix_status_t pmix_server_grpdestruct(pmix_server_caddy_t *cd,
 static void tcon(pmix_server_trkr_t *t)
 {
     t->event_active = false;
-    t->lost_connection = false;
+    t->host_called = false;
     t->local = false;
     t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN+1);

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2012 Los Alamos National Security, LLC.
  *                         All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -151,7 +151,10 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
         return "UNPACK-PAST-END";
     case PMIX_ERR_CONFLICTING_CLEANUP_DIRECTIVES:
         return "PMIX CONFLICTING CLEANUP DIRECTIVES";
-
+    case PMIX_ERR_IOF_FAILURE:
+        return "IOF FAILURE";
+    case PMIX_ERR_IOF_COMPLETE:
+        return "IOF COMPLETE";
 
     case PMIX_ERR_LOST_CONNECTION_TO_SERVER:
         return "LOST_CONNECTION_TO_SERVER";

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2010 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,7 +25,7 @@ headers = simptest.h
 
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simplegacy simptimeout \
-                  gwtest gwclient stability quietclient simpjctrl
+                  gwtest gwclient stability quietclient simpjctrl simpio
 
 simptest_SOURCES = \
         simptest.c
@@ -121,4 +121,10 @@ simpjctrl_SOURCES = \
         simpjctrl.c
 simpjctrl_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpjctrl_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpio_SOURCES = \
+        simpio.c
+simpio_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpio_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/makedata.pl
+++ b/test/simple/makedata.pl
@@ -1,0 +1,46 @@
+#!/usr/bin/env perl
+
+# Make a simple data file of a argv[0]-specified size (understand "k",
+# "m", and "g" suffixes) of a repeating pattern.
+
+use strict;
+
+my $size_arg = $ARGV[0];
+$size_arg =~ m/^(\d+)/;
+my $size = $1;
+$size_arg =~ m/([mkg])$/i;
+my $size_unit = lc($1);
+
+if ($size_unit eq "k") {
+    $size *= 1024;
+} elsif ($size_unit eq "m") {
+    $size *= 1048576;
+} elsif ($size_unit eq "g") {
+    $size *= 1073741824;
+}
+print "Generating size $size\n";
+
+my $file = "data-" . lc($size_arg);
+unlink($file);
+
+my $line = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()_+=-;";
+my $line_len = length($line);
+$line .= $line;
+
+open(FILE, ">$file") || die "Can't open file $file";
+my $count = 0;
+my $line_count = 0;
+while ($count < $size) {
+    my $offset = $line_count % $line_len;
+    my $num_to_print =
+        ($size - $count < $line_len) ? $size - $count : $line_len;
+    if ($num_to_print > 0) {
+        my $printable = substr($line, $offset, $num_to_print - 1);
+        print FILE $printable . "\n";
+        $count += $num_to_print;
+    }
+    ++$line_count;
+}
+close(FILE);
+
+exit(0);

--- a/test/simple/simpio.c
+++ b/test/simple/simpio.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2006-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <time.h>
+
+#include "src/class/pmix_object.h"
+#include "src/util/output.h"
+#include "src/util/printf.h"
+
+#define MAXCNT 1
+
+static volatile bool completed = false;
+static pmix_proc_t myproc;
+
+static void notification_fn(size_t evhdlr_registration_id,
+                            pmix_status_t status,
+                            const pmix_proc_t *source,
+                            pmix_info_t info[], size_t ninfo,
+                            pmix_info_t results[], size_t nresults,
+                            pmix_event_notification_cbfunc_fn_t cbfunc,
+                            void *cbdata)
+{
+    pmix_output(0, "Client %s:%d NOTIFIED with status %s", myproc.nspace, myproc.rank, PMIx_Error_string(status));
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+    }
+    completed = true;
+}
+
+static void errhandler_reg_callbk(pmix_status_t status,
+                                  size_t errhandler_ref,
+                                  void *cbdata)
+{
+    volatile bool *active = (volatile bool*)cbdata;
+
+    pmix_output(0, "Client: ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
+                status, (unsigned long)errhandler_ref);
+    *active = false;
+}
+
+#define SIMPIO_MSG_MAX   8192
+
+int main(int argc, char **argv)
+{
+    pmix_status_t rc;
+    volatile bool active;
+    int msgsize;
+    char msg[SIMPIO_MSG_MAX];
+    pmix_proc_t proc;
+    int cnt = 0;
+
+    /* init us */
+    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        exit(rc);
+    }
+    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+
+    /* register our errhandler */
+    active = true;
+    PMIx_Register_event_handler(NULL, 0, NULL, 0,
+                                notification_fn, errhandler_reg_callbk, (void*)&active);
+    while (active) {
+        usleep(10);
+    }
+
+    /* if we are rank=0, read our stdin */
+    if (0 == myproc.rank) {
+        while (0 < (msgsize = read(0, msg, SIMPIO_MSG_MAX))) {
+            cnt += msgsize;
+            fprintf(stderr, "Rank %d: read %d bytes\n", myproc.rank, cnt);
+        }
+    }
+
+    /* call fence to sync */
+    PMIX_PROC_CONSTRUCT(&proc);
+    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
+    proc.rank = PMIX_RANK_WILDCARD;
+    if (PMIX_SUCCESS != (rc = PMIx_Fence(&proc, 1, NULL, 0))) {
+        pmix_output(0, "Client ns %s rank %d PMIx_Fence failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    }
+
+    /* finalize us */
+    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
+    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
+                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    } else {
+        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+    }
+    fflush(stderr);
+    return(rc);
+}


### PR DESCRIPTION
Forward stdin upon request, reading from the proc's stdin until it is
closed and returns zero bytes. Forward read data to server for relay to
host for delivery. Add simple test plus script to make a data file.

Signed-off-by: Ralph Castain <rhc@pmix.org>