### PR TITLE
Remove the link-backs to libpmix

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -936,7 +936,7 @@ AC_DEFUN([PMIX_DEFINE_ARGS],[
     AC_ARG_ENABLE([embedded-mode],
         [AC_HELP_STRING([--enable-embedded-mode],
                 [Using --enable-embedded-mode causes PMIx to skip a few configure checks and install nothing.  It should only be used when building PMIx within the scope of a larger package.])])
-    AS_IF([test ! -z "$enable_embedded_mode" && test "$enable_embedded_mode" = "yes"],
+    AS_IF([test "$enable_embedded_mode" = "yes"],
           [pmix_mode=embedded
            pmix_install_primary_headers=no
            AC_MSG_RESULT([yes])],
@@ -1178,6 +1178,19 @@ fi
 
 AM_CONDITIONAL([PMIX_INSTALL_BINARIES], [test $WANT_PMIX_BINARIES -eq 1])
 
+
+# see if they want to disable non-RTLD_GLOBAL dlopen
+AC_MSG_CHECKING([if want to support dlopen of non-global namespaces])
+AC_ARG_ENABLE([nonglobal-dlopen],
+              AC_HELP_STRING([--enable-nonglobal-dlopen],
+                             [enable non-global dlopen (default: enabled)]))
+if test "$enable_nonglobal_dlopen" == "no"; then
+    AC_MSG_RESULT([no])
+    pmix_need_libpmix=0
+else
+    AC_MSG_RESULT([yes])
+    pmix_need_libpmix=1
+fi
 ])dnl
 
 # This must be a standalone routine so that it can be called both by
@@ -1193,6 +1206,7 @@ AC_DEFUN([PMIX_DO_AM_CONDITIONALS],[
         AM_CONDITIONAL([WANT_PRIMARY_HEADERS], [test "x$pmix_install_primary_headers" = "xyes"])
         AM_CONDITIONAL(WANT_INSTALL_HEADERS, test "$WANT_INSTALL_HEADERS" = 1)
         AM_CONDITIONAL(WANT_PMI_BACKWARD, test "$WANT_PMI_BACKWARD" = 1)
+        AM_CONDITIONAL(NEED_LIBPMIX, [test "$pmix_need_libpmix" = "1"])
     ])
     pmix_did_am_conditionals=yes
 ])dnl

--- a/src/mca/bfrops/v12/Makefile.am
+++ b/src/mca/bfrops/v12/Makefile.am
@@ -51,7 +51,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v12_la_SOURCES = $(component_sources)
 mca_bfrops_v12_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v12_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v12_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v12/Makefile.am
+++ b/src/mca/bfrops/v12/Makefile.am
@@ -51,6 +51,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v12_la_SOURCES = $(component_sources)
 mca_bfrops_v12_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_bfrops_v12_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v12_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v20/Makefile.am
+++ b/src/mca/bfrops/v20/Makefile.am
@@ -51,6 +51,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v20_la_SOURCES = $(component_sources)
 mca_bfrops_v20_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_bfrops_v20_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v20_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v20/Makefile.am
+++ b/src/mca/bfrops/v20/Makefile.am
@@ -51,7 +51,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v20_la_SOURCES = $(component_sources)
 mca_bfrops_v20_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v20_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v20_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v21/Makefile.am
+++ b/src/mca/bfrops/v21/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v21_la_SOURCES = $(component_sources)
 mca_bfrops_v21_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_bfrops_v21_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v21_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v21/Makefile.am
+++ b/src/mca/bfrops/v21/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v21_la_SOURCES = $(component_sources)
 mca_bfrops_v21_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v21_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v21_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v3/Makefile.am
+++ b/src/mca/bfrops/v3/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v3_la_SOURCES = $(component_sources)
 mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_bfrops_v3_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v3_la_SOURCES = $(lib_sources)

--- a/src/mca/bfrops/v3/Makefile.am
+++ b/src/mca/bfrops/v3/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_bfrops_v3_la_SOURCES = $(component_sources)
 mca_bfrops_v3_la_LDFLAGS = -module -avoid-version
