### PR TITLE
modex: optimization of rank identification size reduction

### DIFF
--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -6,6 +6,8 @@
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -13,6 +13,8 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -297,6 +299,7 @@ typedef struct {
     bool hybrid;                    // true if participating procs are from more than one nspace
     pmix_proc_t *pcs;               // copy of the original array of participants
     size_t   npcs;                  // number of procs in the array
+    pmix_list_t nslist;             // unique nspace list of participants
     pmix_lock_t lock;               // flag for waiting for completion
     bool def_complete;              // all local procs have been registered and the trk definition is complete
     pmix_list_t local_cbs;          // list of pmix_server_caddy_t for sending result to the local participants

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -109,7 +109,6 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank);
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                                 struct pmix_namespace_t *nspace,
-                                                pmix_list_t *cbs,
                                                 pmix_byte_object_t *bo);
 
 static pmix_status_t _dstore_store_nolock(pmix_common_dstore_ctx_t *ds_ctx,
@@ -2520,9 +2519,8 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank)
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t *ds_ctx,
-                                                            struct pmix_namespace_t *nspace,
-                                                            pmix_list_t *cbs,
-                                                            pmix_buffer_t *buf)
+                                                        struct pmix_namespace_t *nspace,
+                                                        pmix_buffer_t *buf)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_status_t rc1 = PMIX_SUCCESS;
@@ -2542,7 +2540,8 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
         return rc;
     }
 
-    rc = pmix_gds_base_store_modex(nspace, cbs, buf, (pmix_gds_base_store_modex_cb_fn_t)_dstor_store_modex_cb, ds_ctx);
+    rc = pmix_gds_base_store_modex(nspace,  buf, ds_ctx,
+                    (pmix_gds_base_store_modex_cb_fn_t)_dstor_store_modex_cb);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }
@@ -2561,7 +2560,6 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                                 struct pmix_namespace_t *nspace,
-                                                pmix_list_t *cbs,
                                                 pmix_byte_object_t *bo)
 {
     pmix_namespace_t *ns = (pmix_namespace_t*)nspace;

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -108,8 +108,8 @@ static inline pmix_peer_t * _client_peer(pmix_common_dstore_ctx_t *ds_ctx);
 static inline int _my_client(const char *nspace, pmix_rank_t rank);
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
-                                                struct pmix_namespace_t *nspace,
-                                                pmix_byte_object_t *bo);
+                                           pmix_proc_t *proc,
+                                           pmix_buffer_t *pbkt);
 
 static pmix_status_t _dstore_store_nolock(pmix_common_dstore_ctx_t *ds_ctx,
                                    ns_map_data_t *ns_map,
@@ -2561,14 +2561,11 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
 }
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
-                                                struct pmix_namespace_t *nspace,
-                                                pmix_byte_object_t *bo)
+                                           pmix_proc_t *proc,
+                                           pmix_buffer_t *pbkt)
 {
-    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
-    pmix_buffer_t pbkt;
-    pmix_proc_t proc;
     pmix_kval_t *kv;
     ns_map_data_t *ns_map;
     pmix_buffer_t tmp;
@@ -2576,7 +2573,7 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:dstore:store_modex for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        ns->nspace);
+                        proc->nspace);
 
     /* NOTE: THE BYTE OBJECT DELIVERED HERE WAS CONSTRUCTED
      * BY A SERVER, AND IS THEREFORE PACKED USING THE SERVER'S
@@ -2588,28 +2585,8 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
      * the rank followed by pmix_kval_t's. The list of callbacks
      * contains all local participants. */
 
-    /* setup the byte object for unpacking */
-    PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-    /* the next step unfortunately NULLs the byte object's
-     * entries, so we need to ensure we restore them! */
-    PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, bo->bytes, bo->size);
-    /* unload the proc that provided this data */
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, &proc, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        bo->bytes = pbkt.base_ptr;
-        bo->size = pbkt.bytes_used; // restore the incoming data
-        pbkt.base_ptr = NULL;
-        PMIX_DESTRUCT(&pbkt);
-        return rc;
-    }
     /* don't store blobs to the sm dstore from local clients */
