### PR TITLE
dist: Clean up handling of --disable-dlopen in dist process

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -47,6 +47,8 @@ Copyright (c) 2012      The University of Wisconsin-La Crosse. All rights
                         reserved.
 Copyright (c) 2013-2019 Intel, Inc. All rights reserved.
 Copyright (c) 2011-2014 NVIDIA Corporation.  All rights reserved.
+Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+                        reserved.
 
 $COPYRIGHT$
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,8 @@
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
 # Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -25,6 +27,7 @@ ACLOCAL_AMFLAGS = -I ./config
 
 SUBDIRS = config contrib include src etc bindings
 
+AM_DISTCHECK_CONFIGURE_FLAGS = --disable-dlopen
 
 headers =
 sources =

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -12,6 +12,8 @@
 #                         All rights reserved.
 # Copyright (c) 2008-2018 Cisco Systems, Inc.  All rights reserved
 # Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      Amazon.com, Inc. or its affiliates.  All Rights
+#                         reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -105,7 +107,7 @@ done
 if test "$LIBEVENT" != ""; then
     echo "*** Found \$LIBEVENT: $LIBEVENT"
     echo "*** Adding --with-libevent=$LIBEVENT to config_args"
-    config_args="--with-libevent=$LIBEVENT $config_args --disable-dlopen"
+    config_args="--with-libevent=$LIBEVENT $config_args"
 fi
 
 # if config_args isn't empty, then add that to the distcheck_flags
@@ -113,9 +115,9 @@ fi
 # distcheck").
 if test "$config_args" != ""; then
     echo "*** Adding to distcheck_flags: $config_args"
-    distcheck_flags="$distcheck_flags AM_DISTCHECK_CONFIGURE_FLAGS=\"--disable-dlopen $config_args\""
+    distcheck_flags="$distcheck_flags $config_args"
 else
-    distcheck_flags="$distcheck_flags AM_DISTCHECK_CONFIGURE_FLAGS=\"--disable-dlopen\""
+    distcheck_flags="$distcheck_flags"
 fi
 
 export DISTCHECK_CONFIGURE_FLAGS=$config_args

--- a/contrib/make_dist_tarball
+++ b/contrib/make_dist_tarball
@@ -110,16 +110,6 @@ if test "$LIBEVENT" != ""; then
     config_args="--with-libevent=$LIBEVENT $config_args"
 fi
 
-# if config_args isn't empty, then add that to the distcheck_flags
-# (because we'll assumedly need those to run configure under "make
-# distcheck").
-if test "$config_args" != ""; then
-    echo "*** Adding to distcheck_flags: $config_args"
-    distcheck_flags="$distcheck_flags $config_args"
-else
-    distcheck_flags="$distcheck_flags"
-fi
-
 export DISTCHECK_CONFIGURE_FLAGS=$config_args
 
 #


### PR DESCRIPTION
"make check" can only succeed if the plugins have been installed or
"--disable-dlopen" has been passed to configure.  The first can't
happen in "make distcheck", so force the second for all invocations
of "make distcheck" by setting AM_DISTCHECK_CONFIGURE_FLAGS in
Makefile.am.

Clean up the handling of AM_DISTCHECK_CONFIGURE_FLAGS and
DISTCHECK_CONFIGURE_FLAGS in make_dist_tarball.  First, with the
above fix, passing --disable-dlopen is no longer required.  Second,
users (and scripts) should set DISTCHECK_CONFIGURE_FLAGS, not
AM_DISTCHECK_CONFIGURE_FLAGS.  Automake will combine the two options
when running "make distcheck", so the right things will happen with
this configuration.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>