### PR TITLE
Add BuildRequires: libevent-devel to spec file

### DIFF
--- a/contrib/pmix.spec
+++ b/contrib/pmix.spec
@@ -204,6 +204,7 @@ Prefix: %{_prefix}
 Provides: pmix
 Provides: pmix = %{version}
 BuildRoot: /var/tmp/%{name}-%{version}-%{release}-root
+BuildRequires: libevent-devel
 %if %{disable_auto_requires}
 AutoReq: no
 %endif


### PR DESCRIPTION
Since PMIx requires libevent the spec file should ensure that libevent-devel is installed.

Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>
(cherry picked from commit 7b829ea4d3d1a24dadfe0f5adecd0c9c0e087406)