### PR TITLE
modex: fix unnecessary proc unpacking for the gds:hash case

### DIFF
--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1230,11 +1230,6 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
      * the rank followed by pmix_kval_t's. The list of callbacks
      * contains all local participants. */
 
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, proc, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);


### PR DESCRIPTION
Signed-off-by: Boris Karasev <karasev.b@gmail.com>

Refs: https://github.com/pmix/pmix/pull/1125