### PR TITLE
Resolve get of proc-specific job-level info from another nspace

### DIFF
--- a/examples/client.c
+++ b/examples/client.c
@@ -254,6 +254,9 @@ int main(int argc, char **argv)
         fprintf(stderr, "Client ns %s rank %d: PMIx_Commit failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
+    if (0 == myproc.rank) {
+        sleep(2);
+    }
 
     /* call fence to synchronize with our peers - instruct
      * the fence operation to collect and return all "put"

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -49,9 +49,7 @@ int main(int argc, char **argv)
     char nsp2[PMIX_MAX_NSLEN+1];
     pmix_app_t *app;
     char hostname[1024], dir[1024];
-    pmix_proc_t *peers;
-    size_t npeers, ntmp=0;
-    char *nodelist;
+    size_t ntmp=0;
 
     if (0 > gethostname(hostname, sizeof(hostname))) {
         exit(1);

--- a/examples/dynamic.c
+++ b/examples/dynamic.c
@@ -71,14 +71,14 @@ int main(int argc, char **argv)
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
 
-    /* get our universe size */
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
+    /* get our job size */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
+        fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace, myproc.rank, rc);
         goto done;
     }
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
-    fprintf(stderr, "Client %s:%d universe size %d\n", myproc.nspace, myproc.rank, nprocs);
+    fprintf(stderr, "Client %s:%d job size %d\n", myproc.nspace, myproc.rank, nprocs);
 
     /* call fence to sync */
     (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
@@ -103,13 +103,6 @@ int main(int argc, char **argv)
         app->env = (char**)malloc(2 * sizeof(char*));
         app->env[0] = strdup("PMIX_ENV_VALUE=3");
         app->env[1] = NULL;
-        PMIX_INFO_CREATE(app->info, 2);
-        (void)strncpy(app->info[0].key, "DARTH", PMIX_MAX_KEYLEN);
-        app->info[0].value.type = PMIX_INT8;
-        app->info[0].value.data.int8 = 12;
-        (void)strncpy(app->info[1].key, "VADER", PMIX_MAX_KEYLEN);
-        app->info[1].value.type = PMIX_DOUBLE;
-        app->info[1].value.data.dval = 12.34;
 
         fprintf(stderr, "Client ns %s rank %d: calling PMIx_Spawn\n", myproc.nspace, myproc.rank);
         if (PMIX_SUCCESS != (rc = PMIx_Spawn(NULL, 0, app, 1, nsp2))) {
@@ -122,65 +115,28 @@ int main(int argc, char **argv)
         val = NULL;
         (void)strncpy(proc.nspace, nsp2, PMIX_MAX_NSLEN);
         proc.rank = PMIX_RANK_WILDCARD;
-        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &val)) ||
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val)) ||
             NULL == val) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Get universe size failed: %d\n", myproc.nspace, myproc.rank, rc);
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get job size failed: %d\n", myproc.nspace, myproc.rank, rc);
             goto done;
         }
         ntmp = val->data.uint32;
         PMIX_VALUE_RELEASE(val);
-        fprintf(stderr, "Client %s:%d universe %s size %d\n", myproc.nspace, myproc.rank, nsp2, (int)ntmp);
-    }
+        fprintf(stderr, "Client %s:%d job %s size %d\n", myproc.nspace, myproc.rank, nsp2, (int)ntmp);
 
-    /* just cycle the connect/disconnect functions */
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Connect(&proc, 1, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Connect failed: %d\n", myproc.nspace, myproc.rank, rc);
-        goto done;
+        /* get a proc-specific value */
+        val = NULL;
+        (void)strncpy(proc.nspace, nsp2, PMIX_MAX_NSLEN);
+        proc.rank = 1;
+        if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_LOCAL_RANK, NULL, 0, &val)) ||
+            NULL == val) {
+            fprintf(stderr, "Client ns %s rank %d: PMIx_Get local rank failed: %d\n", myproc.nspace, myproc.rank, rc);
+            goto done;
+        }
+        ntmp = (int)val->data.uint16;
+        PMIX_VALUE_RELEASE(val);
+        fprintf(stderr, "Client %s:%d job %s local rank %d\n", myproc.nspace, myproc.rank, nsp2, (int)ntmp);
     }