-    if (_my_client(proc.nspace, proc.rank)) {
-        bo->bytes = pbkt.base_ptr;
-        bo->size = pbkt.bytes_used; // restore the incoming data
-        pbkt.base_ptr = NULL;
-        PMIX_DESTRUCT(&pbkt);
+    if (_my_client(proc->nspace, proc->rank)) {
         return PMIX_SUCCESS;
     }
 
@@ -2619,16 +2596,12 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
-        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proc, PMIX_REMOTE, kv);
+        PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, proc, PMIX_REMOTE, kv);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
-            bo->bytes = pbkt.base_ptr;
-            bo->size = pbkt.bytes_used; // restore the incoming data
-            pbkt.base_ptr = NULL;
-            PMIX_DESTRUCT(&pbkt);
             return rc;
         }
 
@@ -2642,7 +2615,7 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
         /* proceed to the next element */
         kv = PMIX_NEW(pmix_kval_t);
         cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
     }
 
     /* Release the kv that didn't received the value
@@ -2662,18 +2635,14 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
     PMIX_UNLOAD_BUFFER(&tmp, kv->value->data.bo.bytes, kv->value->data.bo.size);
 
     /* Get the namespace map element for the process "proc" */
-    if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, proc.nspace))) {
+    if (NULL == (ns_map = ds_ctx->session_map_search(ds_ctx, proc->nspace))) {
         rc = PMIX_ERROR;
         PMIX_ERROR_LOG(rc);
-        bo->bytes = pbkt.base_ptr;
-        bo->size = pbkt.bytes_used; // restore the incoming data
-        pbkt.base_ptr = NULL;
-        PMIX_DESTRUCT(&pbkt);
         return rc;
     }
 
     /* Store all keys at once */
-    rc = _dstore_store_nolock(ds_ctx, ns_map, proc.rank, kv);
+    rc = _dstore_store_nolock(ds_ctx, ns_map, proc->rank, kv);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }
@@ -2681,12 +2650,6 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
     /* Release all resources */
     PMIX_RELEASE(kv);
     PMIX_DESTRUCT(&tmp);
-
-    /* Reset the input buffer */
-    bo->bytes = pbkt.base_ptr;
-    bo->size = pbkt.bytes_used;
-    pbkt.base_ptr = NULL;
-    PMIX_DESTRUCT(&pbkt);
 
     return rc;
 }

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -2520,7 +2520,8 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank)
  * shall store it accordingly */
 PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t *ds_ctx,
                                                         struct pmix_namespace_t *nspace,
-                                                        pmix_buffer_t *buf)
+                                                        pmix_buffer_t *buf,
+                                                        void *cbdata)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_status_t rc1 = PMIX_SUCCESS;
@@ -2541,7 +2542,8 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
     }
 
     rc = pmix_gds_base_store_modex(nspace,  buf, ds_ctx,
-                    (pmix_gds_base_store_modex_cb_fn_t)_dstor_store_modex_cb);
+                    (pmix_gds_base_store_modex_cb_fn_t)_dstor_store_modex_cb,
+                    cbdata);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }

--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -75,5 +75,6 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_fetch(pmix_common_dstore_ctx_t *ds_c
                                 pmix_list_t *kvs);
 PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t *ds_ctx,
                                 struct pmix_namespace_t *nspace,
-                                pmix_buffer_t *buff);
+                                pmix_buffer_t *buff,
+                                void *cbdata);
 #endif

--- a/src/mca/common/dstore/dstore_common.h
+++ b/src/mca/common/dstore/dstore_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018      Mellanox Technologies, Inc.
+ * Copyright (c) 2018-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -75,6 +75,5 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_fetch(pmix_common_dstore_ctx_t *ds_c
                                 pmix_list_t *kvs);
 PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t *ds_ctx,
                                 struct pmix_namespace_t *nspace,
-                                pmix_list_t *cbs,
                                 pmix_buffer_t *buff);
 #endif

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -109,7 +109,8 @@ PMIX_EXPORT pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
 PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                                                     pmix_buffer_t * buff,
                                                     pmix_gds_base_ctx_t ctx,
-                                                    pmix_gds_base_store_modex_cb_fn_t cb_fn);
+                                                    pmix_gds_base_store_modex_cb_fn_t cb_fn,
+                                                    void *cbdata);
 
 END_C_DECLS
 

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -77,10 +79,9 @@ struct pmix_gds_globals_t {
 };
 typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 
