### PR TITLE
 modex: reduce modex size by replacing key names with indexes

### DIFF
--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -109,6 +109,7 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank);
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                            pmix_proc_t *proc,
+                                           pmix_gds_modex_key_fmt_t key_fmt,
                                            char **kmap,
                                            pmix_buffer_t *pbkt);
 
@@ -2542,7 +2543,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
         return rc;
     }
 
-    rc = pmix_gds_base_store_modex(nspace,  buf, ds_ctx,
+    rc = pmix_gds_base_store_modex(nspace, buf, ds_ctx,
                     (pmix_gds_base_store_modex_cb_fn_t)_dstor_store_modex_cb,
                     cbdata);
     if (PMIX_SUCCESS != rc) {
@@ -2563,6 +2564,7 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                            pmix_proc_t *proc,
+                                           pmix_gds_modex_key_fmt_t key_fmt,
                                            char **kmap,
                                            pmix_buffer_t *pbkt)
 {
@@ -2596,7 +2598,7 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
 
     /* unpack the remaining values until we hit the end of the buffer */
     kv = PMIX_NEW(pmix_kval_t);
-    rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+    rc = pmix_gds_base_modex_unpack_kval(key_fmt, pbkt, kmap, kv);
 
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
@@ -2615,7 +2617,7 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
 
         /* proceed to the next element */
         kv = PMIX_NEW(pmix_kval_t);
-        rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+        rc = pmix_gds_base_modex_unpack_kval(key_fmt, pbkt, kmap, kv);
         if (PMIX_SUCCESS != rc) {
             break;
         }

--- a/src/mca/common/dstore/dstore_base.c
+++ b/src/mca/common/dstore/dstore_base.c
@@ -109,6 +109,7 @@ static inline int _my_client(const char *nspace, pmix_rank_t rank);
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                            pmix_proc_t *proc,
+                                           char **kmap,
                                            pmix_buffer_t *pbkt);
 
 static pmix_status_t _dstore_store_nolock(pmix_common_dstore_ctx_t *ds_ctx,
@@ -2562,10 +2563,10 @@ PMIX_EXPORT pmix_status_t pmix_common_dstor_store_modex(pmix_common_dstore_ctx_t
 
 static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
                                            pmix_proc_t *proc,
+                                           char **kmap,
                                            pmix_buffer_t *pbkt)
 {
     pmix_status_t rc = PMIX_SUCCESS;
-    int32_t cnt;
     pmix_kval_t *kv;
     ns_map_data_t *ns_map;
     pmix_buffer_t tmp;
@@ -2594,9 +2595,9 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
     PMIX_CONSTRUCT(&tmp, pmix_buffer_t);
 
     /* unpack the remaining values until we hit the end of the buffer */
-    cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
+    rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
         PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, proc, PMIX_REMOTE, kv);
@@ -2614,8 +2615,10 @@ static pmix_status_t _dstor_store_modex_cb(pmix_common_dstore_ctx_t *ds_ctx,
 
         /* proceed to the next element */
         kv = PMIX_NEW(pmix_kval_t);
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
+        rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+        if (PMIX_SUCCESS != rc) {
+            break;
+        }
     }
 
     /* Release the kv that didn't received the value

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -77,11 +77,29 @@ struct pmix_gds_globals_t {
   bool initialized;
   char *all_mods;
 };
+
+typedef enum {
+    PMIX_MODEX_KEY_INVALID = -1,
+    PMIX_MODEX_KEY_NATIVE_FMT,
+    PMIX_MODEX_KEY_KEYMAP_FMT,
+    PMIX_MODEX_KEY_MAX
+} pmix_gds_modex_key_fmt_t;
+
+/* define a modex blob info */
+typedef uint8_t pmix_gds_modex_blob_info_t;
+
+#define PMIX_GDS_COLLECT_BIT        0x0001
+#define PMIX_GDS_KEYMAP_BIT         0x0002
+
+#define PMIX_GDS_KEYMAP_IS_SET(byte)        (PMIX_GDS_KEYMAP_BIT & (byte))
+#define PMIX_GDS_COLLECT_IS_SET(byte)       (PMIX_GDS_COLLECT_BIT & (byte))
+
 typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 
 typedef void * pmix_gds_base_ctx_t;
 typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_ctx_t ctx,
                                                            pmix_proc_t *proc,
+                                                           pmix_gds_modex_key_fmt_t key_fmt,
                                                            char **kmap,
                                                            pmix_buffer_t *pbkt);
 
@@ -114,11 +132,13 @@ PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nsp
                                                     void *cbdata);
 
 PMIX_EXPORT
