### PR TITLE
Fix access to uninitialized info

### DIFF
--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -15,7 +15,7 @@
  * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2018-2019 IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -1880,7 +1880,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         /* probably cannot send an error reply if we are out of memory */
         return;
     }
-    info->peerid = peer->index;
+    peer->info->peerid = peer->index;
 
     /* start the events for this tool */
     pmix_event_assign(&peer->recv_event, pmix_globals.evbase, peer->sd,


### PR DESCRIPTION
If this is a tool that we already established info for, then
info variable is not set locally, but is in the peer structure.

Signed-off-by: David Solt <dsolt@us.ibm.com>