-typedef void * pmix_gds_base_store_modex_cbdata_t;
-typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_store_modex_cbdata_t cbdata,
+typedef void * pmix_gds_base_ctx_t;
+typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_ctx_t ctx,
                                                            struct pmix_namespace_t *nspace,
-                                                           pmix_list_t *cbs,
                                                            pmix_byte_object_t *bo);
 
 PMIX_EXPORT extern pmix_gds_globals_t pmix_gds_globals;
@@ -106,10 +107,9 @@ PMIX_EXPORT pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
                                                    char ***env);
 
 PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
-                                                           pmix_list_t *cbs,
-                                                           pmix_buffer_t *xfer,
-                                                           pmix_gds_base_store_modex_cb_fn_t cb_fn,
-                                                           pmix_gds_base_store_modex_cbdata_t cbdata);
+                                                    pmix_buffer_t * buff,
+                                                    pmix_gds_base_ctx_t ctx,
+                                                    pmix_gds_base_store_modex_cb_fn_t cb_fn);
 
 END_C_DECLS
 

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -81,8 +81,8 @@ typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 
 typedef void * pmix_gds_base_ctx_t;
 typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_ctx_t ctx,
-                                                           struct pmix_namespace_t *nspace,
-                                                           pmix_byte_object_t *bo);
+                                                           pmix_proc_t *proc,
+                                                           pmix_buffer_t *pbkt);
 
 PMIX_EXPORT extern pmix_gds_globals_t pmix_gds_globals;
 

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
@@ -88,10 +88,9 @@ pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
 }
 
 pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
-                                               pmix_list_t *cbs,
-                                               pmix_buffer_t * buff,
-                                               pmix_gds_base_store_modex_cb_fn_t cb_fn,
-                                               pmix_gds_base_store_modex_cbdata_t cbdata)
+                                        pmix_buffer_t * buff,
+                                        pmix_gds_base_ctx_t ctx,
+                                        pmix_gds_base_store_modex_cb_fn_t cb_fn)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_namespace_t * ns = (pmix_namespace_t *)nspace;
@@ -149,7 +148,7 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
              * shared memory region, then the data may be available
              * right away - but the client still has to be notified
              * of its presence. */
-            rc = cb_fn(cbdata, (struct pmix_namespace_t *)ns, cbs, &bo2);
+            rc = cb_fn(ctx, (struct pmix_namespace_t *)ns, &bo2);
             if (PMIX_SUCCESS != rc) {
                 PMIX_DESTRUCT(&bkt);
                 goto error;

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -24,6 +24,7 @@
 #include "src/util/error.h"
 
 #include "src/mca/gds/base/base.h"
+#include "src/server/pmix_server_ops.h"
 
 
 char* pmix_gds_base_get_available_modules(void)
@@ -104,6 +105,9 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
     pmix_server_trkr_t *trk = (pmix_server_trkr_t*)cbdata;
     pmix_proc_t proc;
     pmix_buffer_t pbkt;
+    pmix_rank_t rel_rank;
+    pmix_nspace_caddy_t *nm;
+    bool found;
 
     /* Loop over the enclosed byte object envelopes and
      * store them in our GDS module */
@@ -158,8 +162,8 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
             PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, bo2.bytes, bo2.size);
             /* unload the proc that provided this data */
             cnt = 1;
-            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, &proc, &cnt,
-                               PMIX_PROC);
+            PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, &rel_rank, &cnt,
+                               PMIX_PROC_RANK);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);
                 pbkt.base_ptr = NULL;
@@ -167,6 +171,29 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                 PMIX_DESTRUCT(&bkt);
                 goto error;
             }
