### PR TITLE
Continue working on the Python bindings

### DIFF
--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -56,7 +56,7 @@ def harvest_constants(options, src, constants, definitions):
                     strconsts.append(tokens[0])
                     if len(tokens[0]) > strconstlen:
                         strconstlen = len(tokens[0])
-                elif "PMIX_ERR_" in value:
+                elif "PMIX_ERR_" in value or tokens[1].startswith("-"):
                     # numerical constant that looks just like a
                     # string constant - i.e., PMIX_ERR_FOO...1
                     # we output them in a separate section, but

--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -12,6 +12,20 @@ include "pmix_constants.pxi"
 # arrays into Python lists of objects
 
 
+def pmix_bool_convert(f):
+    if isinstance(f, str):
+        if f.startswith('t'):
+            return 1
+        elif f.startswith('f'):
+            return 0
+        else:
+            raise ValueError("Incorrect boolean value provided")
+    else:
+        return f
+
+
+pmix_int_types = (int, long)
+
 cdef class PMIxInfoArray:
     cdef pmix_info_t* array
     cdef size_t ninfo
@@ -26,6 +40,8 @@ cdef class PMIxInfoArray:
     def load(self, keyvals:dict):
         kvkeys = list(keyvals.keys())
         if len(kvkeys) > <int>self.ninfo:
+            # this should never happen except in development
+            # so raise an error to let them know
             raise IndexError()
         n = 0
         for key in kvkeys:
@@ -38,13 +54,62 @@ cdef class PMIxInfoArray:
             memset(self.array[n].key, 0, PMIX_MAX_KEYLEN+1)
             memcpy(self.array[n].key, pykeyptr, klen)
             # the value also needs to be transferred
-            if (isinstance(keyvals[key], str)):
+            if keyvals[key][1] == 'bool':
+                self.array[n].value.type = PMIX_BOOL
+                self.array[n].value.data.flag = pmix_bool_convert(keyvals[key][0])
+            elif keyvals[key][1] == 'byte':
+                self.array[n].value.type = PMIX_BYTE
+                self.array[n].value.data.byte = keyvals[key][0]
+            elif keyvals[key][1] == 'string':
                 self.array[n].value.type = PMIX_STRING
-                if isinstance(keyvals[key], str):
-                    pykey = keyvals[key].encode('ascii')
+                if isinstance(keyvals[key][0], str):
+                    pykey = keyvals[key][0].encode('ascii')
                 else:
-                    pykey = keyvals[key]
-                self.array[n].value.data.string = strdup(pykey)
+                    pykey = keyvals[key][0]
+                try:
+                    self.array[n].value.data.string = strdup(pykey)
+                except:
+                    raise ValueError("String value declared but non-string provided")
+            elif keyvals[key][1] == 'size':
+                self.array[n].value.type = PMIX_SIZE
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("size_t value declared but non-integer provided")
+                self.array[n].value.data.size = keyvals[key][0]
+            elif keyvals[key][1] == 'pid':
+                self.array[n].value.type = PMIX_PID
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("pid value declared but non-integer provided")
+                if keyvals[key][0] < 0:
+                    raise ValueError("pid value is negative")
+                self.array[n].value.data.pid = keyvals[key][0]
+            elif keyvals[key][1] == 'int':
+                self.array[n].value.type = PMIX_INT
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("integer value declared but non-integer provided")
+                self.array[n].value.data.integer = keyvals[key][0]
+            elif keyvals[key][1] == 'int8':
+                self.array[n].value.type = PMIX_INT8
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("int8 value declared but non-integer provided")
+                if keyvals[key][0] > 127 or keyvals[key][0] < -128:
+                    raise ValueError("int8 value is out of bounds")
+                self.array[n].value.data.int8 = keyvals[key][0]
+            elif keyvals[key][1] == 'int16':
+                self.array[n].value.type = PMIX_INT16
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("int16 value declared but non-integer provided")
+                if keyvals[key][0] > 32767 or keyvals[key][0] < -32768:
+                    raise ValueError("int16 value is out of bounds")
+                self.array[n].value.data.int16 = keyvals[key][0]
+            elif keyvals[key][1] == 'int32':
+                self.array[n].value.type = PMIX_INT32
+                if not isinstance(keyvals[key][0], pmix_int_types):
+                    raise TypeError("int32 value declared but non-integer provided")
+                if keyvals[key][0] > 2147483647 or keyvals[key][0] < -2147483648:
+                    raise ValueError("int16 value is out of bounds")
+                self.array[n].value.data.int32 = keyvals[key][0]
+            else:
+                print("UNRECOGNIZED INFO VALUE TYPE FOR KEY", key)
             n += 1
 
     def unload(self, infoarray:list):

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -61,20 +61,54 @@ cdef class PMIxClient:
 pmixservermodule = {}
 def setmodulefn(k, f):
     global pmixservermodule
