### PR TITLE
bfrops: fixed coverity: `Using uninitialized value "*tmpbuf"`

### DIFF
--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -225,7 +225,7 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
 #define PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, tmptype, tmpbfroptype)    \
     do {                                                                    \
         int32_t i;                                                          \
-        tmptype *tmpbuf = (tmptype*)malloc(sizeof(tmptype) * (*num_vals));  \
+        tmptype *tmpbuf = (tmptype*)calloc(*num_vals, sizeof(tmptype));     \
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmpbuf, num_vals, tmpbfroptype, reg_types);        \
         if (PMIX_ERR_UNKNOWN_DATA_TYPE != ret) {                            \
             for (i = 0 ; i < *num_vals ; ++i) {                             \


### PR DESCRIPTION
CID 1444191
CID 1444190
CID 1444187
CID 1444185
CID 1444180
CID 1444178
CID 1444175
CID 1444173

Signed-off-by: Boris Karasev <karasev.b@gmail.com>