### PR TITLE
Avoid segfault in event notification

### DIFF
--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -977,16 +977,6 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     if (!pmix_notify_check_range(&rngtrk, &proc)) {
                         continue;
                     }
-                    if (NULL != cd->targets) {
-                        /* track the number of targets we have left to notify */
-                        --cd->nleft;
-                        /* if the event was cached and this is the last one,
-                         * then evict this event from the cache */
-                        if (0 == cd->nleft) {
-                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
-                            PMIX_RELEASE(cd);
-                        }
-                    }
                     pmix_output_verbose(2, pmix_server_globals.event_output,
                                         "pmix_server: notifying client %s:%u on status %s",
                                         pr->peer->info->pname.nspace, pr->peer->info->pname.rank,
@@ -1043,6 +1033,17 @@ static void _notify_client_event(int sd, short args, void *cbdata)
                     PMIX_SERVER_QUEUE_REPLY(rc, pr->peer, 0, bfr);
                     if (PMIX_SUCCESS != rc) {
                         PMIX_RELEASE(bfr);
+                    }
+                    if (NULL != cd->targets && 0 < cd->nleft) {
+                        /* track the number of targets we have left to notify */
+                        --cd->nleft;
+                        /* if the event was cached and this is the last one,
+                         * then evict this event from the cache */
+                        if (0 == cd->nleft) {
+                            pmix_hotel_checkout(&pmix_globals.notifications, cd->room);
+                            holdcd = false;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -293,7 +293,7 @@ static pmix_status_t notify_server_of_event(pmix_status_t status,
             PMIX_RELEASE(cb);
             goto cleanup;
         }
-    } else {
+    } else if (NULL != cbfunc) {
         cbfunc(PMIX_SUCCESS, cbdata);
     }
 

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -280,7 +280,7 @@ typedef struct {
     pmix_list_item_t super;
     pmix_event_t ev;
     bool event_active;
-    bool lost_connection;           // tracker went thru lost connection procedure
+    bool host_called;               // tracker has been passed up to host
     bool local;                     // operation is strictly local
     char *id;                       // string identifier for the collective
     pmix_cmd_t type;

--- a/src/mca/ptl/base/ptl_base_sendrecv.c
+++ b/src/mca/ptl/base/ptl_base_sendrecv.c
@@ -55,13 +55,6 @@ static void _notify_complete(pmix_status_t status, void *cbdata)
     PMIX_RELEASE(chain);
 }
 
-static void _timeout(int sd, short args, void *cbdata)
-{
-    pmix_server_trkr_t *trk = (pmix_server_trkr_t*)cbdata;
-
-    PMIX_RELEASE(trk);
-}
-
 static void lcfn(pmix_status_t status, void *cbdata)
 {
     pmix_peer_t *peer = (pmix_peer_t*)cbdata;
@@ -76,7 +69,6 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
     pmix_ptl_posted_recv_t *rcv;
     pmix_buffer_t buf;
     pmix_ptl_hdr_t hdr;
-    struct timeval tv = {1200, 0};
     pmix_proc_t proc;
     pmix_status_t rc;
 
@@ -114,59 +106,60 @@ void pmix_ptl_base_lost_connection(pmix_peer_t *peer, pmix_status_t err)
                 /* remove it from the list */
                 pmix_list_remove_item(&trk->local_cbs, &rinfo->super);
                 PMIX_RELEASE(rinfo);
-                trk->lost_connection = true;  // mark that a peer's connection was lost
-                if (0 == pmix_list_get_size(&trk->local_cbs)) {
-                    /* this tracker is complete, so release it - there
-                     * is nobody waiting for a response */
-                    pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
-                    /* do NOT release the tracker here as the host may
-                     * have a copy they will return later. However, they
-                     * might never call back, so set a LONG timeout to
-                     * we avoid a memory leak if they don't */
-                    pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                           _timeout, trk);
-                    pmix_event_evtimer_add(&trk->ev, &tv);
-                    trk->event_active = true;
-                    break;
+                /* if the host has already been called for this tracker,
+                 * then do nothing here - just wait for the host to return
+                 * from the operation */
+                if (trk->host_called) {
+                    continue;
                 }
-                /* if there are other participants waiting for a response,
-                 * we need to let them know that this proc has disappeared
-                 * as otherwise the collective will never complete */
-                if (PMIX_FENCENB_CMD == trk->type) {
-                    if (NULL != trk->modexcbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
-                    }
-                } else if (PMIX_CONNECTNB_CMD == trk->type) {
-                    if (NULL != trk->op_cbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
-                    }
-                } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
-                    if (NULL != trk->op_cbfunc) {
-                        /* do NOT release the tracker here as the host may
-                         * have a copy they will return later. However, they
-                         * might never call back, so set a LONG timeout to
-                         * we avoid a memory leak if they don't */
-                        pmix_event_evtimer_set(pmix_globals.evbase, &trk->ev,
-                                               _timeout, trk);
-                        pmix_event_evtimer_add(&trk->ev, &tv);
-                        trk->event_active = true;
-                        trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                if (trk->def_complete && trk->nlocal == pmix_list_get_size(&trk->local_cbs)) {
+                    /* if this is a local-only collective, then resolve it now */
+                    if (trk->local) {
+                        /* everyone else has called in - we need to let them know
+                         * that this proc has disappeared
+                         * as otherwise the collective will never complete */
+                        if (PMIX_FENCENB_CMD == trk->type) {
+                            if (NULL != trk->modexcbfunc) {
+                                trk->modexcbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, NULL, 0, trk, NULL, NULL);
+                            }
+                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                            if (NULL != trk->op_cbfunc) {
+                                trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                            }
+                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                            if (NULL != trk->op_cbfunc) {
+                                trk->op_cbfunc(PMIX_ERR_LOST_CONNECTION_TO_CLIENT, trk);
+                            }
+                        }
+                    } else {
+                        /* if the host has not been called, then we need to see if
+                         * the collective is locally complete without this lost
+                         * participant. If so, then we need to pass the call
+                         * up to the host as otherwise the global collective will hang */
+                        if (PMIX_FENCENB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs,
+                                                           trk->info, trk->ninfo,
+                                                           NULL, 0, trk->modexcbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        } else if (PMIX_CONNECTNB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        } else if (PMIX_DISCONNECTNB_CMD == trk->type) {
+                            trk->host_called = true;
+                            rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, trk->op_cbfunc, trk);
+                            if (PMIX_SUCCESS != rc) {
+                                pmix_list_remove_item(&pmix_server_globals.collectives, &trk->super);
+                                PMIX_RELEASE(trk);
+                            }
+                        }
                     }
                 }
             }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2386,12 +2386,7 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     xfer.bytes_used = 0;
     PMIX_DESTRUCT(&xfer);
 
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
     PMIX_LIST_DESTRUCT(&nslist);
 
@@ -2644,12 +2639,7 @@ static void _cnct(int sd, short args, void *cbdata)
     if (NULL != nspaces) {
       pmix_argv_free(nspaces);
     }
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
 
     /* we are done */
@@ -2726,12 +2716,7 @@ static void _discnct(int sd, short args, void *cbdata)
   cleanup:
     /* cleanup the tracker -- the host RM is responsible for
      * telling us when to remove the nspace from our data */
-    if (!tracker->lost_connection) {
-        /* if this tracker has gone thru the "lost_connection" procedure,
-         * then it has already been removed from the list - otherwise,
-         * remove it now */
-        pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
-    }
+    pmix_list_remove_item(&pmix_server_globals.collectives, &tracker->super);
     PMIX_RELEASE(tracker);
 
     /* we are done */

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -725,6 +725,7 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
         /* now unload the blob and pass it upstairs */
         PMIX_UNLOAD_BUFFER(&bucket, data, sz);
         PMIX_DESTRUCT(&bucket);
+        trk->host_called = true;
         rc = pmix_host_server.fence_nb(trk->pcs, trk->npcs,
                                        trk->info, trk->ninfo,
                                        data, sz, trk->modexcbfunc, trk);
@@ -1377,6 +1378,7 @@ pmix_status_t pmix_server_disconnect(pmix_server_caddy_t *cd,
      * across all participants has been completed */
     if (trk->def_complete &&
         pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        trk->host_called = true;
         rc = pmix_host_server.disconnect(trk->pcs, trk->npcs, trk->info, trk->ninfo, cbfunc, trk);
         if (PMIX_SUCCESS != rc) {
             /* remove this contributor from the list - they will be notified
@@ -1526,6 +1528,7 @@ pmix_status_t pmix_server_connect(pmix_server_caddy_t *cd,
      * across all participants has been completed */
     if (trk->def_complete &&
         pmix_list_get_size(&trk->local_cbs) == trk->nlocal) {
+        trk->host_called = true;
         rc = pmix_host_server.connect(trk->pcs, trk->npcs, trk->info, trk->ninfo, cbfunc, trk);
         if (PMIX_SUCCESS != rc) {
             /* remove this contributor from the list - they will be notified
@@ -3318,7 +3321,7 @@ pmix_status_t pmix_server_iofstdin(pmix_peer_t *peer,
 static void tcon(pmix_server_trkr_t *t)
 {
     t->event_active = false;
-    t->lost_connection = false;
+    t->host_called = false;
     t->id = NULL;
     memset(t->pname.nspace, 0, PMIX_MAX_NSLEN+1);
     t->pname.rank = PMIX_RANK_UNDEF;


### PR DESCRIPTION
Delay the checkout/release of the cached event object to ensure the
object remains valid until we are done with it.

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit 17bb87f6016148ec8f874188822364500f0cf0d6)