### PR TITLE
util/argv: remove the useless 'overwrite' parameter

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -1,8 +1,8 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
- * Copyright (c) 2016-2018 Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2016-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
@@ -1977,17 +1977,16 @@ typedef struct pmix_regattr_t {
  *
  * @param argv Pointer to an argv array.
  * @param str Pointer to the string to append.
- * @param bool Whether or not to overwrite a matching value if found
  *
  * @retval PMIX_SUCCESS On success
  * @retval PMIX_ERROR On failure
  *
  * This function is identical to the pmix_argv_append_nosize() function
  * except that it only appends the provided argument if it does not already
- * exist in the provided array, or overwrites it if it is.
+ * exist in the provided array.
  */
-#define PMIX_ARGV_APPEND_UNIQUE(r, a, b, c) \
-    (r) = pmix_argv_append_unique_nosize(a, b, c)
+#define PMIX_ARGV_APPEND_UNIQUE(r, a, b) \
+    (r) = pmix_argv_append_unique_nosize(a, b)
 
 /* Free a NULL-terminated argv array.
  *

--- a/include/pmix_extend.h
+++ b/include/pmix_extend.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
  * Copyright (c) 2015      Artem Y. Polyakov <artpol84@gmail.com>.
  *                         All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Redistribution and use in source and binary forms, with or without
@@ -91,7 +91,7 @@ pmix_status_t pmix_argv_append_nosize(char ***argv, const char *arg);
 
 pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg);
 
-pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite);
+pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg);
 
 void pmix_argv_free(char **argv);
 

--- a/src/mca/base/pmix_mca_base_var.c
+++ b/src/mca/base/pmix_mca_base_var.c
@@ -14,8 +14,8 @@
  * Copyright (c) 2012-2015 Los Alamos National Security, LLC. All rights
  *                         reserved.
  * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -221,7 +221,7 @@ static char *append_filename_to_list(const char *filename)
 {
     int i, count;
 
-    (void) pmix_argv_append_unique_nosize(&pmix_mca_base_var_file_list, filename, false);
+    (void) pmix_argv_append_unique_nosize(&pmix_mca_base_var_file_list, filename);
 
     count = pmix_argv_count(pmix_mca_base_var_file_list);
 

--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -4,7 +4,7 @@
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
- * Copyright (c) 2018      Research Organization for Information Science
+ * Copyright (c) 2018-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  *
  * $COPYRIGHT$
@@ -306,7 +306,7 @@ pmix_status_t pmix_gds_base_modex_pack_kval(pmix_gds_modex_key_fmt_t key_fmt,
     pmix_status_t rc = PMIX_SUCCESS;
 
     if (PMIX_MODEX_KEY_KEYMAP_FMT == key_fmt) {
-        rc = pmix_argv_append_unique_idx((int*)&key_idx, kmap, kv->key, 0);
+        rc = pmix_argv_append_unique_idx((int*)&key_idx, kmap, kv->key);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             return rc;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -573,7 +573,7 @@ static pmix_status_t _collect_data(pmix_server_trkr_t *trk,
                     int key_idx;
                     PMIX_LIST_FOREACH(kv, &cb.kvs, pmix_kval_t) {
                         rc = pmix_argv_append_unique_idx(&key_idx, &kmap,
-                                                         kv->key, false);
+                                                         kv->key);
                         if (pmix_value_array_get_size(key_count_array) <
                                 (size_t)(key_idx+1)) {
                             size_t new_size;

--- a/src/util/argv.c
+++ b/src/util/argv.c
@@ -128,7 +128,7 @@ pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg)
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg, bool overwrite)
+pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg)
 {
     int i;
     pmix_status_t rc;
@@ -142,11 +142,7 @@ pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *ar
     /* see if this arg is already present in the array */
     for (i=0; NULL != (*argv)[i]; i++) {
         if (0 == strcmp(arg, (*argv)[i])) {
-            /* already exists - are we authorized to overwrite? */
-            if (overwrite) {
-                free((*argv)[i]);
-                (*argv)[i] = strdup(arg);
-            }
+            /* already exists */
             *idx = i;
             return PMIX_SUCCESS;
         }
@@ -160,7 +156,7 @@ add:
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite)
+pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg)
 {
     int i;
 
@@ -174,11 +170,7 @@ pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool
     /* see if this arg is already present in the array */
     for (i=0; NULL != (*argv)[i]; i++) {
         if (0 == strcmp(arg, (*argv)[i])) {
-            /* already exists - are we authorized to overwrite? */
-            if (overwrite) {
-                free((*argv)[i]);
-                (*argv)[i] = strdup(arg);
-            }
+            /* already exists */
             return PMIX_SUCCESS;
         }
     }

--- a/src/util/argv.h
+++ b/src/util/argv.h
@@ -15,8 +15,8 @@
  * Copyright (c) 2012      Los Alamos National Security, LLC. All rights reserved.
  * Copyright (c) 2015-2016 Intel, Inc.  All rights reserved.
  *
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -110,16 +110,15 @@ PMIX_EXPORT pmix_status_t pmix_argv_prepend_nosize(char ***argv, const char *arg
  *
  * @param argv Pointer to an argv array.
  * @param str Pointer to the string to append.
- * @param bool Whether or not to overwrite a matching value if found
  *
  * @retval PMIX_SUCCESS On success
  * @retval PMIX_ERROR On failure
  *
  * This function is identical to the pmix_argv_append_nosize() function
  * except that it only appends the provided argument if it does not already
- * exist in the provided array, or overwrites it if it is.
+ * exist in the provided array.
  */
-PMIX_EXPORT pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg, bool overwrite);
+PMIX_EXPORT pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const char *arg);
 
 /**
  * Append to an argv-style array, but only if the provided argument
@@ -129,7 +128,6 @@ PMIX_EXPORT pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const cha
  * @param idx Index the found/added item in the array.
  * @param argv Pointer to an argv array.
  * @param str Pointer to the string to append.
- * @param bool Whether or not to overwrite a matching value if found
  *
  * @retval PMIX_SUCCESS On success
  * @retval PMIX_ERROR On failure
@@ -137,7 +135,7 @@ PMIX_EXPORT pmix_status_t pmix_argv_append_unique_nosize(char ***argv, const cha
  * This function is identical to the pmix_argv_append_unique_nosize() function
  * but it has an extra argument defining the index of the item in the array.
  */
-PMIX_EXPORT pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg, bool overwrite);
+PMIX_EXPORT pmix_status_t pmix_argv_append_unique_idx(int *idx, char ***argv, const char *arg);
 
 /**
    * Free a NULL-terminated argv array.


### PR DESCRIPTION
Remove the unused and useless 'overwrite' parameter from
pmix_status_t pmix_argv_append_unique_idx() and
pmix_argv_append_unique_nosize()

In order to maintain backward compatibility, the 'overwrite' parameter
was not removed from the public PMIX_ARGV_APPEND_UNIQUE() macro
but is now ignored.

Note pmix_argv_append_unique_nosize() was updated accordingly in pmix_extend.h

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>