+            found = false;
+            /* calculate proc form the relative rank */
+            if (pmix_list_get_size(&trk->nslist) == 1) {
+                found = true;
+                nm = (pmix_nspace_caddy_t*)pmix_list_get_first(&trk->nslist);
+            } else {
+                PMIX_LIST_FOREACH(nm, &trk->nslist, pmix_nspace_caddy_t) {
+                    if (rel_rank < nm->ns->nprocs) {
+                        found = true;
+                        break;
+                    }
+                    rel_rank -= nm->ns->nprocs;
+                }
+            }
+            if (false == found) {
+                rc = PMIX_ERR_NOT_FOUND;
+                PMIX_ERROR_LOG(rc);
+                pbkt.base_ptr = NULL;
+                PMIX_DESTRUCT(&pbkt);
+                PMIX_DESTRUCT(&bkt);
+                goto error;
+            }
+            PMIX_PROC_LOAD(&proc, nm->ns->nspace, rel_rank);
 
             rc = cb_fn(ctx, &proc, &pbkt);
             if (PMIX_SUCCESS != rc) {

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -90,7 +90,8 @@ pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
 pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                                         pmix_buffer_t * buff,
                                         pmix_gds_base_ctx_t ctx,
-                                        pmix_gds_base_store_modex_cb_fn_t cb_fn)
+                                        pmix_gds_base_store_modex_cb_fn_t cb_fn,
+                                        void *cbdata)
 {
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_namespace_t * ns = (pmix_namespace_t *)nspace;
@@ -100,6 +101,7 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
     char byte;
     pmix_collect_t ctype;
     bool have_ctype = false;
+    pmix_server_trkr_t *trk = (pmix_server_trkr_t*)cbdata;
 
     /* Loop over the enclosed byte object envelopes and
      * store them in our GDS module */

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -119,10 +119,9 @@ static pmix_status_t ds12_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t ds12_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_list_t *cbs,
                                       pmix_buffer_t *buf)
 {
-    return pmix_common_dstor_store_modex(ds12_ctx, nspace, cbs, buf);
+    return pmix_common_dstor_store_modex(ds12_ctx, nspace, buf);
 }
 
 static pmix_status_t ds12_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/ds12/gds_ds12_base.c
+++ b/src/mca/gds/ds12/gds_ds12_base.c
@@ -119,9 +119,10 @@ static pmix_status_t ds12_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t ds12_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_buffer_t *buf)
+                                      pmix_buffer_t *buf,
+                                      void *cbdata)
 {
-    return pmix_common_dstor_store_modex(ds12_ctx, nspace, buf);
+    return pmix_common_dstor_store_modex(ds12_ctx, nspace, buf, cbdata);
 }
 
 static pmix_status_t ds12_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -107,9 +107,10 @@ static pmix_status_t ds21_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t ds21_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_buffer_t *buf)
+                                      pmix_buffer_t *buf,
+                                      void *cbdata)
 {
-    return pmix_common_dstor_store_modex(ds21_ctx, nspace, buf);
+    return pmix_common_dstor_store_modex(ds21_ctx, nspace, buf, cbdata);
 }
 
 static pmix_status_t ds21_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/ds21/gds_ds21_base.c
+++ b/src/mca/gds/ds21/gds_ds21_base.c
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -107,10 +107,9 @@ static pmix_status_t ds21_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t ds21_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_list_t *cbs,
                                       pmix_buffer_t *buf)
 {
-    return pmix_common_dstor_store_modex(ds21_ctx, nspace, cbs, buf);
+    return pmix_common_dstor_store_modex(ds21_ctx, nspace, buf);
 }
 
 static pmix_status_t ds21_fetch(const pmix_proc_t *proc,

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -234,16 +234,12 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  * ranks - a list of pmix_rank_info_t for the local ranks from this
  *         nspace - this is to be used to filter the cbs list
  *
- * cbs - a list of pmix_server_caddy_t's that contain the pmix_peer_t
- *       pointers of the local participants. The list can be used to
- *       identify those participants corresponding to this nspace
- *       (and thus, GDS component)
+ * cbdata - pointer to modex callback data
  *
  * bo - pointer to the byte object containing the data
  *
  */
 typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_namespace_t *ns,
-                                                               pmix_list_t *cbs,
                                                                pmix_buffer_t *buff);
 
 /**
@@ -253,17 +249,14 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_names
  *
  * n - pointer to the pmix_namespace_t this blob is to be stored for
  *
- * l - pointer to pmix_list_t containing pmix_server_caddy_t objects
- *     of the local_cbs of the collective tracker
- *
  * b - pointer to pmix_byte_object_t containing the data
  */
