### PR TITLE
Avoid segfault in event notification

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -1020,16 +1020,6 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     if (!pmix_notify_check_range(&rngtrk, &proc)) {
                         continue;
                     }
-                    if (NULL != cd->targets) {
-                        /* track the number of targets we have left to notify */
-                        --cd->nleft;
-                        /* if the event was cached and this is the last one,
-                         * then evict this event from the cache */
-                        if (0 == cd->nleft) {
-                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
-                            PMIX_RELEASE(cd);
-                        }
-                    }
                     pmix_output_verbose(2, pmix_server_globals.event_output,
                                         "pmix_server: notifying client %s:%u on status %s",
                                         pr->peer->info->pname.nspace, pr->peer->info->pname.rank,
@@ -1086,6 +1076,17 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     PMIX_SERVER_QUEUE_REPLY(rc, pr->peer, 0, bfr);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_RELEASE(bfr);
+                    }
+                    if (NULL != cd->targets && 0 < cd->nleft) {
+                        /* track the number of targets we have left to notify */
+                        --cd->nleft;
+                        /* if the event was cached and this is the last one,
+                         * then evict this event from the cache */
+                        if (0 == cd->nleft) {
+                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
+                            holdcd = false;
+                            break;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Delay the checkout/release of the cached event object to ensure the
object remains valid until we are done with it.

Signed-off-by: Ralph Castain <rhc@pmix.org>