-    permitted = ['clientconnected']
+    permitted = ['clientconnected', 'clientfinalized', 'abort',
+                 'fencenb', 'directmodex', 'publish', 'lookup', 'unpublish',
+                 'spawn', 'connect', 'disconnect', 'registerevents',
+                 'deregisterevents', 'listener', 'notify_event', 'query',
+                 'toolconnected', 'log', 'allocate', 'jobcontrol',
+                 'monitor', 'getcredential', 'validatecredential',
+                 'iofpull', 'pushstdin']
     if k not in permitted:
         raise KeyError
     if not k in pmixservermodule:
         print("SETTING MODULE FN FOR ", k)
         pmixservermodule[k] = f
 
-cdef class PMIxServer:
-    cdef pmix_proc_t myproc;
+cdef class PMIxServer(PMIxClient):
     cdef pmix_server_module_t myserver;
     def __init__(self):
         memset(self.myproc.nspace, 0, sizeof(self.myproc.nspace))
         self.myproc.rank = PMIX_RANK_UNDEF
-        self.myserver.client_connected = <pmix_server_client_connected_fn_t>client_connected
+        # v1.x interfaces
+        self.myserver.client_connected = <pmix_server_client_connected_fn_t>clientconnected
+        self.myserver.client_finalized = <pmix_server_client_finalized_fn_t>clientfinalized
+        self.myserver.abort = <pmix_server_abort_fn_t>clientaborted
+        self.myserver.fence_nb = <pmix_server_fencenb_fn_t>fencenb
+        self.myserver.direct_modex = <pmix_server_dmodex_req_fn_t>directmodex
+        self.myserver.publish = <pmix_server_publish_fn_t>publish
+        self.myserver.lookup = <pmix_server_lookup_fn_t>lookup
+        self.myserver.unpublish = <pmix_server_unpublish_fn_t>unpublish
+        self.myserver.spawn = <pmix_server_spawn_fn_t>spawn
+        self.myserver.connect = <pmix_server_connect_fn_t>connect
+        self.myserver.disconnect = <pmix_server_disconnect_fn_t>disconnect
+        self.myserver.register_events = <pmix_server_register_events_fn_t>registerevents
+        self.myserver.deregister_events = <pmix_server_deregister_events_fn_t>deregisterevents
+        # skip the listener entry as Python servers will never
+        # provide their own socket listener thread
+        #
+        # v2.x interfaces
+        self.myserver.notify_event = <pmix_server_notify_event_fn_t>notifyevent
+        self.myserver.query = <pmix_server_query_fn_t>query
+        self.myserver.tool_connected = <pmix_server_tool_connection_fn_t>toolconnected
+        self.myserver.log = <pmix_server_log_fn_t>log
+        self.myserver.allocate = <pmix_server_alloc_fn_t>allocate
+        self.myserver.job_control = <pmix_server_job_control_fn_t>jobcontrol
+        self.myserver.monitor = <pmix_server_monitor_fn_t>monitor
+        # v3.x interfaces
+        self.myserver.get_credential = <pmix_server_get_cred_fn_t>getcredential
+        self.myserver.validate_credential = <pmix_server_validate_cred_fn_t>validatecredential
+        self.myserver.iof_pull = <pmix_server_iof_fn_t>iofpull
+        self.myserver.push_stdin = <pmix_server_stdin_fn_t>pushstdin
 
     def initialized(self):
         return PMIx_Initialized()
@@ -93,17 +127,6 @@ cdef class PMIxServer:
     #            server module callback functions to provided
     #            implementations
     def init(self, keyvals, map):
