### PR TITLE
Remove the link-backs to libpmix

### DIFF
--- a/src/mca/bfrops/v12/Makefile.am
+++ b/src/mca/bfrops/v12/Makefile.am
@@ -51,7 +51,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v12_la_SOURCES = $(component_sources)
 mca_bfrops_v12_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v12_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v12_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v20/Makefile.am
+++ b/src/mca/bfrops/v20/Makefile.am
@@ -51,7 +51,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v20_la_SOURCES = $(component_sources)
 mca_bfrops_v20_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v20_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v20_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v21/Makefile.am
+++ b/src/mca/bfrops/v21/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v21_la_SOURCES = $(component_sources)
 mca_bfrops_v21_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v21_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v21_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v3/Makefile.am
+++ b/src/mca/bfrops/v3/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v3_la_SOURCES = $(component_sources)
 mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v3_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v3_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v4/Makefile.am
+++ b/src/mca/bfrops/v4/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v4_la_SOURCES = $(component_sources)
 mca_bfrops_v4_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v4_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v4_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds12/Makefile.am
+++ b/src/mca/gds/ds12/Makefile.am
@@ -64,7 +64,6 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds12_la_SOURCES = $(component_sources)
 mca_gds_ds12_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
-mca_gds_ds12_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds12_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds21/Makefile.am
+++ b/src/mca/gds/ds21/Makefile.am
@@ -56,7 +56,6 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds21_la_SOURCES = $(component_sources)
 mca_gds_ds21_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
-mca_gds_ds21_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds21_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/hash/Makefile.am
+++ b/src/mca/gds/hash/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_gds_hash_la_SOURCES = $(component_sources)
-mca_gds_hash_la_LIBADD = $(gds_hash_LIBS) $(top_builddir)/src/libpmix.la
+mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
 mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/pcompress/zlib/Makefile.am
+++ b/src/mca/pcompress/zlib/Makefile.am
@@ -34,7 +34,7 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_pcompress_zlib_la_SOURCES = $(sources)
 mca_pcompress_zlib_la_LDFLAGS = -module -avoid-version $(pcompress_zlib_LDFLAGS)
-mca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS) $(top_builddir)/src/libpmix.la
+mca_pcompress_zlib_la_LIBADD = $(pcompress_zlib_LIBS)
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_pcompress_zlib_la_SOURCES = $(sources)

--- a/src/mca/plog/default/Makefile.am
+++ b/src/mca/plog/default/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_default_la_SOURCES = $(sources)
 mca_plog_default_la_LDFLAGS = -module -avoid-version
-mca_plog_default_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_default_la_SOURCES =$(sources)

--- a/src/mca/plog/stdfd/Makefile.am
+++ b/src/mca/plog/stdfd/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_stdfd_la_SOURCES = $(sources)
 mca_plog_stdfd_la_LDFLAGS = -module -avoid-version
-mca_plog_stdfd_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_stdfd_la_SOURCES =$(sources)

--- a/src/mca/plog/syslog/Makefile.am
+++ b/src/mca/plog/syslog/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_syslog_la_SOURCES = $(sources)
 mca_plog_syslog_la_LDFLAGS = -module -avoid-version
-mca_plog_syslog_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_syslog_la_SOURCES =$(sources)

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_opa_la_SOURCES = $(component_sources)
-mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS) $(top_builddir)/src/libpmix.la
+mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS)
 mca_pnet_opa_la_LDFLAGS = -module -avoid-version $(pnet_opa_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/pnet/tcp/Makefile.am
+++ b/src/mca/pnet/tcp/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_tcp_la_SOURCES = $(component_sources)
-mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS) $(top_builddir)/src/libpmix.la
+mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
 mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/pnet/test/Makefile.am
+++ b/src/mca/pnet/test/Makefile.am
@@ -46,7 +46,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_test_la_SOURCES = $(component_sources)
 mca_pnet_test_la_LDFLAGS = -module -avoid-version
-mca_pnet_test_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pnet_test_la_SOURCES = $(lib_sources)

--- a/src/mca/preg/native/Makefile.am
+++ b/src/mca/preg/native/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_preg_native_la_SOURCES = $(component_sources)
 mca_preg_native_la_LDFLAGS = -module -avoid-version
-mca_preg_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_preg_native_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -46,7 +46,7 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_munge_la_SOURCES = $(component_sources)
 mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
-mca_psec_munge_la_LIBADD = $(psec_munge_LIBS) $(top_builddir)/src/libpmix.la
+mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_munge_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/native/Makefile.am
+++ b/src/mca/psec/native/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_native_la_SOURCES = $(component_sources)
 mca_psec_native_la_LDFLAGS = -module -avoid-version
-mca_psec_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_native_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/none/Makefile.am
+++ b/src/mca/psec/none/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_none_la_SOURCES = $(component_sources)
 mca_psec_none_la_LDFLAGS = -module -avoid-version
-mca_psec_none_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_none_la_SOURCES = $(lib_sources)

--- a/src/mca/psensor/file/Makefile.am
+++ b/src/mca/psensor/file/Makefile.am
@@ -31,7 +31,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_file_la_SOURCES = $(sources)
 mca_psensor_file_la_LDFLAGS = -module -avoid-version
-mca_psensor_file_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_file_la_SOURCES =$(sources)

--- a/src/mca/psensor/heartbeat/Makefile.am
+++ b/src/mca/psensor/heartbeat/Makefile.am
@@ -32,7 +32,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_heartbeat_la_SOURCES = $(sources)
 mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
-mca_psensor_heartbeat_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_heartbeat_la_SOURCES =$(sources)

--- a/src/mca/pshmem/mmap/Makefile.am
+++ b/src/mca/pshmem/mmap/Makefile.am
@@ -37,7 +37,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pshmem_mmap_la_SOURCES = $(component_sources)
 mca_pshmem_mmap_la_LDFLAGS = -module -avoid-version
-mca_pshmem_mmap_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pshmem_mmap_la_SOURCES = $(lib_sources)

--- a/src/mca/psquash/flex128/Makefile.am
+++ b/src/mca/psquash/flex128/Makefile.am
@@ -34,7 +34,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psquash_flex128_la_SOURCES = $(component_sources)
 mca_psquash_flex128_la_LDFLAGS = -module -avoid-version
-mca_psquash_flex128_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psquash_flex128_la_SOURCES = $(lib_sources)

--- a/src/mca/psquash/native/Makefile.am
+++ b/src/mca/psquash/native/Makefile.am
@@ -37,7 +37,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psquash_native_la_SOURCES = $(component_sources)
 mca_psquash_native_la_LDFLAGS = -module -avoid-version
-mca_psquash_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psquash_native_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/tcp/Makefile.am
+++ b/src/mca/ptl/tcp/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_tcp_la_SOURCES = $(component_sources)
 mca_ptl_tcp_la_LDFLAGS = -module -avoid-version
-mca_ptl_tcp_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_tcp_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/usock/Makefile.am
+++ b/src/mca/ptl/usock/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_usock_la_SOURCES = $(component_sources)
 mca_ptl_usock_la_LDFLAGS = -module -avoid-version
-mca_ptl_usock_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_usock_la_SOURCES = $(lib_sources)


### PR DESCRIPTION
They don't appear to be necessary for Python bindings support and are messing up OMPI

Signed-off-by: Ralph Castain <rhc@pmix.org>