-mca_bfrops_v3_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_bfrops_v3_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds12/Makefile.am
+++ b/src/mca/gds/ds12/Makefile.am
@@ -64,6 +64,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds12_la_SOURCES = $(component_sources)
 mca_gds_ds12_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
+if NEED_LIBPMIX
+mca_gds_ds12_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds12_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds12/Makefile.am
+++ b/src/mca/gds/ds12/Makefile.am
@@ -64,7 +64,6 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds12_la_SOURCES = $(component_sources)
 mca_gds_ds12_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
-mca_gds_ds12_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds12_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds21/Makefile.am
+++ b/src/mca/gds/ds21/Makefile.am
@@ -56,7 +56,6 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds21_la_SOURCES = $(component_sources)
 mca_gds_ds21_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
-mca_gds_ds21_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds21_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/ds21/Makefile.am
+++ b/src/mca/gds/ds21/Makefile.am
@@ -56,6 +56,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_ds21_la_SOURCES = $(component_sources)
 mca_gds_ds21_la_LDFLAGS = -module -avoid-version \
     $(PMIX_TOP_BUILDDIR)/src/mca/common/dstore/libmca_common_dstore.la
+if NEED_LIBPMIX
+mca_gds_ds21_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_ds21_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/hash/Makefile.am
+++ b/src/mca/gds/hash/Makefile.am
@@ -49,6 +49,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_gds_hash_la_SOURCES = $(component_sources)
 mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
 mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
+if NEED_LIBPMIX
+mca_gds_hash_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_gds_hash_la_SOURCES = $(lib_sources)

--- a/src/mca/gds/hash/Makefile.am
+++ b/src/mca/gds/hash/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_gds_hash_la_SOURCES = $(component_sources)
-mca_gds_hash_la_LIBADD = $(gds_hash_LIBS) $(top_builddir)/src/libpmix.la
+mca_gds_hash_la_LIBADD = $(gds_hash_LIBS)
 mca_gds_hash_la_LDFLAGS = -module -avoid-version $(gds_hash_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/plog/default/Makefile.am
+++ b/src/mca/plog/default/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_default_la_SOURCES = $(sources)
 mca_plog_default_la_LDFLAGS = -module -avoid-version
-mca_plog_default_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_default_la_SOURCES =$(sources)

--- a/src/mca/plog/default/Makefile.am
+++ b/src/mca/plog/default/Makefile.am
@@ -40,6 +40,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_default_la_SOURCES = $(sources)
 mca_plog_default_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_plog_default_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_default_la_SOURCES =$(sources)

--- a/src/mca/plog/smtp/Makefile.am
+++ b/src/mca/plog/smtp/Makefile.am
@@ -46,6 +46,9 @@ mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_smtp_la_SOURCES = $(sources)
 mca_plog_smtp_la_LDFLAGS = -module -avoid-version $(plog_smtp_LDFLAGS)
 mca_plog_smtp_la_LIBADD = $(plog_smtp_LIBS) $(top_builddir)/src/libpmix.la
+if NEED_LIBPMIX
+mca_plog_smtp_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_smtp_la_SOURCES =$(sources)

--- a/src/mca/plog/stdfd/Makefile.am
+++ b/src/mca/plog/stdfd/Makefile.am
@@ -40,6 +40,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_stdfd_la_SOURCES = $(sources)
 mca_plog_stdfd_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_plog_stdfd_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_stdfd_la_SOURCES =$(sources)

--- a/src/mca/plog/stdfd/Makefile.am
+++ b/src/mca/plog/stdfd/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_stdfd_la_SOURCES = $(sources)
 mca_plog_stdfd_la_LDFLAGS = -module -avoid-version
-mca_plog_stdfd_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_stdfd_la_SOURCES =$(sources)

--- a/src/mca/plog/syslog/Makefile.am
+++ b/src/mca/plog/syslog/Makefile.am
@@ -40,6 +40,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_syslog_la_SOURCES = $(sources)
 mca_plog_syslog_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_plog_syslog_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_syslog_la_SOURCES =$(sources)

--- a/src/mca/plog/syslog/Makefile.am
+++ b/src/mca/plog/syslog/Makefile.am
@@ -40,7 +40,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_plog_syslog_la_SOURCES = $(sources)
 mca_plog_syslog_la_LDFLAGS = -module -avoid-version
-mca_plog_syslog_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_plog_syslog_la_SOURCES =$(sources)

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_opa_la_SOURCES = $(component_sources)
-mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS) $(top_builddir)/src/libpmix.la
+mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS)
 mca_pnet_opa_la_LDFLAGS = -module -avoid-version $(pnet_opa_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/pnet/opa/Makefile.am
+++ b/src/mca/pnet/opa/Makefile.am
@@ -49,6 +49,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_opa_la_SOURCES = $(component_sources)
 mca_pnet_opa_la_LIBADD = $(pnet_opa_LIBS)
 mca_pnet_opa_la_LDFLAGS = -module -avoid-version $(pnet_opa_LDFLAGS)
+if NEED_LIBPMIX
+mca_pnet_opa_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pnet_opa_la_SOURCES = $(lib_sources)

--- a/src/mca/pnet/tcp/Makefile.am
+++ b/src/mca/pnet/tcp/Makefile.am
@@ -47,7 +47,7 @@ endif
 mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_tcp_la_SOURCES = $(component_sources)
-mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS) $(top_builddir)/src/libpmix.la
+mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
 mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
 
 noinst_LTLIBRARIES = $(lib)

