### PR TITLE
Default to disable-nonglobal-dlopen in embedded mode

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1245,6 +1245,12 @@ else
     AC_MSG_RESULT([yes])
     pmix_need_libpmix=1
 fi
+
+# if someone enables embedded mode but doesn't want to install the
+# devel headers, then default nonglobal-dlopen to false
+AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" && test "$WANT_INSTALL_HEADERS" = 0 && test "$pmix_need_libpmix" = "1"],
+      [$pmix_need_libpmix=0])
+
 ])dnl
 
 # This must be a standalone routine so that it can be called both by


### PR DESCRIPTION
Refs https://github.com/pmix/pmix/pull/1215#issuecomment-484771286

Signed-off-by: Ralph Castain <rhc@pmix.org>