### PR TITLE
configury: fix a typo in embedded mode handling

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -1248,8 +1248,8 @@ fi
 
 # if someone enables embedded mode but doesn't want to install the
 # devel headers, then default nonglobal-dlopen to false
-AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" && test "$WANT_INSTALL_HEADERS" = 0 && test "$pmix_need_libpmix" = "1"],
-      [$pmix_need_libpmix=0])
+AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" && test $WANT_INSTALL_HEADERS -eq 0 && test $pmix_need_libpmix -eq 1],
+      [pmix_need_libpmix=0])
 
 ])dnl
 


### PR DESCRIPTION
This fixes pmix/pmix@886724a5889f61608b07a5defcdbf64650d6aa7d
Refs. pmix/pmix#1215
Refs. pmix/pmix#1217

Also use 'test ... -eq ...' when comparing a variable with an integer.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>