### PR TITLE
Add BuildRequires: libevent-devel to spec file

### DIFF
--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -204,6 +204,7 @@ Prefix: %{_prefix}
 Provides: pmix
 Provides: pmix = %{version}
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+BuildRequires: libevent-devel
 %if %{disable_auto_requires}
 AutoReq: no
 %endif


### PR DESCRIPTION
Since PMIx requires _libevent_ the spec file should ensure that _libevent-devel_ is installed.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>