### PR TITLE
psquash/flex128: Fix mismatch prototype

### DIFF
--- a/src/mca/psquash/flex128/psquash_flex128.c
+++ b/src/mca/psquash/flex128/psquash_flex128.c
@@ -217,11 +217,11 @@ static pmix_status_t flex128_decode_int(pmix_data_type_t type, void *src,
                                         size_t src_len, void *dest,
                                         size_t *dst_size);
 
-static size_t flex_pack_integer(uint64_t val,
+static size_t flex_pack_integer(size_t val,
                                 uint8_t out_buf[FLEX_BASE7_MAX_BUF_SIZE]);
 
 static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size,
-                                  uint64_t *out_val, size_t *out_val_size);
+                                  size_t *out_val, size_t *out_val_size);
 
 pmix_psquash_base_module_t pmix_flex128_module = {
     .name = "flex128",
@@ -279,7 +279,7 @@ static pmix_status_t flex128_decode_int(pmix_data_type_t type, void *src,
                                         size_t src_len, void *dest, size_t *dst_size)
 {
     pmix_status_t rc = PMIX_SUCCESS;
-    uint64_t tmp;
+    size_t tmp;
     size_t val_size, unpack_val_size;
 
     PMIX_SQUASH_TYPE_SIZEOF(rc, type, val_size);


### PR DESCRIPTION
The `master` branch will not build on my Mac because of the conflicting function signatures.

```
$$ gcc --version
Configured with: --prefix=/Library/Developer/CommandLineTools/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 10.0.0 (clang-1000.10.44.4)
Target: x86_64-apple-darwin18.2.0
Thread model: posix
InstalledDir: /Library/Developer/CommandLineTools/usr/bin
```

```
psquash_flex128.c:316:15: error: conflicting types for 'flex_pack_integer'
static size_t flex_pack_integer(size_t val,
              ^
psquash_flex128.c:220:15: note: previous declaration is here
static size_t flex_pack_integer(uint64_t val,
              ^
psquash_flex128.c:342:15: error: conflicting types for 'flex_unpack_integer'
static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size,
              ^
psquash_flex128.c:223:15: note: previous declaration is here
static size_t flex_unpack_integer(const uint8_t in_buf[], size_t buf_size,
              ^
```