-    fprintf(stderr, "Client ns %s rank %d: PMIx_Connect succeeded\n",
-            myproc.nspace, myproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Disconnect(&proc, 1, NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Disonnect failed: %d\n", myproc.nspace, myproc.rank, rc);
-        goto done;
-    }
-    fprintf(stderr, "Client ns %s rank %d: PMIx_Disconnect succeeded\n", myproc.nspace, myproc.rank);
-
-    /* finally, test the resolve functions */
-    if (0 == myproc.rank) {
-        if (PMIX_SUCCESS != (rc = PMIx_Resolve_peers(hostname, NULL, &peers, &npeers))) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers failed for nspace %s: %d\n", myproc.nspace, myproc.rank, nsp2, rc);
-            goto done;
-        }
-        if ((nprocs+ntmp) != npeers) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers returned incorrect npeers: %d vs %d\n", myproc.nspace, myproc.rank, (int)(nprocs+ntmp), (int)npeers);
-            goto done;
-        }
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers returned %d npeers\n", myproc.nspace, myproc.rank, (int)npeers);
-        if (PMIX_SUCCESS != (rc = PMIx_Resolve_nodes(nsp2, &nodelist))) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_nodes failed for nspace %s: %d\n", myproc.nspace, myproc.rank, nsp2, rc);
-            goto done;
-        }
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_nodes %s", myproc.nspace, myproc.rank, nodelist);
-    } else {
-        if (PMIX_SUCCESS != (rc = PMIx_Resolve_peers(hostname, myproc.nspace, &peers, &npeers))) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers failed for nspace %s: %d\n", myproc.nspace, myproc.rank, myproc.nspace, rc);
-            goto done;
-        }
-        if (nprocs != npeers) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers returned incorrect npeers: %d vs %d\n", myproc.nspace, myproc.rank, nprocs, (int)npeers);
-            goto done;
-        }
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_peers returned %d npeers\n", myproc.nspace, myproc.rank, (int)npeers);
-        if (PMIX_SUCCESS != (rc = PMIx_Resolve_nodes(myproc.nspace, &nodelist))) {
-            fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_nodes failed: %d\n", myproc.nspace, myproc.rank, rc);
-            goto done;
-        }
-        fprintf(stderr, "Client ns %s rank %d: PMIx_Resolve_nodes %s\n", myproc.nspace, myproc.rank, nodelist);
-    }
-    PMIX_PROC_FREE(peers, npeers);
-    free(nodelist);
 
  done:
     /* call fence to sync */

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -1381,8 +1381,8 @@ static void _dmodex_req(int sd, short args, void *cbdata)
     PMIX_ACQUIRE_OBJECT(cd);
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "DMODX LOOKING FOR %s:%d",
-                        cd->proc.nspace, cd->proc.rank);
+                        "DMODX LOOKING FOR %s",
+                        PMIX_NAME_PRINT(&cd->proc));
 
     /* this should be one of my clients, but a race condition
      * could cause this request to arrive prior to us having
@@ -1515,8 +1515,9 @@ PMIX_EXPORT pmix_status_t PMIx_server_dmodex_request(const pmix_proc_t *proc,
     }
 
     pmix_output_verbose(2, pmix_server_globals.base_output,
-                        "pmix:server dmodex request%s:%d",
-                        proc->nspace, proc->rank);
+                        "%s pmix:server dmodex request for proc %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_NAME_PRINT(proc));
 
     cd = PMIX_NEW(pmix_setup_caddy_t);
     pmix_strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -126,6 +126,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_dmdx_request_t *req;
     bool local;
     bool localonly = false;
+    bool diffnspace = false;
     struct timeval tv = {0, 0};
     pmix_buffer_t pbkt, pkt;
     pmix_byte_object_t bo;
@@ -133,7 +134,6 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     pmix_proc_t proc;
     char *data;
     size_t sz, n;
-    pmix_peer_t *peer;
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
                         "recvd GET");
@@ -196,6 +196,12 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             nptr = ns;
             break;
         }
+    }
+
+    /* check if the nspace of the requestor is different from
+     * the nspace of the target process */
+    if (PMIX_CHECK_NSPACE(nspace, cd->peer->info->pname.nspace)) {
+        diffnspace = true;
     }
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
@@ -294,10 +300,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         return PMIX_SUCCESS;
     }
 