-pmix_status_t pmix_gds_base_modex_pack_kval(char ***kmap, pmix_buffer_t *buf,
+pmix_status_t pmix_gds_base_modex_pack_kval(pmix_gds_modex_key_fmt_t key_fmt,
+                                            pmix_buffer_t *buf, char ***kmap,
                                             pmix_kval_t *kv);
 
 PMIX_EXPORT
-pmix_status_t pmix_gds_base_modex_unpack_kval(char **kmap, pmix_buffer_t *buf,
+pmix_status_t pmix_gds_base_modex_unpack_kval(pmix_gds_modex_key_fmt_t key_fmt,
+                                              pmix_buffer_t *buf, char **kmap,
                                               pmix_kval_t *kv);
 END_C_DECLS
 

--- a/src/mca/gds/base/base.h
+++ b/src/mca/gds/base/base.h
@@ -82,6 +82,7 @@ typedef struct pmix_gds_globals_t pmix_gds_globals_t;
 typedef void * pmix_gds_base_ctx_t;
 typedef pmix_status_t (*pmix_gds_base_store_modex_cb_fn_t)(pmix_gds_base_ctx_t ctx,
                                                            pmix_proc_t *proc,
+                                                           char **kmap,
                                                            pmix_buffer_t *pbkt);
 
 PMIX_EXPORT extern pmix_gds_globals_t pmix_gds_globals;
@@ -112,6 +113,13 @@ PMIX_EXPORT pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nsp
                                                     pmix_gds_base_store_modex_cb_fn_t cb_fn,
                                                     void *cbdata);
 
+PMIX_EXPORT
+pmix_status_t pmix_gds_base_modex_pack_kval(char ***kmap, pmix_buffer_t *buf,
+                                            pmix_kval_t *kv);
+
+PMIX_EXPORT
+pmix_status_t pmix_gds_base_modex_unpack_kval(char **kmap, pmix_buffer_t *buf,
+                                              pmix_kval_t *kv);
 END_C_DECLS
 
 #endif

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -107,6 +107,8 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
     pmix_rank_t rel_rank;
     pmix_nspace_caddy_t *nm;
     bool found;
+    char  **kmap = NULL;
+    uint32_t kmap_size;
 
     /* Loop over the enclosed byte object envelopes and
      * store them in our GDS module */
@@ -127,8 +129,9 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
         }
         if (PMIX_SUCCESS != rc) {
             /* we have an error */
+            PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&bkt);
-            goto error;
+            goto exit;
         }
 
         // Check that this blob was accumulated with the same data collection setting
@@ -136,12 +139,51 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
             if (ctype != (pmix_collect_t)byte) {
                 rc = PMIX_ERR_INVALID_ARG;
                 pbkt.base_ptr = NULL;
-                goto error;
+                PMIX_ERROR_LOG(rc);
+                PMIX_DESTRUCT(&bkt);
+                goto exit;
             }
         }
         else {
             ctype = (pmix_collect_t)byte;
             have_ctype = true;
+        }
+
+        /* unpack the size of uniq keys names in the map */
+        cnt = 1;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
+                           &bkt, &kmap_size, &cnt, PMIX_UINT32);
+        if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
+            rc = PMIX_SUCCESS;
+            PMIX_DESTRUCT(&bkt);
+            break;
+        } else if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&bkt);
+            break;
+        }
+
+        /* init and unpack key names map, the position of the key name
+         * in the array determines the unique key index */
+        kmap = (char**)(calloc(kmap_size + 1, sizeof(char*)));
+        if (NULL == kmap) {
+            rc = PMIX_ERR_OUT_OF_RESOURCE;
+            PMIX_ERROR_LOG(rc);
+            goto exit;
+        }
+        cnt = kmap_size;
+        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, &bkt,
+                           kmap, &cnt, PMIX_STRING);
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&bkt);
+            goto exit;
+        }
+        if (pmix_argv_count(kmap) != (int)kmap_size) {
+            rc = PMIX_ERR_UNPACK_FAILURE;
+            PMIX_ERROR_LOG(rc);
+            PMIX_DESTRUCT(&bkt);
+            goto exit;
         }
 
         /* unpack the enclosed blobs from the various peers */
