### PR TITLE
server: plug a memory leak in _collect_data()

### DIFF
--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -573,7 +573,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                     int key_idx;
                     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
                         rc = pmix_argv_append_unique_idx(&key_idx, &kmap,
-                                                         strdup(kv->key), 0);
+                                                         kv->key, false);
                         if (pmix_value_array_get_size(key_count_array) <
                                 (size_t)(key_idx+1)) {
                             size_t new_size;


### PR DESCRIPTION
This was identified by Coverity with CID 337282

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>