-        cdef pmix_info_t *info = NULL
-        cdef size_t ninfo = 0
-        # Convert any provided dictionary to an array of pmix_info_t
-        if keyvals is not None and 0 < len(keyvals):
-            ninfo = len(keyvals)
-            info = <pmix_info_t *>malloc(ninfo * sizeof(pmix_info_t))
-            if not info:
-                raise MemoryError()
-         #   pyinfoarray_to_pmix(keyvals, info, ninfo)
-            for n in range(ninfo):
-                print("INFO[" + n + "] " + info[n].key + "\n")
         if map is None or 0 == len(map):
             print("SERVER REQUIRES AT LEAST ONE MODULE FUNCTION TO OPERATE")
             return PMIX_ERR_INIT
@@ -114,7 +137,21 @@ cdef class PMIxServer:
             except KeyError:
                 print("SERVER MODULE FUNCTION ", key, " IS NOT RECOGNIZED")
                 return PMIX_ERR_INIT
-        return PMIx_server_init(&self.myserver, NULL, 0)
+        # Convert any provided dictionary to an array of pmix_info_t
+        if keyvals is not None:
+            kvkeys = list(keyvals.keys())
+            klen = len(kvkeys)
+            try:
+                inarray = PMIxInfoArray(klen)
+            except:
+                print("Unable to create info array")
+                return -1
+            inarray.load(keyvals)
+            print(keyvals)
+            rc = PMIx_server_init(&self.myserver, inarray.array, klen)
+        else:
+            rc = PMIx_server_init(&self.myserver, NULL, 0)
+        return rc
 
     def finalize(self):
         return PMIx_server_finalize()
@@ -123,15 +160,565 @@ cdef class PMIxServer:
         # convert the args into the necessary C-arguments
         pass
 