--- a/src/mca/pnet/tcp/Makefile.am
+++ b/src/mca/pnet/tcp/Makefile.am
@@ -49,6 +49,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_tcp_la_SOURCES = $(component_sources)
 mca_pnet_tcp_la_LIBADD = $(pnet_tcp_LIBS)
 mca_pnet_tcp_la_LDFLAGS = -module -avoid-version $(pnet_tcp_LDFLAGS)
+if NEED_LIBPMIX
+mca_pnet_tcp_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pnet_tcp_la_SOURCES = $(lib_sources)

--- a/src/mca/pnet/test/Makefile.am
+++ b/src/mca/pnet/test/Makefile.am
@@ -46,6 +46,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_test_la_SOURCES = $(component_sources)
 mca_pnet_test_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_pnet_test_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pnet_test_la_SOURCES = $(lib_sources)

--- a/src/mca/pnet/test/Makefile.am
+++ b/src/mca/pnet/test/Makefile.am
@@ -46,7 +46,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pnet_test_la_SOURCES = $(component_sources)
 mca_pnet_test_la_LDFLAGS = -module -avoid-version
-mca_pnet_test_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pnet_test_la_SOURCES = $(lib_sources)

--- a/src/mca/preg/native/Makefile.am
+++ b/src/mca/preg/native/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_preg_native_la_SOURCES = $(component_sources)
 mca_preg_native_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_preg_native_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_preg_native_la_SOURCES = $(lib_sources)

--- a/src/mca/preg/native/Makefile.am
+++ b/src/mca/preg/native/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_preg_native_la_SOURCES = $(component_sources)
 mca_preg_native_la_LDFLAGS = -module -avoid-version
-mca_preg_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_preg_native_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -46,7 +46,7 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_munge_la_SOURCES = $(component_sources)
 mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
-mca_psec_munge_la_LIBADD = $(psec_munge_LIBS) $(top_builddir)/src/libpmix.la
+mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_munge_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/munge/Makefile.am
+++ b/src/mca/psec/munge/Makefile.am
@@ -47,6 +47,9 @@ mcacomponent_LTLIBRARIES = $(component)
 mca_psec_munge_la_SOURCES = $(component_sources)
 mca_psec_munge_la_LDFLAGS = -module -avoid-version $(psec_munge_LDFLAGS)
 mca_psec_munge_la_LIBADD = $(psec_munge_LIBS)
+if NEED_LIBPMIX
+mca_psec_munge_la_LIBADD += $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_munge_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/native/Makefile.am
+++ b/src/mca/psec/native/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_native_la_SOURCES = $(component_sources)
 mca_psec_native_la_LDFLAGS = -module -avoid-version
-mca_psec_native_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_native_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/native/Makefile.am
+++ b/src/mca/psec/native/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_native_la_SOURCES = $(component_sources)
 mca_psec_native_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_psec_native_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_native_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/none/Makefile.am