-#define PMIX_GDS_STORE_MODEX(r, n, l, b)  \
+#define PMIX_GDS_STORE_MODEX(r, n, b)  \
     do {                                                                    \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS STORE MODEX WITH %s",              \
                             __FILE__, __LINE__, (n)->compat.gds->name);     \
-        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, l, b); \
+        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, b); \
     } while (0)
 
 /**

--- a/src/mca/gds/gds.h
+++ b/src/mca/gds/gds.h
@@ -240,7 +240,8 @@ typedef pmix_status_t (*pmix_gds_base_module_store_fn_t)(const pmix_proc_t *proc
  *
  */
 typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_namespace_t *ns,
-                                                               pmix_buffer_t *buff);
+                                                               pmix_buffer_t *buff,
+                                                               void *cbdata);
 
 /**
  * define a convenience macro for storing modex byte objects
@@ -250,13 +251,15 @@ typedef pmix_status_t (*pmix_gds_base_module_store_modex_fn_t)(struct pmix_names
  * n - pointer to the pmix_namespace_t this blob is to be stored for
  *
  * b - pointer to pmix_byte_object_t containing the data
+ *
+ * t - pointer to the modex server tracker
  */
-#define PMIX_GDS_STORE_MODEX(r, n, b)  \
+#define PMIX_GDS_STORE_MODEX(r, n, b, t)  \
     do {                                                                    \
         pmix_output_verbose(1, pmix_gds_base_output,                        \
                             "[%s:%d] GDS STORE MODEX WITH %s",              \
                             __FILE__, __LINE__, (n)->compat.gds->name);     \
-        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, b); \
+        (r) = (n)->compat.gds->store_modex((struct pmix_namespace_t*)n, b, t); \
     } while (0)
 
 /**

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -3,7 +3,7 @@
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
- * Copyright (c) 2018      Mellanox Technologies, Inc.
+ * Copyright (c) 2018-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
  * $COPYRIGHT$
@@ -67,12 +67,10 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_kval_t *kv);
 
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
-                                      pmix_list_t *cbs,
                                       pmix_buffer_t *buff);
 
-static pmix_status_t _hash_store_modex(void * cbdata,
-                                       struct pmix_namespace_t *ns,
-                                       pmix_list_t *cbs,
+static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
+                                       struct pmix_namespace_t *nspace,
                                        pmix_byte_object_t *bo);
 
 static pmix_status_t hash_fetch(const pmix_proc_t *proc,
@@ -1190,14 +1188,13 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_list_t *cbs,
                                       pmix_buffer_t *buf) {
-    return pmix_gds_base_store_modex(nspace, cbs, buf, _hash_store_modex, NULL);
+    return pmix_gds_base_store_modex(nspace, buf, NULL,
+                                     _hash_store_modex);
 }
 
-static pmix_status_t _hash_store_modex(void * cbdata,
+static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        struct pmix_namespace_t *nspace,
-                                       pmix_list_t *cbs,
                                        pmix_byte_object_t *bo)
 {
     pmix_namespace_t *ns = (pmix_namespace_t*)nspace;

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -67,7 +67,8 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_kval_t *kv);
 
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
-                                      pmix_buffer_t *buff);
+                                      pmix_buffer_t *buff,
+                                      void *cbdata);
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        struct pmix_namespace_t *nspace,
@@ -1188,9 +1189,10 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
  * always contains data solely from remote procs, and we
  * shall store it accordingly */
 static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
-                                      pmix_buffer_t *buf) {
+                                      pmix_buffer_t *buf,
+                                      void *cbdata) {
     return pmix_gds_base_store_modex(nspace, buf, NULL,
-                                     _hash_store_modex);
+                                     _hash_store_modex, cbdata);
 }
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -71,8 +71,8 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
                                       void *cbdata);
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
-                                       struct pmix_namespace_t *nspace,
-                                       pmix_byte_object_t *bo);
+                                       pmix_proc_t *proc,
+                                       pmix_buffer_t *pbkt);
 
 static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                                 pmix_scope_t scope, bool copy,
@@ -1196,26 +1196,23 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
 }
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
-                                       struct pmix_namespace_t *nspace,
-                                       pmix_byte_object_t *bo)
+                                       pmix_proc_t *proc,
+                                       pmix_buffer_t *pbkt)
 {
-    pmix_namespace_t *ns = (pmix_namespace_t*)nspace;
     pmix_hash_trkr_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
     int32_t cnt;
-    pmix_buffer_t pbkt;
-    pmix_proc_t proc;
     pmix_kval_t *kv;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_modex for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        ns->nspace);