-cdef void client_connected(pmix_proc_t *proc, void *server_object,
-                           pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+cdef int clientconnected(pmix_proc_t *proc, void *server_object,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
     keys = pmixservermodule.keys()
     if 'clientconnected' in keys:
     #    args = pmixproc_to_py(proc)
         args = {}
         rc = pmixservermodule['clientconnected'](args)
     else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int clientfinalized(pmix_proc_t *proc, void *server_object,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'clientfinalized' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['clientfinalized'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int clientaborted(const pmix_proc_t *proc, void *server_object,
+                       int status, const char msg[],
+                       pmix_proc_t procs[], size_t nprocs,
+                       pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'abort' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['abort'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
+                 const pmix_info_t info[], size_t ninfo,
+                 char *data, size_t ndata,
+                 pmix_modex_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'fencenb' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['fencenb'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int directmodex(const pmix_proc_t *proc,
+                     const pmix_info_t info[], size_t ninfo,
+                     pmix_modex_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'directmodex' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['directmodex'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int publish(const pmix_proc_t *proc,
+                 const pmix_info_t info[], size_t ninfo,
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'publish' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['publish'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int lookup(const pmix_proc_t *proc, char **keys,
+                const pmix_info_t info[], size_t ninfo,
+                pmix_lookup_cbfunc_t cbfunc, void *cbdata) with gil:
+    srvkeys = pmixservermodule.keys()
+    if 'lookup' in srvkeys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['lookup'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int unpublish(const pmix_proc_t *proc, char **keys,
+                   const pmix_info_t info[], size_t ninfo,
+                   pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    srvkeys = pmixservermodule.keys()
+    if 'unpublish' in srvkeys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['unpublish'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int spawn(const pmix_proc_t *proc,
+               const pmix_info_t job_info[], size_t ninfo,
+               const pmix_app_t apps[], size_t napps,
+               pmix_spawn_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'spawn' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['spawn'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int connect(const pmix_proc_t procs[], size_t nprocs,
+                 const pmix_info_t info[], size_t ninfo,
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'connect' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['connect'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int disconnect(const pmix_proc_t procs[], size_t nprocs,
+                    const pmix_info_t info[], size_t ninfo,
+                    pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'disconnect' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['disconnect'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int registerevents(pmix_status_t *codes, size_t ncodes,
+                        const pmix_info_t info[], size_t ninfo,
+                        pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'registerevents' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['registerevents'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int deregisterevents(pmix_status_t *codes, size_t ncodes,
+                          pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'deregisterevents' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['deregisterevents'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int notifyevent(pmix_status_t code,
+                     const pmix_proc_t *source,
+                     pmix_data_range_t range,
+                     pmix_info_t info[], size_t ninfo,
+                     pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'notifyevent' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['notifyevent'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int query(pmix_proc_t *proct,
+               pmix_query_t *queries, size_t nqueries,
+               pmix_info_cbfunc_t cbfunc,
+               void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'query' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['query'](args)
+    else:
+        return PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef void toolconnected(pmix_info_t *info, size_t ninfo,
+                        pmix_tool_connection_cbfunc_t cbfunc,
+                        void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'toolconnected' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['toolconnected'](args)
+    else:
         rc = PMIX_ERR_NOT_SUPPORTED
-    cbfunc(rc, cbdata)
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
     return
 
+cdef void log(const pmix_proc_t *client,
+              const pmix_info_t data[], size_t ndata,
+              const pmix_info_t directives[], size_t ndirs,
+              pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'log' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['log'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return
+
+cdef int allocate(const pmix_proc_t *client,
+                  pmix_alloc_directive_t directive,
+                  const pmix_info_t data[], size_t ndata,
+                  pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'allocate' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['allocate'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int jobcontrol(const pmix_proc_t *requestor,
+                    const pmix_proc_t targets[], size_t ntargets,
+                    const pmix_info_t directives[], size_t ndirs,
+                    pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'jobcontrol' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['jobcontrol'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int monitor(const pmix_proc_t *requestor,
+                 const pmix_info_t *monitor, pmix_status_t error,
+                 const pmix_info_t directives[], size_t ndirs,
+                 pmix_info_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'monitor' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['monitor'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int getcredential(const pmix_proc_t *proc,
+                       const pmix_info_t directives[], size_t ndirs,
+                       pmix_credential_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'getcredential' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['getcredential'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int validatecredential(const pmix_proc_t *proc,
+                            const pmix_byte_object_t *cred,
+                            const pmix_info_t directives[], size_t ndirs,
+                            pmix_validation_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'validatecredential' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['validatecredential'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int iofpull(const pmix_proc_t procs[], size_t nprocs,
+                 const pmix_info_t directives[], size_t ndirs,
+                 pmix_iof_channel_t channels,
+                 pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'iofpull' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['iofpull'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc
+
+cdef int pushstdin(const pmix_proc_t *source,
+                   const pmix_proc_t targets[], size_t ntargets,
+                   const pmix_info_t directives[], size_t ndirs,
+                   const pmix_byte_object_t *bo,
+                   pmix_op_cbfunc_t cbfunc, void *cbdata) with gil:
+    keys = pmixservermodule.keys()
+    if 'pushstdin' in keys:
+    #    args = pmixproc_to_py(proc)
+        args = {}
+        rc = pmixservermodule['pushstdin'](args)
+    else:
+        rc = PMIX_ERR_NOT_SUPPORTED
+    # we cannot execute a callback function here as
+    # that would cause PMIx to lockup. Likewise, the
+    # Python function we called can't do it as it
+    # would require them to call a C-function. So
+    # if they succeeded in processing this request,
+    # we return a PMIX_OPERATION_SUCCEEDED status
+    # that let's the underlying PMIx library know
+    # the situation so it can generate its own
+    # callback
+    if PMIX_SUCCESS == rc:
+        rc = PMIX_OPERATION_SUCCEEDED
+    return rc

--- a/bindings/python/server.py
+++ b/bindings/python/server.py
@@ -25,7 +25,7 @@ def main():
         print("FAILED TO CREATE SERVER")
         exit(1)
     print("Testing server version ", foo.get_version())
-    args = {'FOOBAR': 'VAR', 'BLAST': 7}
+    args = {'FOOBAR': ('VAR', 'string'), 'BLAST': (7, 'size')}
     map = {'clientconnected': clientconnected}
     my_result = foo.init(args, map)
     while True:


### PR DESCRIPTION
Fix detection of error constants - not all constants have PMIX_ERR in their name!
Begin implementation of server module functions by adding skeletons.
Deal with Python unhappiness with types such as "bool".

Signed-off-by: Ralph Castain <rhc@pmix.org>