+++ b/src/mca/psec/none/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_none_la_SOURCES = $(component_sources)
 mca_psec_none_la_LDFLAGS = -module -avoid-version
-mca_psec_none_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_none_la_SOURCES = $(lib_sources)

--- a/src/mca/psec/none/Makefile.am
+++ b/src/mca/psec/none/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_psec_none_la_SOURCES = $(component_sources)
 mca_psec_none_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_psec_none_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_psec_none_la_SOURCES = $(lib_sources)

--- a/src/mca/psensor/file/Makefile.am
+++ b/src/mca/psensor/file/Makefile.am
@@ -31,7 +31,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_file_la_SOURCES = $(sources)
 mca_psensor_file_la_LDFLAGS = -module -avoid-version
-mca_psensor_file_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_file_la_SOURCES =$(sources)

--- a/src/mca/psensor/file/Makefile.am
+++ b/src/mca/psensor/file/Makefile.am
@@ -31,6 +31,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_file_la_SOURCES = $(sources)
 mca_psensor_file_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_psensor_file_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_file_la_SOURCES =$(sources)

--- a/src/mca/psensor/heartbeat/Makefile.am
+++ b/src/mca/psensor/heartbeat/Makefile.am
@@ -32,6 +32,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_heartbeat_la_SOURCES = $(sources)
 mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_psensor_heartbeat_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_heartbeat_la_SOURCES =$(sources)

--- a/src/mca/psensor/heartbeat/Makefile.am
+++ b/src/mca/psensor/heartbeat/Makefile.am
@@ -32,7 +32,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component_install)
 mca_psensor_heartbeat_la_SOURCES = $(sources)
 mca_psensor_heartbeat_la_LDFLAGS = -module -avoid-version
-mca_psensor_heartbeat_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(component_noinst)
 libmca_psensor_heartbeat_la_SOURCES =$(sources)

--- a/src/mca/pshmem/mmap/Makefile.am
+++ b/src/mca/pshmem/mmap/Makefile.am
@@ -37,6 +37,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pshmem_mmap_la_SOURCES = $(component_sources)
 mca_pshmem_mmap_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_pshmem_mmap_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pshmem_mmap_la_SOURCES = $(lib_sources)

--- a/src/mca/pshmem/mmap/Makefile.am
+++ b/src/mca/pshmem/mmap/Makefile.am
@@ -37,7 +37,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_pshmem_mmap_la_SOURCES = $(component_sources)
 mca_pshmem_mmap_la_LDFLAGS = -module -avoid-version
-mca_pshmem_mmap_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_pshmem_mmap_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/tcp/Makefile.am
+++ b/src/mca/ptl/tcp/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_tcp_la_SOURCES = $(component_sources)
 mca_ptl_tcp_la_LDFLAGS = -module -avoid-version
-mca_ptl_tcp_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_tcp_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/tcp/Makefile.am
+++ b/src/mca/ptl/tcp/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_tcp_la_SOURCES = $(component_sources)
 mca_ptl_tcp_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_ptl_tcp_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_tcp_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/usock/Makefile.am
+++ b/src/mca/ptl/usock/Makefile.am
@@ -44,6 +44,9 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_usock_la_SOURCES = $(component_sources)
 mca_ptl_usock_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_ptl_usock_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_usock_la_SOURCES = $(lib_sources)

--- a/src/mca/ptl/usock/Makefile.am
+++ b/src/mca/ptl/usock/Makefile.am
@@ -44,7 +44,6 @@ mcacomponentdir = $(pmixlibdir)
 mcacomponent_LTLIBRARIES = $(component)
 mca_ptl_usock_la_SOURCES = $(component_sources)
 mca_ptl_usock_la_LDFLAGS = -module -avoid-version
-mca_ptl_usock_la_LIBADD = $(top_builddir)/src/libpmix.la
 
 noinst_LTLIBRARIES = $(lib)
 libmca_ptl_usock_la_SOURCES = $(lib_sources)


### PR DESCRIPTION
They don't appear to be necessary for Python bindings support and are messing up OMPI

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit f81caf453f846267b4dd9736a822c20cd1ff5eeb)