@@ -167,8 +209,7 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                 PMIX_ERROR_LOG(rc);
                 pbkt.base_ptr = NULL;
                 PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&bkt);
-                goto error;
+                break;
             }
             found = false;
             /* calculate proc form the relative rank */
@@ -189,17 +230,18 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                 PMIX_ERROR_LOG(rc);
                 pbkt.base_ptr = NULL;
                 PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&bkt);
-                goto error;
+                break;
             }
             PMIX_PROC_LOAD(&proc, nm->ns->nspace, rel_rank);
 
-            rc = cb_fn(ctx, &proc, &pbkt);
+            /* call a specific GDS function to storing
+             * part of the process data */
+            rc = cb_fn(ctx, &proc, kmap, &pbkt);
             if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
                 pbkt.base_ptr = NULL;
                 PMIX_DESTRUCT(&pbkt);
-                PMIX_DESTRUCT(&bkt);
-                goto error;
+                break;
             }
             pbkt.base_ptr = NULL;
             PMIX_DESTRUCT(&pbkt);
@@ -210,24 +252,104 @@ pmix_status_t pmix_gds_base_store_modex(struct pmix_namespace_t *nspace,
                     &bkt, &bo2, &cnt, PMIX_BYTE_OBJECT);
         }
         PMIX_DESTRUCT(&bkt);
+
         if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
             rc = PMIX_SUCCESS;
         } else if (PMIX_SUCCESS != rc) {
-            goto error;
+            PMIX_ERROR_LOG(rc);
+            goto exit;
         }
         /* unpack and process the next blob */
         cnt = 1;
         PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer,
                 buff, &bo, &cnt, PMIX_BYTE_OBJECT);
     }
+
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER == rc) {
         rc = PMIX_SUCCESS;
-    }
-
-error:
-    if (PMIX_SUCCESS != rc) {
+    } else if (PMIX_SUCCESS != rc) {
         PMIX_ERROR_LOG(rc);
     }
+exit:
+    pmix_argv_free(kmap);
+    return rc;
+}
 
+/*
+ * Pack the key-value as a tuple of key-name index and key-value.
+ * The key-name to store replaced by unique key-index that stored
+ * to the key-map. So the remote server can determine the key-name
+ * by the index from map that packed in modex as well.
+ *
+ * kmap - key values array by (char*), uses to store unique key
+ *        names string and determine their indexes
+ *
+ * buf - output buffer to pack key-values
+ *
+ * kv - pmix key-value pair
+ */
+pmix_status_t pmix_gds_base_modex_pack_kval(char ***kmap, pmix_buffer_t *buf,
+                                            pmix_kval_t *kv)
+{
+    uint32_t key_idx;
+    char *tmp;
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    tmp = strdup(kv->key);
+    rc = pmix_argv_append_unique_idx(&key_idx, kmap, tmp, 0);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_ERROR_LOG(rc);
+        free(tmp);
+        return rc;
+    }
+    /* pack key-index */
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, &key_idx, 1, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    /* pack key-value */
+    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, buf, kv->value, 1, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    return rc;
+}
+
+/*
+ * Unpack the key-value as a tuple of key-name index and key-value.
+ *
+ * kmap - key values array by (char*), uses to store unique key
+ *        names string and determine their indexes
+ *
+ * buf - input buffer to unpack key-values
+ *
+ * kv - unpacked pmix key-value pair
+ */
+pmix_status_t pmix_gds_base_modex_unpack_kval(char **kmap, pmix_buffer_t *buf,
+                                              pmix_kval_t *kv)
+{
+    int32_t cnt;
+    uint32_t key_idx;
+    pmix_status_t rc = PMIX_SUCCESS;
+
+    cnt = 1;
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buf, &key_idx, &cnt, PMIX_UINT32);
+    if (PMIX_SUCCESS != rc) {
+        return rc;
+    }
+    // sanity check
+    if (NULL == kmap[key_idx]) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        return rc;
+    }
+    kv->key = strdup(kmap[key_idx]);
+    cnt = 1;
+    PMIX_VALUE_CREATE(kv->value, 1);
+    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, buf, kv->value, &cnt, PMIX_VALUE);
+    if (PMIX_SUCCESS != rc) {
+        PMIX_VALUE_RELEASE(kv->value);
+        return rc;
+    }
     return rc;
 }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -72,6 +72,7 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        pmix_proc_t *proc,