+                        proc->nspace);
 
     /* find the hash table for this nspace */
     trk = NULL;
     PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
-        if (0 == strcmp(ns->nspace, t->ns)) {
+        if (0 == strcmp(proc->nspace, t->ns)) {
             trk = t;
             break;
         }
@@ -1223,7 +1220,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
     if (NULL == trk) {
         /* create one */
         trk = PMIX_NEW(pmix_hash_trkr_t);
-        trk->ns = strdup(ns->nspace);
+        trk->ns = strdup(proc->nspace);
         pmix_list_append(&myhashes, &trk->super);
     }
 
@@ -1233,41 +1230,26 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
      * the rank followed by pmix_kval_t's. The list of callbacks
      * contains all local participants. */
 
-    /* setup the byte object for unpacking */
-    PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-    /* the next step unfortunately NULLs the byte object's
-     * entries, so we need to ensure we restore them! */
-    PMIX_LOAD_BUFFER(pmix_globals.mypeer, &pbkt, bo->bytes, bo->size);
-    /* unload the proc that provided this data */
-    cnt = 1;
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, &proc, &cnt, PMIX_PROC);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, proc, &cnt, PMIX_PROC);
     if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
-        bo->bytes = pbkt.base_ptr;
-        bo->size = pbkt.bytes_used; // restore the incoming data
-        pbkt.base_ptr = NULL;
-        PMIX_DESTRUCT(&pbkt);
         return rc;
     }
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc.rank, kv))) {
+        if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc->rank, kv))) {
             PMIX_ERROR_LOG(rc);
-            bo->bytes = pbkt.base_ptr;
-            bo->size = pbkt.bytes_used; // restore the incoming data
-            pbkt.base_ptr = NULL;
-            PMIX_DESTRUCT(&pbkt);
             return rc;
         }
         PMIX_RELEASE(kv);  // maintain accounting as the hash increments the ref count
         /* continue along */
         kv = PMIX_NEW(pmix_kval_t);
         cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &pbkt, kv, &cnt, PMIX_KVAL);
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
     }
     PMIX_RELEASE(kv);  // maintain accounting
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {
@@ -1275,10 +1257,6 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
     } else {
         rc = PMIX_SUCCESS;
     }
-    bo->bytes = pbkt.base_ptr;
-    bo->size = pbkt.bytes_used; // restore the incoming data
-    pbkt.base_ptr = NULL;
-    PMIX_DESTRUCT(&pbkt);
     return rc;
 }
 

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2338,7 +2338,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     }
 
     PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
-        PMIX_GDS_STORE_MODEX(rc, nptr->ns, &xfer);
+        PMIX_GDS_STORE_MODEX(rc, nptr->ns, &xfer, tracker);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             break;

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016-2018 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
@@ -2338,7 +2338,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     }
 
     PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
-        PMIX_GDS_STORE_MODEX(rc, nptr->ns, &tracker->local_cbs, &xfer);
+        PMIX_GDS_STORE_MODEX(rc, nptr->ns, &xfer);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             break;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -5,7 +5,7 @@
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014-2015 Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
- * Copyright (c) 2016-2017 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -3509,7 +3509,7 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
         }
 
         PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
-            PMIX_GDS_STORE_MODEX(ret, nptr->ns, &trk->local_cbs, &xfer);
+            PMIX_GDS_STORE_MODEX(ret, nptr->ns, &xfer);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 break;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -3509,7 +3509,7 @@ static void _grpcbfunc(int sd, short argc, void *cbdata)
         }
 
         PMIX_LIST_FOREACH(nptr, &nslist, pmix_nspace_caddy_t) {
-            PMIX_GDS_STORE_MODEX(ret, nptr->ns, &xfer);
+            PMIX_GDS_STORE_MODEX(ret, nptr->ns, &xfer, trk);
             if (PMIX_SUCCESS != ret) {
                 PMIX_ERROR_LOG(ret);
                 break;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -374,6 +374,7 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
     bool all_def;
     pmix_namespace_t *nptr, *ns;
     pmix_rank_info_t *info;
+    pmix_nspace_caddy_t *nm;
 
     pmix_output_verbose(5, pmix_server_globals.base_output,
                         "new_tracker called with %d procs", (int)nprocs);
@@ -436,6 +437,19 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
                                 procs[i].nspace);
             continue;
         }
