### PR TITLE
Complete indirect launch under debugger

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -326,6 +326,8 @@ typedef uint32_t pmix_rank_t;
                                                                     //        specified operation
 #define PMIX_JOB_TERM_STATUS                "pmix.job.term.status"  // (pmix_status_t) status returned upon job termination
 #define PMIX_PROC_STATE_STATUS              "pmix.proc.state"       // (pmix_proc_state_t) process state
+#define PMIX_NOTIFY_LAUNCH                  "pmix.note.lnch"        // (bool) notify the requestor upon launch of the child job and return
+                                                                    //        its namespace in the event
 
 
 /* attributes used by host server to pass data to the server convenience library - the
@@ -888,6 +890,7 @@ typedef int pmix_status_t;
 #define PMIX_ERR_REPEAT_ATTR_REGISTRATION           -170
 #define PMIX_ERR_IOF_FAILURE                        -171
 #define PMIX_ERR_IOF_COMPLETE                       -172
+#define PMIX_LAUNCH_COMPLETE                        -173     // include nspace of the launched job with notification
 
 /* system failures */
 #define PMIX_ERR_NODE_DOWN                          -231

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -2303,6 +2303,12 @@ static void _mdxcbfunc(int sd, short argc, void *cbdata)
     /* if we get here, then there are processes waiting
      * for a response */
 
+    /* if the timer is active, clear it */
+    if (tracker->event_active) {
+        pmix_event_del(&tracker->ev);
+    }
+
+    /* pass the blobs being returned */
     PMIX_CONSTRUCT(&xfer, pmix_buffer_t);
     PMIX_CONSTRUCT(&nslist, pmix_list_t);
 

--- a/src/util/error.c
+++ b/src/util/error.c
@@ -273,6 +273,8 @@ PMIX_EXPORT const char* PMIx_Error_string(pmix_status_t errnum)
     case PMIX_ERR_TEMP_UNAVAILABLE:
         return "PMIX TEMPORARILY UNAVAILABLE";
 
+    case PMIX_LAUNCH_COMPLETE:
+        return "PMIX LAUNCH COMPLETE";
 
     case PMIX_MAX_ERR_CONSTANT:
         return "PMIX_ERR_WILDCARD";


### PR DESCRIPTION
Add attribute to request notification when launch completes

Add error constant for registering to get launch complete notifications

Delete timeout timer when op completes. There is still a timeout timer execution, so delete it when the modex completes

Add missing error constant string

Signed-off-by: Ralph Castain <rhc@pmix.org>