+                                       char **kmap,
                                        pmix_buffer_t *pbkt);
 
 static pmix_status_t hash_fetch(const pmix_proc_t *proc,
@@ -1197,11 +1198,11 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        pmix_proc_t *proc,
+                                       char **kmap,
                                        pmix_buffer_t *pbkt)
 {
     pmix_hash_trkr_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
-    int32_t cnt;
     pmix_kval_t *kv;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
@@ -1231,9 +1232,9 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
      * contains all local participants. */
 
     /* unpack the remaining values until we hit the end of the buffer */
-    cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
+    rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
         if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc->rank, kv))) {
@@ -1243,8 +1244,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
         PMIX_RELEASE(kv);  // maintain accounting as the hash increments the ref count
         /* continue along */
         kv = PMIX_NEW(pmix_kval_t);
-        cnt = 1;
-        PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, kv, &cnt, PMIX_KVAL);
+        rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
     }
     PMIX_RELEASE(kv);  // maintain accounting
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -72,6 +72,7 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *ns,
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        pmix_proc_t *proc,
+                                       pmix_gds_modex_key_fmt_t key_fmt,
                                        char **kmap,
                                        pmix_buffer_t *pbkt);
 
@@ -1198,6 +1199,7 @@ static pmix_status_t hash_store_modex(struct pmix_namespace_t *nspace,
 
 static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        pmix_proc_t *proc,
+                                       pmix_gds_modex_key_fmt_t key_fmt,
                                        char **kmap,
                                        pmix_buffer_t *pbkt)
 {
@@ -1233,7 +1235,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
 
     /* unpack the remaining values until we hit the end of the buffer */
     kv = PMIX_NEW(pmix_kval_t);
-    rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+    rc = pmix_gds_base_modex_unpack_kval(key_fmt, pbkt, kmap, kv);
 
     while (PMIX_SUCCESS == rc) {
         /* store this in the hash table */
@@ -1244,7 +1246,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
         PMIX_RELEASE(kv);  // maintain accounting as the hash increments the ref count
         /* continue along */
         kv = PMIX_NEW(pmix_kval_t);
-        rc = pmix_gds_base_modex_unpack_kval(kmap, pbkt, kv);
+        rc = pmix_gds_base_modex_unpack_kval(key_fmt, pbkt, kmap, kv);
     }
     PMIX_RELEASE(kv);  // maintain accounting
     if (PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER != rc) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1230,11 +1230,6 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
      * the rank followed by pmix_kval_t's. The list of callbacks
      * contains all local participants. */
 
-    PMIX_BFROPS_UNPACK(rc, pmix_globals.mypeer, pbkt, proc, &cnt, PMIX_PROC);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-        return rc;
-    }
     /* unpack the remaining values until we hit the end of the buffer */
     cnt = 1;
     kv = PMIX_NEW(pmix_kval_t);

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -60,8 +60,24 @@
 #include "src/util/error.h"
 #include "src/util/output.h"
 #include "src/util/pmix_environ.h"
