### PR TITLE
configury: fix git source tree is detected

### DIFF
--- a/config/distscript.sh
+++ b/config/distscript.sh
@@ -11,8 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2009-2015 Cisco Systems, Inc.  All rights reserved.
-# Copyright (c) 2015      Research Organization for Information Science
-#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2015-2019 Research Organization for Information Science
+#                         and Technology (RIST).  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved.
 # Copyright (c) 2017      Intel, Inc. All rights reserved.
@@ -42,7 +42,7 @@ fi
 # Otherwise, use what configure told us, at the cost of allowing one
 # or two corner cases in (but otherwise VPATH builds won't work).
 repo_rev=$PMIX_REPO_REV
-if test -d .git ; then
+if test -e .git ; then
     repo_rev=$(config/pmix_get_version.sh VERSION --repo-rev)
 fi
 

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -928,7 +928,7 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
 # Is this a developer copy?
 #
 
-if test -d .git; then
+if test -e $PMIX_TOP_SRCDIR/.git; then
     PMIX_DEVEL=1
     # check for Flex
     AC_PROG_LEX


### PR DESCRIPTION
test the existence of .git in the top source tree
in order to
 - support VPATH
 - support git worktrees (.git is a file and not
   a directory)

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>