-    /* this nspace is known, so we can process the request.
-     * if the rank is wildcard, then they are asking for the
-     * job-level info for this nspace - provide it */
-    if (PMIX_RANK_WILDCARD == rank) {
+    /* the target nspace is known, so we can process the request.
+     * if the rank is wildcard, or the nspace is different, then
+     * they are asking for the job-level info for this nspace - provide it */
+    if (PMIX_RANK_WILDCARD == rank || diffnspace) {
         /* see if we have the job-level info - we won't have it
          * if we have no local procs and haven't already asked
          * for it, so there is no guarantee we have it */
@@ -309,21 +315,32 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * can retrieve the info from that GDS. Otherwise,
          * we need to retrieve it from our own */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
-        peer = pmix_globals.mypeer;
         /* this data is for a local client, so give the gds the
          * option of returning a complete copy of the data,
          * or returning a pointer to local storage */
         cb.proc = &proc;
         cb.scope = PMIX_SCOPE_UNDEF;
         cb.copy = false;
-        PMIX_GDS_FETCH_KV(rc, peer, &cb);
+        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
         if (PMIX_SUCCESS != rc) {
             PMIX_DESTRUCT(&cb);
             return rc;
         }
+        /* if the requested rank is not WILDCARD, then retrieve the
+         * job-specific data for that rank - a scope of UNDEF
+         * will direct the GDS to provide it. Anything found will
+         * simply be added to the cb.kvs list */
+        if (PMIX_RANK_WILDCARD != rank) {
+            proc.rank = rank;
+            PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_DESTRUCT(&cb);
+                return rc;
+            }
+        }
         PMIX_CONSTRUCT(&pkt, pmix_buffer_t);
         /* assemble the provided data into a byte object */
-        PMIX_GDS_ASSEMB_KVS_REQ(rc, peer, &proc, &cb.kvs, &pkt, cd);
+        PMIX_GDS_ASSEMB_KVS_REQ(rc, pmix_globals.mypeer, &proc, &cb.kvs, &pkt, cd);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);
             PMIX_DESTRUCT(&cb);
@@ -333,7 +350,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         PMIX_DESTRUCT(&pkt);
         /* pack it into the payload */
         PMIX_CONSTRUCT(&pbkt, pmix_buffer_t);
-        PMIX_BFROPS_PACK(rc, cd->peer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &pbkt, &bo, 1, PMIX_BYTE_OBJECT);
         free(bo.bytes);
         if (PMIX_SUCCESS != rc) {
             PMIX_ERROR_LOG(rc);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -136,7 +136,8 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     size_t sz, n;
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
-                        "recvd GET");
+                        "%s recvd GET",
+                        PMIX_NAME_PRINT(&pmix_globals.myid));
 
     /* setup */
     memset(nspace, 0, sizeof(nspace));
@@ -200,7 +201,7 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
 
     /* check if the nspace of the requestor is different from
      * the nspace of the target process */
-    if (PMIX_CHECK_NSPACE(nspace, cd->peer->info->pname.nspace)) {
+    if (!PMIX_CHECK_NSPACE(nspace, cd->peer->info->pname.nspace)) {
         diffnspace = true;
     }
 


### PR DESCRIPTION
The current code focused solely on retrieving modex info for procs where
the "get" request goes up to the PMIx server as there was an assumption
that job-level information would already be available. However, when
asking for information on a different nspace, the job-level info may be
available at the server, but not to the requesting process.

We had a code path to return the job-level info from the other nspace,
but that didn't include the proc-specific portion of the job-level info.
In other words, we returned things like PMIX_UNIV_SIZE but did not
return PMIX_HOSTNAME for each proc in the other nspace. This change
fixes that gap.

As a note for the future: it would be simpler if we just provided a
"hook" to the other proc's shmem region. However, that would require
some additional code to avoid leaving a proc with a stale handle to the
other nspace's shmem region once that nspace goes away.

Fixes #1172 

Signed-off-by: Ralph Castain <rhc@pmix.org>