+#include "src/mca/gds/base/base.h"
 
 #include "pmix_server_ops.h"
+
+/* The rank_blob_t type to collect processes blobs,
+ * this list afterward will form a node modex blob. */
+typedef struct {
+    pmix_list_item_t super;
+    pmix_buffer_t *buf;
+} rank_blob_t;
+
+static void bufdes(rank_blob_t *p)
+{
+    PMIX_RELEASE(p);
+}
+static PMIX_CLASS_INSTANCE(rank_blob_t,
+                           pmix_list_item_t,
+                           NULL, bufdes);
 
 pmix_server_module_t pmix_host_server = {0};
 
@@ -506,7 +522,7 @@ static void fence_timeout(int sd, short args, void *cbdata)
 static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                                    pmix_buffer_t *buf)
 {
-    pmix_buffer_t bucket, pbkt;
+    pmix_buffer_t bucket, *pbkt = NULL;
     pmix_cb_t cb;
     pmix_kval_t *kv;
     pmix_byte_object_t bo;
@@ -517,6 +533,12 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
     pmix_rank_t rel_rank;
     pmix_nspace_caddy_t *nm;
     bool found;
+    pmix_list_t rank_blobs;
+    rank_blob_t *blob;
+    uint32_t kmap_size;
+    /* key names map, the position of the key name
+     * in the array determines the unique key index */
+    char **kmap = NULL;
 
     PMIX_CONSTRUCT(&bucket, pmix_buffer_t);
     /* mark the collection type so we can check on the
@@ -528,6 +550,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
         pmix_output_verbose(2, pmix_server_globals.fence_output,
                             "fence - assembling data");
 
+        PMIX_CONSTRUCT(&rank_blobs, pmix_list_t);
         PMIX_LIST_FOREACH(scd, &trk->local_cbs, pmix_server_caddy_t) {
             /* get any remote contribution - note that there
              * may not be a contribution */
@@ -557,47 +580,68 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                     rc = PMIX_ERR_NOT_FOUND;
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&cb);
-                    PMIX_DESTRUCT(&pbkt);
+                    PMIX_DESTRUCT(&rank_blobs);
                     goto cleanup;
                 }
                 rel_rank += pcs.rank;
 
                 /* pack the relative rank */
-                PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &pbkt,
+                pbkt = PMIX_NEW(pmix_buffer_t);
+                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, pbkt,
                                  &rel_rank, 1, PMIX_PROC_RANK);
                 if (PMIX_SUCCESS != rc) {
                     PMIX_ERROR_LOG(rc);
                     PMIX_DESTRUCT(&cb);
-                    PMIX_DESTRUCT(&pbkt);
+                    PMIX_DESTRUCT(&rank_blobs);
+                    PMIX_RELEASE(pbkt);
                     goto cleanup;
                 }
                 /* pack the returned kval's */
                 PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
-                    PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &pbkt, kv, 1, PMIX_KVAL);
-                    if (PMIX_SUCCESS != rc) {
+                    rc = pmix_gds_base_modex_pack_kval(&kmap, pbkt, kv);
+                    if (rc != PMIX_SUCCESS) {
                         PMIX_ERROR_LOG(rc);
                         PMIX_DESTRUCT(&cb);
-                        PMIX_DESTRUCT(&pbkt);
+                        PMIX_DESTRUCT(&rank_blobs);
+                        PMIX_RELEASE(pbkt);
                         goto cleanup;
                     }
                 }
-                /* extract the blob */
-                PMIX_UNLOAD_BUFFER(&pbkt, bo.bytes, bo.size);
-                PMIX_DESTRUCT(&pbkt);
-                /* pack the returned blob */
-                PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket,
-                                 &bo, 1, PMIX_BYTE_OBJECT);
-                PMIX_BYTE_OBJECT_DESTRUCT(&bo);
-                if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_DESTRUCT(&cb);
-                    goto cleanup;
-                }
+
+                /* add part of the process modex to the list */
+                blob = PMIX_NEW(rank_blob_t);
+                blob->buf = pbkt;
+                pmix_list_append(&rank_blobs, &blob->super);
+                pbkt = NULL;
             }
             PMIX_DESTRUCT(&cb);
         }
