### PR TITLE
gds/ds21: update the pointer of `seg_hdr` when segment re-attached

### DIFF
--- a/src/mca/gds/ds21/gds_ds21_lock_pthread.c
+++ b/src/mca/gds/ds21/gds_ds21_lock_pthread.c
@@ -234,6 +234,7 @@ pmix_status_t pmix_gds_ds21_lock_init(pmix_common_dstor_lock_ctx_t *ctx, const c
                 rc = PMIX_ERR_NOT_FOUND;
                 goto error;
             }
+            seg_hdr = (segment_hdr_t*)lock_item->seg_desc->seg_info.seg_base_addr;
         }
 
         lock_item->num_locks = seg_hdr->num_locks;


### PR DESCRIPTION
When re-attaching the lock-segment, the `seg_hdr` pointer was not
updated, which caused to reference on incorrect data and damage.

Signed-off-by: Boris Karasev <karasev.b@gmail.com>