### PR TITLE
configury: use PMIX_ENABLE_DLOPEN_SUPPORT instead of enable_dlopen

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -901,6 +901,10 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
                         [Whether build should attempt to use dlopen (or
                          similar) to dynamically load components.
                          (default: enabled)])])
+    AS_IF([test "$enable_dlopen" = "unknown"],
+          [AC_MSG_WARN([enable_dlopen variable has been overwritten by configure])
+           AC_MSG_WARN([This is an internal error that should be reported to PMIx developers])
+           AC_MSG_ERROR([Cannot continue])])
     AS_IF([test "$enable_dlopen" = "no"],
           [enable_mca_dso="no"
            enable_mca_static="yes"

--- a/src/mca/pdl/configure.m4
+++ b/src/mca/pdl/configure.m4
@@ -2,7 +2,7 @@ dnl -*- shell-script -*-
 dnl
 dnl Copyright (c) 2010-2015 Cisco Systems, Inc.  All rights reserved.
 dnl Copyright (c) 2016-2017 Intel, Inc. All rights reserved.
-dnl Copyright (c) 2016      Research Organization for Information Science
+dnl Copyright (c) 2016-2019 Research Organization for Information Science
 dnl                         and Technology (RIST). All rights reserved.
 dnl $COPYRIGHT$
 dnl
@@ -27,7 +27,7 @@ AC_DEFUN([MCA_pmix_pdl_CONFIG],[
     # (we still need to configure them all so that things like "make
     # dist" work", but we just want the MCA system to (artificially)
     # conclude that it can't build any of the components.
-    AS_IF([test "$enable_dlopen" = "no"],
+    AS_IF([test $PMIX_ENABLE_DLOPEN_SUPPORT -eq 0],
           [want_pdl=0], [want_pdl=1])
 
     MCA_CONFIGURE_FRAMEWORK([pdl], [$want_pdl])
@@ -35,7 +35,7 @@ AC_DEFUN([MCA_pmix_pdl_CONFIG],[
     # If we found no suitable static pdl component and dlopen support
     # was not specifically disabled, this is an error.
     AS_IF([test "$MCA_pmix_pdl_STATIC_COMPONENTS" = "" && \
-           test "$enable_dlopen" != "no"],
+           test $PMIX_ENABLE_DLOPEN_SUPPORT -eq 1],
           [AC_MSG_WARN([Did not find a suitable static pmix pdl component])
            AC_MSG_WARN([You might need to install libltld (and its headers) or])
            AC_MSG_WARN([specify --disable-dlopen to configure.])


### PR DESCRIPTION
The $enable_dlopen variable might be set to "unknown" by libtool.m4.
In order to cope with that, use $PMIX_ENABLE_DLOPEN_SUPPORT that is
set before $enable_dlopen might be overwritten.
Also add a test to make sure PMIX_ENABLE_DLOPEN_SUPPORT was not set
after $enable_dlopen was overwritten.

Refs. pmix/pmix#1121

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>