+        /* pack node part of modex to `bucket` */
+        /* pack the key names map for the remote server can
+         * use it to match key names by index */
+        kmap_size = pmix_argv_count(kmap);
+        if (0 < kmap_size) {
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket,
+                             &kmap_size, 1, PMIX_UINT32);
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket,
+                             kmap, kmap_size, PMIX_STRING);
+        }
+        /* pack the collected blobs of processes */
+        PMIX_LIST_FOREACH(blob, &rank_blobs, rank_blob_t) {
+            /* extract the blob */
+            PMIX_UNLOAD_BUFFER(blob->buf, bo.bytes, bo.size);
+            /* pack the returned blob */
+            PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &bucket,
+                             &bo, 1, PMIX_BYTE_OBJECT);
+            PMIX_BYTE_OBJECT_DESTRUCT(&bo); // releases the data
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto cleanup;
+            }
+        }
+        PMIX_DESTRUCT(&rank_blobs);
     }
+
     /* because the remote servers have to unpack things
      * in chunks, we have to pack the bucket as a single
      * byte object to allow remote unpack */
@@ -611,6 +655,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
 
   cleanup:
     PMIX_DESTRUCT(&bucket);
+    pmix_argv_free(kmap);
     return rc;
 }
 

--- a/src/util/argv.c
+++ b/src/util/argv.c
@@ -128,6 +128,38 @@ pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg)
     return PMIX_SUCCESS;
 }
 
+pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg, bool overwrite)
+{
+    int i;
+    pmix_status_t rc;
+
+    /* if the provided array is NULL, then the arg cannot be present,
+     * so just go ahead and append
+     */
+    if (NULL == *argv) {
+        goto add;
+    }
+    /* see if this arg is already present in the array */
+    for (i=0; NULL != (*argv)[i]; i++) {
+        if (0 == strcmp(arg, (*argv)[i])) {
+            /* already exists - are we authorized to overwrite? */
+            if (overwrite) {
+                free((*argv)[i]);
+                (*argv)[i] = strdup(arg);
+            }
+            *idx = i;
+            return PMIX_SUCCESS;
+        }
+    }
+add:
+    if (PMIX_SUCCESS != (rc = pmix_argv_append_nosize(argv, arg))) {
+        return rc;
+    }
+    *idx = pmix_argv_count(*argv)-1;
+
+    return PMIX_SUCCESS;
+}
+
 pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite)
 {
     int i;

--- a/src/util/argv.h
+++ b/src/util/argv.h
@@ -122,6 +122,24 @@ PMIX_EXPORT pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg
 PMIX_EXPORT pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite);
 
 /**
+ * Append to an argv-style array, but only if the provided argument
+ * doesn't already exist somewhere in the array. Ignore the size of the array.
+ * Defines the index of the found/added item in the array.
+ *
+ * @param idx Index the found/added item in the array.
+ * @param argv Pointer to an argv array.
+ * @param str Pointer to the string to append.
+ * @param bool Whether or not to overwrite a matching value if found
+ *
+ * @retval PMIX_SUCCESS On success
+ * @retval PMIX_ERROR On failure
+ *
+ * This function is identical to the pmix_argv_append_unique_nosize() function
+ * but it has an extra argument defining the index of the item in the array.
+ */
+PMIX_EXPORT pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg, bool overwrite);
+
+/**
    * Free a NULL-terminated argv array.
    *
    * @param argv Argv array to free.


### PR DESCRIPTION
This commit optimizes the modex size, avoiding duplication of key-names for key-value pairs. It generates the key-map with the unique names and packs key indexes instead of key-name strings. The key-map packaged separately and allows the remote side to determine the key-name by index when unpacking.