+        /* check and add uniq ns into trk nslist */
+        PMIX_LIST_FOREACH(nm, &trk->nslist, pmix_nspace_caddy_t) {
+            if (0 == strcmp(nptr->nspace, nm->ns->nspace)) {
+                break;
+            }
+        }
+        if ((pmix_nspace_caddy_t*)pmix_list_get_end(&trk->nslist) == nm) {
+            nm = PMIX_NEW(pmix_nspace_caddy_t);
+            PMIX_RETAIN(nptr);
+            nm->ns = nptr;
+            pmix_list_append(&trk->nslist, &nm->super);
+        }
+
         /* have all the clients for this nspace been defined? */
         if (!nptr->all_registered) {
             /* nope, so no point in going further on this one - we'll
@@ -499,6 +513,9 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
     pmix_server_caddy_t *scd;
     pmix_proc_t pcs;
     pmix_status_t rc;
+    pmix_rank_t rel_rank;
+    pmix_nspace_caddy_t *nm;
+    bool found;
 
     PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
     /* mark the collection type so we can check on the
@@ -509,6 +526,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
     if (PMIX_COLLECT_YES == trk->collect_type) {
         pmix_output_verbose(2, pmix_server_globals.fence_output,
                             "fence - assembling data");
+
         PMIX_LIST_FOREACH(scd, &trk->local_cbs, pmix_server_caddy_t) {
             /* get any remote contribution - note that there
              * may not be a contribution */
@@ -520,10 +538,33 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
             cb.copy = true;
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS == rc) {
+                /* calculate the throughout rank */
+                rel_rank = 0;
+                found = false;
+                if (pmix_list_get_size(&trk->nslist) == 1) {
+                    found = true;
+                } else {
+                    PMIX_LIST_FOREACH(nm, &trk->nslist, pmix_nspace_caddy_t) {
+                        if (0 == strcmp(nm->ns->nspace, pcs.nspace)) {
+                            found = true;
+                            break;
+                        }
+                        rel_rank += nm->ns->nprocs;
+                    }
+                }
+                if (false == found) {
+                    rc = PMIX_ERR_NOT_FOUND;
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_DESTRUCT(&cb);
+                    PMIX_DESTRUCT(&pbkt);
+                    goto cleanup;
+                }
+                rel_rank += pcs.rank;
+
+                /* pack the relative rank */
                 PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-                /* pack the proc so we know the source */
                 PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &pbkt,
-                                 &pcs, 1, PMIX_PROC);
+                                 &rel_rank, 1, PMIX_PROC_RANK);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&cb);
@@ -4091,6 +4132,7 @@ static void tcon(pmix_server_trkr_t *t)
     t->pname.rank = PMIX_RANK_UNDEF;
     t->pcs = NULL;
     t->npcs = 0;
+    PMIX_CONSTRUCT(&t->nslist, pmix_list_t);
     PMIX_CONSTRUCT_LOCK(&t->lock);
     t->def_complete = false;
     PMIX_CONSTRUCT(&t->local_cbs, pmix_list_t);
@@ -4118,6 +4160,7 @@ static void tdes(pmix_server_trkr_t *t)
     if (NULL != t->info) {
         PMIX_INFO_FREE(t->info, t->ninfo);
     }
+    PMIX_DESTRUCT(&t->nslist);
 }
 PMIX_CLASS_INSTANCE(pmix_server_trkr_t,
                    pmix_list_item_t,


### PR DESCRIPTION
Packing the nspace string with each proc is redundant and not need for unpacker side. This commit avoids packing `nspace:rank` tuples into the modex blob, instead of that all ranks are renumbered throughtout procs involved in Modex and packed as integers.

Example procs paking:
```
{ "nspace1", 0} : 0
{ "nspace1", 1} : 1 => procs = { {0}, {1}, {2} }
{ "nspace2", 0} : 2
```

Refs https://github.com/pmix/pmix/issues/681