### PR TITLE
 Enable launcher tools to fork/exec local children

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,5 @@
+ptl_tcp:
+    Rendezvous file - if not present, then treat it as name of file for contact info. If present, then treat as file containing contact info of server to be contacted
+
+pfexec_base:
+    wireup stdin of the parent proc for delivery to the child

--- a/TODO
+++ b/TODO
@@ -1,5 +1,0 @@
-ptl_tcp:
-    Rendezvous file - if not present, then treat it as name of file for contact info. If present, then treat as file containing contact info of server to be contacted
-
-pfexec_base:
-    wireup stdin of the parent proc for delivery to the child

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -418,7 +418,8 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                       ioLib.h sockLib.h hostLib.h limits.h \
                       sys/fcntl.h sys/statfs.h sys/statvfs.h \
                       netdb.h ucred.h zlib.h sys/auxv.h \
-                      sys/sysctl.h])
+                      sys/sysctl.h termio.h termios.h pty.h \
+                      libutil.h util.h grp.h sys/cdefs.h utmp.h stropts.h])
 
     AC_CHECK_HEADERS([sys/mount.h], [], [],
                      [AC_INCLUDES_DEFAULT
@@ -663,7 +664,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # -lrt might be needed for clock_gettime
     PMIX_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with
@@ -1250,6 +1251,24 @@ fi
 # devel headers, then default nonglobal-dlopen to false
 AS_IF([test -z "$enable_nonglobal_dlopen" && test "x$pmix_mode" = "xembedded" && test $WANT_INSTALL_HEADERS -eq 0 && test $pmix_need_libpmix -eq 1],
       [pmix_need_libpmix=0])
+
+#
+# Do we want PTY support?
+#
+
+AC_MSG_CHECKING([if want pty support])
+AC_ARG_ENABLE(pty-support,
+    AC_HELP_STRING([--enable-pty-support],
+                   [Enable/disable PTY support for STDIO forwarding.  (default: enabled)]))
+if test "$enable_pty_support" = "no" ; then
+    AC_MSG_RESULT([no])
+    PMIX_ENABLE_PTY_SUPPORT=0
+else
+    AC_MSG_RESULT([yes])
+    PMIX_ENABLE_PTY_SUPPORT=1
+fi
+AC_DEFINE_UNQUOTED([PMIX_ENABLE_PTY_SUPPORT], [$PMIX_ENABLE_PTY_SUPPORT],
+                   [Whether user wants PTY support or not])
 
 ])dnl
 

--- a/examples/tool.c
+++ b/examples/tool.c
@@ -31,6 +31,8 @@
 #include <pmix_tool.h>
 #include "examples.h"
 
+static pmix_proc_t myproc = {"UNDEF", PMIX_RANK_UNDEF};
+
 static void cbfunc(pmix_status_t status,
                    pmix_info_t *info, size_t ninfo,
                    void *cbdata,
@@ -61,10 +63,94 @@ static void cbfunc(pmix_status_t status,
     DEBUG_WAKEUP_THREAD(&mq->lock);
 }
 
+/* this is an event notification function that we explicitly request
+ * be called when the PMIX_ERR_JOB_TERMINATED notification is issued.
+ * We could catch it in the general event notification function and test
+ * the status to see if it was "job terminated", but it often is simpler
+ * to declare a use-specific notification callback point. In this case,
+ * we are asking to know whenever a job terminates, and we will then
+ * know we can exit */
+static void release_fn(size_t evhdlr_registration_id,
+                       pmix_status_t status,
+                       const pmix_proc_t *source,
+                       pmix_info_t info[], size_t ninfo,
+                       pmix_info_t results[], size_t nresults,
+                       pmix_event_notification_cbfunc_fn_t cbfunc,
+                       void *cbdata)
+{
+    myrel_t *lock;
+    bool found;
+    int exit_code;
+    size_t n;
+    pmix_proc_t *affected = NULL;
+
+    /* find the return object */
+    lock = NULL;
+    found = false;
+    for (n=0; n < ninfo; n++) {
+        if (0 == strncmp(info[n].key, PMIX_EVENT_RETURN_OBJECT, PMIX_MAX_KEYLEN)) {
+            lock = (myrel_t*)info[n].value.data.ptr;
+            /* not every RM will provide an exit code, but check if one was given */
+        } else if (0 == strncmp(info[n].key, PMIX_EXIT_CODE, PMIX_MAX_KEYLEN)) {
+            exit_code = info[n].value.data.integer;
+            found = true;
+        } else if (0 == strncmp(info[n].key, PMIX_EVENT_AFFECTED_PROC, PMIX_MAX_KEYLEN)) {
+            affected = info[n].value.data.proc;
+        }
+    }
+    /* if the object wasn't returned, then that is an error */
+    if (NULL == lock) {
+        fprintf(stderr, "LOCK WASN'T RETURNED IN RELEASE CALLBACK\n");
+        /* let the event handler progress */
+        if (NULL != cbfunc) {
+            cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
+        }
+        return;
+    }
+
+    fprintf(stderr, "TOOL NOTIFIED THAT ALL CHILD PROCS %s TERMINATED \n",
+            (NULL == affected) ? "NULL" : affected->nspace);
+    if (found) {
+        if (!lock->exit_code_given) {
+            lock->exit_code = exit_code;
+            lock->exit_code_given = true;
+        }
+    }
+    DEBUG_WAKEUP_THREAD(&lock->lock);
+
+    /* tell the event handler state machine that we are the last step */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_EVENT_ACTION_COMPLETE, NULL, 0, NULL, NULL, cbdata);
+    }
+    return;
+}
+
+/* event handler registration is done asynchronously because it
+ * may involve the PMIx server registering with the host RM for
+ * external events. So we provide a callback function that returns
+ * the status of the request (success or an error), plus a numerical index
+ * to the registered event. The index is used later on to deregister
+ * an event handler - if we don't explicitly deregister it, then the
+ * PMIx server will do so when it see us exit */
+static void evhandler_reg_callbk(pmix_status_t status,
+                                 size_t evhandler_ref,
+                                 void *cbdata)
+{
+    mylock_t *lock = (mylock_t*)cbdata;
+
+    if (PMIX_SUCCESS != status) {
+        fprintf(stderr, "Client %s:%d EVENT HANDLER REGISTRATION FAILED WITH STATUS %d, ref=%lu\n",
+                   myproc.nspace, myproc.rank, status, (unsigned long)evhandler_ref);
+    }
+    lock->status = status;
+    DEBUG_WAKEUP_THREAD(lock);
+}
+
+
 int main(int argc, char **argv)
 {
     pmix_status_t rc;
-    pmix_proc_t myproc;
+    pmix_proc_t proc;
     pmix_query_t *query;
     size_t nq, ninfo = 0, n, m;
     myquery_data_t mydata;
@@ -75,6 +161,12 @@ int main(int argc, char **argv)
     pmix_data_array_t *darray, *dptr;
     bool geturi = false;
     char hostname[1024];
+    char *spawn = NULL;
+    pmix_app_t app;
+    pmix_nspace_t child;
+    pmix_status_t code = PMIX_ERR_JOB_TERMINATED;
+    myrel_t myrel;
+    mylock_t mylock;
 
     gethostname(hostname, 1024);
     for (n=1; n < (size_t)argc; n++) {
@@ -84,24 +176,43 @@ int main(int argc, char **argv)
                 exit(1);
             }
             server_uri = argv[n+1];
+            ++n;
+            ++ninfo;
         } else if (0 == strcmp("-nspace", argv[n]) || 0 == strcmp("--nspace", argv[n])) {
             if (NULL == argv[n+1]) {
                 fprintf(stderr, "Must provide nspace argument to %s option\n", argv[n]);
                 exit(1);
             }
             nspace = argv[n+1];
+            ++n;
         } else if (0 == strcmp("-uri", argv[n]) || 0 == strcmp("--uri", argv[n])) {
             /* retrieve the PMIx server's uri from the indicated node */
             nodename = argv[n+1];
             geturi = true;
+            ++n;
+        } else if (0 == strcmp("-spawn", argv[n]) || 0 == strcmp("--spawn", argv[n])) {
+            if (NULL == argv[n+1]) {
+                fprintf(stderr, "Must provide executable argument to %s option\n", argv[n]);
+                exit(1);
+            }
+            spawn = argv[n+1];
+            ++n;
+            ninfo += 2;
         }
     }
 
+    PMIX_INFO_CREATE(info, ninfo);
+    n = 0;
     if (NULL != server_uri) {
-        ninfo = 1;
-        PMIX_INFO_CREATE(info, ninfo);
-        PMIX_INFO_LOAD(&info[0], PMIX_SERVER_URI, server_uri, PMIX_STRING);
+        PMIX_INFO_LOAD(&info[n], PMIX_SERVER_URI, server_uri, PMIX_STRING);
         fprintf(stderr, "Connecting to %s\n", server_uri);
+        ++n;
+    }
+    if (NULL != spawn) {
+        PMIX_INFO_LOAD(&info[n], PMIX_TOOL_CONNECT_OPTIONAL, NULL, PMIX_BOOL);
+        ++n;
+        PMIX_INFO_LOAD(&info[n], PMIX_LAUNCHER, NULL, PMIX_BOOL);
+        ++n;
     }
 
     /* init us */
@@ -141,6 +252,39 @@ int main(int argc, char **argv)
             fprintf(stderr, "Query returned error: %s\n", PMIx_Error_string(mydata.lock.status));
         }
         DEBUG_DESTRUCT_MYQUERY(&mydata);
+        goto done;
+    }
+
+    /* if we want to spawn a proc, then do so */
+    if (NULL != spawn) {
+        DEBUG_CONSTRUCT_LOCK(&myrel.lock);
+        /* setup notification so we know when the child has terminated */
+        PMIX_INFO_CREATE(info, 2);
+        PMIX_INFO_LOAD(&info[0], PMIX_EVENT_RETURN_OBJECT, &myrel, PMIX_POINTER);
+        /* only call me back when this specific job terminates - the
+         * children will have our nspace */
+        PMIX_LOAD_PROCID(&proc, myproc.nspace, PMIX_RANK_WILDCARD);
+        PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &proc, PMIX_PROC);
+
+        DEBUG_CONSTRUCT_LOCK(&mylock);
+        PMIx_Register_event_handler(&code, 1, info, 2,
+                                    release_fn, evhandler_reg_callbk, (void*)&mylock);
+        DEBUG_WAIT_THREAD(&mylock);
+        rc = mylock.status;
+        DEBUG_DESTRUCT_LOCK(&mylock);
+        PMIX_INFO_FREE(info, 2);
+
+        PMIX_APP_CONSTRUCT(&app);
+        PMIX_ARGV_SPLIT(app.argv, spawn, ' ');
+        app.cmd = strdup(app.argv[0]);
+        app.maxprocs = 1;
+        rc = PMIx_Spawn(NULL, 0, &app, 1, child);
+        if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
+            fprintf(stderr, "Failed to spawn %s\n", PMIx_Error_string(rc));
+            goto done;
+        }
+        /* wait here */
+        DEBUG_WAIT_THREAD(&myrel.lock);
         goto done;
     }
 
@@ -218,6 +362,6 @@ int main(int argc, char **argv)
 
  done:
     /* finalize us */
-    PMIx_Finalize(NULL, 0);
+    PMIx_tool_finalize();
     return(rc);
 }

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -172,6 +172,8 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_TOOL_DO_NOT_CONNECT            "pmix.tool.nocon"       // (bool) the tool wants to use internal PMIx support, but does
                                                                     //        not want to connect to a PMIx server
                                                                     //        from the specified processes to this tool
+#define PMIX_TOOL_CONNECT_OPTIONAL          "pmix.tool.conopt"      // (bool) tool shall connect to a server if available, but otherwise
+                                                                    //        continue to operate unconnected
 #define PMIX_RECONNECT_SERVER               "pmix.cnct.recon"       // (bool) tool is requesting to change server connections
 #define PMIX_LAUNCHER                       "pmix.tool.launcher"    // (bool) tool is a launcher and needs rendezvous files created
 #define PMIX_LAUNCHER_RENDEZVOUS_FILE       "pmix.tool.lncrnd"      // (char*) Pathname of file where connection info is to be stored
@@ -426,6 +428,9 @@ typedef uint32_t pmix_rank_t;
                                                                     //        from the spawned processes to this process (typically used by a tool)
 #define PMIX_SPAWN_TOOL                     "pmix.spwn.tool"        // (bool) job being spawned is a tool
 #define PMIX_CMD_LINE                       "pmix.cmd.line"         // (char*) command line executing in the specified nspace
+#define PMIX_FORK_EXEC_AGENT                "pmix.fe.agnt"          // (char*) command line of fork/exec agent to be used for starting
+                                                                    //         local processes
+
 
 /* query attributes */
 #define PMIX_QUERY_REFRESH_CACHE            "pmix.qry.rfsh"         // (bool) retrieve updated information from server

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -97,7 +97,10 @@ typedef struct {
     struct timeval tv;
     int fd;
     bool active;
+    void *childproc;
     bool always_readable;
+    pmix_proc_t name;
+    pmix_iof_channel_t channel;
     pmix_proc_t *targets;
     size_t ntargets;
     pmix_info_t *directives;
@@ -198,9 +201,11 @@ pmix_iof_fd_always_ready(int fd)
                             "defining read event at: %s %d",            \
                             __FILE__, __LINE__));                       \
         rev = PMIX_NEW(pmix_iof_read_event_t);                          \
-        (rev)->ntargets = (np);                                         \
-        PMIX_PROC_CREATE((rev)->targets, (rev)->ntargets);              \
-        memcpy((rev)->targets, (p), (np) * sizeof(pmix_proc_t));        \
+        if (NULL != (p)) {                                              \
+            (rev)->ntargets = (np);                                     \
+            PMIX_PROC_CREATE((rev)->targets, (rev)->ntargets);          \
+            memcpy((rev)->targets, (p), (np) * sizeof(pmix_proc_t));    \
+        }                                                               \
         if (NULL != (d)) {                                              \
             PMIX_INFO_CREATE((rev)->directives, (nd));                  \
             (rev)->ndirs = (nd);                                        \

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -71,7 +71,7 @@ PMIX_EXPORT pmix_status_t PMIx_Notify_event(pmix_status_t status,
     }
 
     /* if we aren't connected, don't attempt to send */
-    if (!pmix_globals.connected) {
+    if (!pmix_globals.connected && PMIX_RANGE_PROC_LOCAL != range) {
         PMIX_RELEASE_THREAD(&pmix_global_lock);
         return PMIX_ERR_UNREACH;
     }

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -473,6 +473,7 @@ typedef struct {
     uid_t uid;                          // my effective uid
     gid_t gid;                          // my effective gid
     char *hostname;                     // my hostname
+    pid_t pid;                          // my local pid
     uint32_t nodeid;                    // my nodeid, if given
     int pindex;
     pmix_event_base_t *evbase;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -232,6 +232,8 @@ static inline uint64_t pmix_swap_bytes8(uint64_t val)
 #define PMIX_EVLOOP_ONCE     EVLOOP_ONCE        /**< Block at most once. */
 #define PMIX_EVLOOP_NONBLOCK EVLOOP_NONBLOCK    /**< Do not block. */
 
+#define PMIX_EVENT_SIGNAL(ev)   pmix_event_get_signal(ev)
+
 typedef struct event_base pmix_event_base_t;
 typedef struct event pmix_event_t;
 

--- a/src/mca/pfexec/Makefile.am
+++ b/src/mca/pfexec/Makefile.am
@@ -1,0 +1,41 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# main library setup
+noinst_LTLIBRARIES = libmca_pfexec.la
+libmca_pfexec_la_SOURCES =
+
+# pkgdata setup
+dist_pmixdata_DATA =
+
+# local files
+headers = pfexec.h
+libmca_pfexec_la_SOURCES += $(headers)
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+pmixdir = $(pmixincludedir)/$(subdir)
+nobase_pmix_HEADERS = $(headers)
+endif
+
+include base/Makefile.am
+
+distclean-local:
+	rm -f base/static-components.h

--- a/src/mca/pfexec/base/Makefile.am
+++ b/src/mca/pfexec/base/Makefile.am
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012-2013 Los Alamos National Security, LLC.
+#                         All rights reserved
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers += \
+        base/base.h
+
+libmca_pfexec_la_SOURCES += \
+        base/pfexec_base_frame.c \
+        base/pfexec_base_select.c \
+        base/pfexec_base_default_fns.c
+
+dist_pmixdata_DATA += base/help-pfexec-base.txt

--- a/src/mca/pfexec/base/base.h
+++ b/src/mca/pfexec/base/base.h
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2013      Los Alamos National Security, LLC.  All rights reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ */
+
+#ifndef MCA_PFEXEC_BASE_H
+#define MCA_PFEXEC_BASE_H
+
+/*
+ * includes
+ */
+#include "pmix_config.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/common/pmix_iof.h"
+#include "src/mca/pfexec/pfexec.h"
+
+
+BEGIN_C_DECLS
+
+/*
+ * MCA framework
+ */
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pfexec_base_framework;
+/*
+ * Select an available component.
+ */
+PMIX_EXPORT pmix_status_t pmix_pfexec_base_select(void);
+
+typedef struct {
+    int usepty;
+    bool connect_stdin;
+
+    /* private - callers should not modify these fields */
+    int p_stdin[2];
+    int p_stdout[2];
+    int p_stderr[2];
+} pmix_pfexec_base_io_conf_t;
+
+typedef struct {
+    pmix_list_item_t super;
+    pmix_event_t ev;
+    pmix_rank_t rank;
+    pid_t pid;
+    bool completed;
+    int exitcode;
+    pmix_pfexec_base_io_conf_t opts;
+    pmix_iof_read_event_t *stdoutev;
+    pmix_iof_read_event_t *stderrev;
+} pmix_pfexec_child_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_child_t);
+
+typedef struct {
+    pmix_event_t handler;
+    bool active;
+    pmix_list_t children;
+    int timeout_before_sigkill;
+    size_t next;
+} pmix_pfexec_globals_t;
+
+PMIX_EXPORT extern pmix_pfexec_globals_t pmix_pfexec_globals;
+
+/* define a function that will fork/exec a local proc */
+typedef pmix_status_t (*pmix_pfexec_base_fork_proc_fn_t)(pmix_app_t *app,
+                                                         pmix_pfexec_child_t *child,
+                                                         char **env);
+
+/* define a function type for signaling a local proc */
+typedef pmix_status_t (*pmix_pfexec_base_signal_local_fn_t)(pid_t pd, int signum);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    const pmix_info_t *jobinfo;
+    size_t njinfo;
+    const pmix_app_t *apps;
+    size_t napps;
+    pmix_pfexec_base_fork_proc_fn_t frkfn;
+    pmix_lock_t *lock;
+} pmix_pfexec_fork_caddy_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_fork_caddy_t);
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    pmix_rank_t rank;
+    int signal;
+    pmix_pfexec_base_signal_local_fn_t sigfn;
+    pmix_lock_t *lock;
+} pmix_pfexec_signal_caddy_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_signal_caddy_t);
+
+
+PMIX_EXPORT void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata);
+
+PMIX_EXPORT void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata);
+
+PMIX_EXPORT void pmix_pfexec_base_signal_proc(int sd, short args, void *cbdata);
+
+PMIX_EXPORT void pmix_pfexec_check_complete(int sd, short args, void *cbdata);
+
+#define PMIX_PFEXEC_SPAWN(fcd, j, nj, a, na, fn, lk)                        \
+    do {                                                                    \
+        (fcd) = PMIX_NEW(pmix_pfexec_fork_caddy_t);                         \
+        (fcd)->jobinfo = (j);                                               \
+        (fcd)->njinfo = (nj);                                               \
+        (fcd)->apps = (a);                                                  \
+        (fcd)->napps = (na);                                                \
+        (fcd)->frkfn = (fn);                                                \
+        (fcd)->lock = (lk);                                                 \
+        pmix_event_assign(&((fcd)->ev), pmix_globals.evbase, -1,            \
+                          EV_WRITE, pmix_pfexec_base_spawn_proc, (fcd));    \
+        PMIX_POST_OBJECT((fcd));                                            \
+        pmix_event_active(&((fcd)->ev), EV_WRITE, 1);                       \
+    } while(0)
+
+#define PMIX_PFEXEC_KILL(scd, r, fn, lk)                                    \
+    do {                                                                    \
+        (scd) = PMIX_NEW(pmix_pfexec_signal_caddy_t);                       \
+        (scd)->rank = (r);                                                  \
+        (scd)->sigfn = (fn);                                                \
+        (scd)->lock = (lk);                                                 \
+        pmix_event_assign(&((scd)->ev), pmix_globals.evbase, -1,            \
+                          EV_WRITE, pmix_pfexec_base_kill_proc, (scd));     \
+        PMIX_POST_OBJECT((scd));                                            \
+        pmix_event_active(&((scd)->ev), EV_WRITE, 1);                       \
+    } while(0)
+
+#define PMIX_PFEXEC_SIGNAL(scd, r, nm, fn, lk)                              \
+    do {                                                                    \
+        (scd) = PMIX_NEW(pmix_pfexec_signal_caddy_t);                       \
+        (scd)->rank = (r);                                                  \
+        (scd)->signal = (nm);                                               \
+        (scd)->sigfn = (fn);                                                \
+        (scd)->lock = (lk);                                                 \
+        pmix_event_assign(&((scd)->ev), pmix_globals.evbase, -1,            \
+                          EV_WRITE, pmix_pfexec_base_signal_proc, (scd));   \
+        PMIX_POST_OBJECT((scd));                                            \
+        pmix_event_active(&((scd)->ev), EV_WRITE, 1);                       \
+    } while(0)
+
+typedef struct {
+    pmix_object_t super;
+    pmix_event_t ev;
+    pmix_pfexec_child_t *child;
+} pmix_pfexec_cmpl_caddy_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pfexec_cmpl_caddy_t);
+
+#define PMIX_PFEXEC_CHK_COMPLETE(c)                                         \
+    do {                                                                    \
+        pmix_pfexec_cmpl_caddy_t *pc = PMIX_NEW(pmix_pfexec_cmpl_caddy_t);  \
+        pc->child = (c);                                                    \
+        pmix_event_assign(&((pc)->ev), pmix_globals.evbase, -1,             \
+                          EV_WRITE, pmix_pfexec_check_complete, (pc));      \
+        PMIX_POST_OBJECT((pc));                                             \
+        pmix_event_active(&((pc)->ev), EV_WRITE, 1);                        \
+    } while(0)
+
+/*
+ * Struct written up the pipe from the child to the parent.
+ */
+typedef struct {
+    /* True if the child has died; false if this is just a warning to
+       be printed. */
+    bool fatal;
+    /* Relevant only if fatal==true */
+    int exit_status;
+
+    /* Length of the strings that are written up the pipe after this
+       struct */
+    int file_str_len;
+    int topic_str_len;
+    int msg_str_len;
+} pmix_pfexec_pipe_err_msg_t;
+
+PMIX_EXPORT pmix_status_t pmix_pfexec_base_setup_child(pmix_pfexec_child_t *child);
+
+/*
+ * Max length of strings from the pmix_pfexec_pipe_err_msg_t
+ */
+#define PMIX_PFEXEC_MAX_FILE_LEN 511
+#define PMIX_PFEXEC_MAX_TOPIC_LEN PMIX_PFEXEC_MAX_FILE_LEN
+
+
+END_C_DECLS
+#endif

--- a/src/mca/pfexec/base/help-pfexec-base.txt
+++ b/src/mca/pfexec/base/help-pfexec-base.txt
@@ -1,0 +1,103 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2014      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is the US/English general help file for Open RTE's ODLS Framework
+#
+[orte-odls-base:could-not-kill]
+WARNING: A process refused to die despite all the efforts!
+This process may still be running and/or consuming resources.
+
+Host: %s
+PID:  %d
+
+[orte-odls-base:could-not-preload-binary]
+WARNING: Could not preload the binary file.
+
+Binary: %s
+
+Will continue attempting to launch the process.
+[orte-odls-base:could-not-preload-files]
+WARNING: Could not preload the files specified.
+
+Fileset: %s
+
+Will continue attempting to launch the process.
+[orte-odls-base:could-not-preload]
+WARNING: Could not preload the requested files and directories.
+
+Binary : %s
+Fileset: %s
+
+Will continue attempting to launch the process.
+
+#
+[orte-odls-base:xterm-rank-out-of-bounds]
+The xterm option was asked to display a rank that is larger
+than the number of procs in the job:
+
+Node:      %s
+Rank:      %d
+Num procs: %d
+
+Note that ranks start with 0, not 1, and must be specified
+accordingly.
+#
+[orte-odls-base:xterm-neg-rank]
+The xterm option was asked to display a rank that is negative:
+
+Rank:      %d
+Num procs: %d
+
+Note that ranks start with 0, not 1, and must be specified
+accordingly.
+#
+[orte-odls-base:show-bindings]
+System has detected external process binding to cores %04lx.
+#
+[warn not bound]
+A request to bind the processes to a %s was made, but the operation
+resulted in the processes being unbound. This was most likely caused
+by the following:
+
+  %s
+
+This is only a warning that can be suppressed in the future by
+setting the odls_warn_if_not_bound MCA parameter to 0. Execution
+will continue.
+
+  Local host:        %s
+  Application name:  %s
+  Action requested:  %s %s
+#
+[error not bound]
+A request to bind the processes to a %s was made, but the operation
+resulted in the processes being unbound. This was most likely caused
+by the following:
+
+  %s
+
+This is an error; your job will now abort.
+
+  Local host:        %s
+  Application name:  %s
+  Action requested:  %s %s
+#
+[orte-odls-base:fork-agent-not-found]
+The specified fork agent was not found:
+
+  Node:        %s
+  Fork agent:  %s
+
+The application cannot be launched.

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -1,0 +1,508 @@
+/*
+ * Copyright (c) 2004-2010 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2011 Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
+ * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2017      Mellanox Technologies Ltd. All rights reserved.
+ * Copyright (c) 2017      IBM Corporation. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "pmix_config.h"
+
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <errno.h>
+#include <sys/types.h>
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+#include <signal.h>
+#ifdef HAVE_UTIL_H
+#include <util.h>
+#endif
+#ifdef HAVE_PTY_H
+#include <pty.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_TERMIOS_H
+#include <termios.h>
+# ifdef HAVE_TERMIO_H
+#  include <termio.h>
+# endif
+#endif
+#ifdef HAVE_LIBUTIL_H
+#include <libutil.h>
+#endif
+
+#include <pmix.h>
+#include <pmix_server.h>
+#include "pmix_common.h"
+
+#include "src/include/pmix_stdint.h"
+#include "src/include/pmix_globals.h"
+#include "src/threads/threads.h"
+#include "src/util/argv.h"
+#include "src/util/context_fns.h"
+#include "src/util/error.h"
+#include "src/util/name_fns.h"
+#include "src/util/os_dirpath.h"
+#include "src/util/os_path.h"
+#include "src/util/path.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/pmix_pty.h"
+#include "src/util/printf.h"
+#include "src/util/show_help.h"
+
+#include "src/client/pmix_client_ops.h"
+#include "src/server/pmix_server_ops.h"
+#include "src/mca/pfexec/base/base.h"
+
+static pmix_status_t setup_prefork(pmix_pfexec_child_t *child);
+
+
+static pmix_status_t setup_path(pmix_app_t *app)
+{
+    pmix_status_t rc;
+    char dir[MAXPATHLEN];
+
+    /* see if the app specifies a working dir */
+    if (NULL != app->cwd) {
+        /* Try to change to the app's cwd and check that the app
+           exists and is executable The function will
+           take care of outputting a pretty error message, if required
+        */
+        if (PMIX_SUCCESS != (rc = pmix_util_check_context_cwd(app))) {
+            /* do not ERROR_LOG - it will be reported elsewhere */
+            return rc;
+        }
+
+        /* The prior function will have done a chdir() to jump us to
+         * wherever the app is to be executed. It seems that chdir doesn't
+         * adjust the $PWD enviro variable when it changes the directory. This
+         * can cause a user to get a different response when doing getcwd vs
+         * looking at the enviro variable. To keep this consistent, we explicitly
+         * ensure that the PWD enviro variable matches the CWD we moved to.
+         *
+         * NOTE: if a user's program does a chdir(), then $PWD will once
+         * again not match getcwd! This is beyond our control - we are only
+         * ensuring they start out matching.
+         */
+        if (NULL == getcwd(dir, sizeof(dir))) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        pmix_setenv("PWD", dir, true, &app->env);
+    }
+
+    /* ensure the app is pointing to a full path */
+    rc = pmix_util_check_context_app(app, app->env);
+
+    return rc;
+}
+
+
+void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
+{
+    pmix_pfexec_fork_caddy_t *fcd = (pmix_pfexec_fork_caddy_t*)cbdata;
+    pmix_app_t *app;
+    int i, n;
+    size_t m, k;
+    pmix_status_t rc;
+    char **argv = NULL, **env = NULL;
+    char basedir[MAXPATHLEN];
+    pmix_pfexec_child_t *child;
+    pmix_proc_t proc;
+    pmix_rank_info_t *info;
+    pmix_namespace_t *nptr, *n2;
+
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output,
+                        "%s pfexec:base spawn proc",
+                        PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    /* establish our baseline working directory - we will be potentially
+     * bouncing around as we execute various apps, but we will always return
+     * to this place as our default directory
+     */
+    if (NULL == getcwd(basedir, sizeof(basedir))) {
+        rc = PMIX_ERROR;
+        goto complete;
+    }
+
+    /* ensure our nspace is on the server global list */
+    nptr = NULL;
+    PMIX_LIST_FOREACH(n2, &pmix_server_globals.nspaces, pmix_namespace_t) {
+        if (0 == strcmp(n2->nspace, pmix_globals.myid.nspace)) {
+            nptr = n2;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        /* add it */
+        nptr = PMIX_NEW(pmix_namespace_t);
+        nptr->nspace = strdup(pmix_globals.myid.nspace);
+        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+    }
+    /* mark all children as "registered" so collectives don't falter */
+    nptr->all_registered = true;
+
+    PMIX_LOAD_NSPACE(proc.nspace, pmix_globals.myid.nspace);
+    for (m=0; m < fcd->napps; m++) {
+        app = (pmix_app_t*)&fcd->apps[m];
+        /* merge our launch environment into the proc */
+        for (i=0; NULL != environ[i]; i++) {
+            pmix_argv_append_unique_nosize(&app->env, environ[i]);
+        }
+
+        /* check for a fork/exec agent we should use */
+        if (NULL != app->info) {
+            for (k=0; k < app->ninfo; k++) {
+                if (PMIX_CHECK_KEY(&app->info[k], PMIX_FORK_EXEC_AGENT)) {
+                    /* we were given a fork agent - use it. We have to put its
+                     * argv at the beginning of the app argv array */
+                    argv = pmix_argv_split(app->info[k].value.data.string, ' ');
+                    /* add in the argv from the app */
+                    for (i=0; NULL != argv[i]; i++) {
+                        pmix_argv_prepend_nosize(&app->argv, argv[i]);
+                    }
+                    if (NULL != app->cmd) {
+                        free(app->cmd);
+                    }
+                    app->cmd = pmix_path_findv(argv[0], X_OK, app->env, NULL);
+                    if (NULL == app->cmd) {
+                        pmix_show_help("help-pfexec-base.txt",
+                                       "fork-agent-not-found",
+                                       true, pmix_globals.hostname, argv[0]);
+                        rc = PMIX_ERR_NOT_FOUND;
+                        goto complete;
+                    }
+                }
+            }
+        }
+
+        /* setup the path */
+        if (PMIX_SUCCESS != (rc = setup_path(app))) {
+            goto complete;
+        }
+
+        for (n=0; n < app->maxprocs; n++) {
+            /* create a tracker for this child */
+            child = PMIX_NEW(pmix_pfexec_child_t);
+            pmix_list_append(&pmix_pfexec_globals.children, &child->super);
+
+            /* setup any IOF */
+            child->opts.usepty = PMIX_ENABLE_PTY_SUPPORT;
+            if (PMIX_SUCCESS != (rc = setup_prefork(child))) {
+                PMIX_ERROR_LOG(rc);
+                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+                PMIX_RELEASE(child);
+                goto complete;
+            }
+
+            /* register this client in case they callback to us */
+            info = PMIX_NEW(pmix_rank_info_t);
+            if (NULL == info) {
+                rc = PMIX_ERR_NOMEM;
+                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+                PMIX_RELEASE(child);
+                goto complete;
+            }
+            info->pname.nspace = strdup(pmix_globals.myid.nspace);
+            info->pname.rank = child->rank;
+            info->uid = pmix_globals.uid;
+            info->gid = pmix_globals.gid;
+            pmix_list_append(&nptr->ranks, &info->super);
+
+            /* setup the PMIx environment */
+            env = pmix_argv_copy(app->env);
+            proc.rank = child->rank;
+            rc = PMIx_server_setup_fork(&proc, &env);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+                PMIX_RELEASE(child);
+                pmix_argv_free(env);
+                goto complete;
+            }
+            pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output,
+                                "%s pfexec:base spawning child %s",
+                                PMIX_NAME_PRINT(&pmix_globals.myid), app->cmd);
+
+            rc = fcd->frkfn(app, child, env);
+            pmix_argv_free(env);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+                PMIX_RELEASE(child);
+                goto complete;
+            }
+            PMIX_IOF_READ_ACTIVATE(child->stdoutev);
+            PMIX_IOF_READ_ACTIVATE(child->stderrev);
+        }
+    }
+
+    /* ensure we reset our working directory back to our default location  */
+    if (0 != chdir(basedir)) {
+        PMIX_ERROR_LOG(PMIX_ERROR);
+    }
+
+  complete:
+    fcd->lock->status = rc;
+    PMIX_WAKEUP_THREAD(fcd->lock);
+    return;
+}
+
+void pmix_pfexec_base_kill_proc(int sd, short args, void *cbdata)
+{
+    pmix_pfexec_signal_caddy_t *scd = (pmix_pfexec_signal_caddy_t*)cbdata;
+    pmix_pfexec_child_t *child, *cd;
+
+    /* find the process */
+    child = NULL;
+    PMIX_LIST_FOREACH(cd, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+        if (scd->rank == cd->rank) {
+            child = cd;
+            break;
+        }
+    }
+    if (NULL == child) {
+        scd->lock->status = PMIX_SUCCESS;
+        PMIX_WAKEUP_THREAD(scd->lock);
+        return;
+    }
+
+#if 0
+    /* if we opened the stdin IOF channel, be sure
+     * we close it */
+    if (NULL != orte_iof.close) {
+        orte_iof.close(&child->name, ORTE_IOF_STDIN);
+    }
+#endif
+
+    /* remove the child from the list so waitpid callback won't
+     * find it as this induces unmanageable race
+     * conditions when we are deliberately killing the process
+     */
+    pmix_list_remove_item(&pmix_pfexec_globals.children, &child->super);
+
+    /* First send a SIGCONT in case the process is in stopped state.
+       If it is in a stopped state and we do not first change it to
+       running, then SIGTERM will not get delivered.  Ignore return
+       value. */
+    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output,
+                         "%s SENDING SIGCONT",
+                         PMIX_NAME_PRINT(&pmix_globals.myid)));
+    scd->sigfn(child->pid, SIGCONT);
+
+    /* wait a little to give the proc a chance to wakeup */
+    sleep(pmix_pfexec_globals.timeout_before_sigkill);
+    /* issue a SIGTERM */
+    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output,
+                         "%s SENDING SIGTERM",
+                         PMIX_NAME_PRINT(&pmix_globals.myid)));
+    scd->lock->status = scd->sigfn(child->pid, SIGTERM);
+
+    if (0 != scd->lock->status) {
+        /* wait a little again */
+        sleep(pmix_pfexec_globals.timeout_before_sigkill);
+        /* issue a SIGKILL */
+        PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output,
+                             "%s SENDING SIGKILL",
+                             PMIX_NAME_PRINT(&pmix_globals.myid)));
+        scd->lock->status = scd->sigfn(child->pid, SIGKILL);
+    }
+
+    /* cleanup */
+    PMIX_RELEASE(child);
+    PMIX_WAKEUP_THREAD(scd->lock);
+
+#if 0
+    /* ensure the child's session directory is cleaned up */
+    orte_session_dir_finalize(&child->name);
+#endif
+
+    return;
+}
+
+void pmix_pfexec_base_signal_proc(int sd, short args, void *cbdata)
+{
+    pmix_pfexec_signal_caddy_t *scd = (pmix_pfexec_signal_caddy_t*)cbdata;
+    pmix_pfexec_child_t *child, *cd;
+
+    /* find the process */
+    child = NULL;
+    PMIX_LIST_FOREACH(cd, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+        if (scd->rank == cd->rank) {
+            child = cd;
+            break;
+        }
+    }
+    if (NULL == child) {
+        scd->lock->status = PMIX_SUCCESS;
+        PMIX_WAKEUP_THREAD(scd->lock);
+        return;
+    }
+
+    PMIX_OUTPUT_VERBOSE((5, pmix_pfexec_base_framework.framework_output,
+                         "%s SIGNALING %d",
+                         PMIX_NAME_PRINT(&pmix_globals.myid), scd->signal));
+    scd->lock->status = scd->sigfn(child->pid, scd->signal);
+
+    PMIX_WAKEUP_THREAD(scd->lock);
+}
+
+static pmix_status_t setup_prefork(pmix_pfexec_child_t *child)
+{
+    int ret = -1;
+    pmix_pfexec_base_io_conf_t *opts = &child->opts;
+    pmix_proc_t *targets = NULL;
+    pmix_info_t *directives = NULL;
+
+    fflush(stdout);
+
+    /* first check to make sure we can do ptys */
+#if PMIX_ENABLE_PTY_SUPPORT
+    if (opts->usepty) {
+        ret = pmix_openpty(&(opts->p_stdout[0]), &(opts->p_stdout[1]),
+                           (char*)NULL, (struct termios*)NULL, (struct winsize*)NULL);
+    }
+#else
+    opts->usepty = 0;
+#endif
+
+    if (ret < 0) {
+        opts->usepty = 0;
+        if (pipe(opts->p_stdout) < 0) {
+            PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+            return PMIX_ERR_SYS_OTHER;
+        }
+    }
+    if (opts->connect_stdin) {
+        if (pipe(opts->p_stdin) < 0) {
+            PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+            return PMIX_ERR_SYS_OTHER;
+        }
+    }
+    if (pipe(opts->p_stderr) < 0) {
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+        return PMIX_ERR_SYS_OTHER;
+    }
+
+#if 0
+    /* connect stdin endpoint */
+    if (opts->connect_stdin) {
+        /* and connect the pty to stdin */
+        ret = orte_iof.pull(name, ORTE_IOF_STDIN, opts->p_stdin[1]);
+        if(ORTE_SUCCESS != ret) {
+            ORTE_ERROR_LOG(ret);
+            return ret;
+        }
+    }
+#endif
+    /* connect read ends to IOF */
+    PMIX_IOF_READ_EVENT(&child->stdoutev,
+                        targets, 0, directives, 0, opts->p_stdout[0],
+                        pmix_iof_read_local_handler, false);
+    PMIX_LOAD_PROCID(&child->stdoutev->name, pmix_globals.myid.nspace, child->rank);
+    child->stdoutev->childproc = (void*)child;
+    child->stdoutev->channel = PMIX_FWD_STDOUT_CHANNEL;
+    PMIX_IOF_READ_EVENT(&child->stderrev,
+                        targets, 0, directives, 0, opts->p_stderr[0],
+                        pmix_iof_read_local_handler, false);
+    PMIX_LOAD_PROCID(&child->stderrev->name, pmix_globals.myid.nspace, child->rank);
+    child->stderrev->childproc = (void*)child;
+    child->stderrev->channel = PMIX_FWD_STDERR_CHANNEL;
+
+    return PMIX_SUCCESS;
+}
+
+
+pmix_status_t pmix_pfexec_base_setup_child(pmix_pfexec_child_t *child)
+{
+    int ret;
+    pmix_pfexec_base_io_conf_t *opts = &child->opts;
+
+    if (opts->connect_stdin) {
+        close(opts->p_stdin[1]);
+    }
+    close(opts->p_stdout[0]);
+    close(opts->p_stderr[0]);
+
+    if (opts->usepty) {
+        /* disable echo */
+        struct termios term_attrs;
+        if (tcgetattr(opts->p_stdout[1], &term_attrs) < 0) {
+            return PMIX_ERR_SYS_OTHER;
+        }
+        term_attrs.c_lflag &= ~ (ECHO | ECHOE | ECHOK |
+                                 ECHOCTL | ECHOKE | ECHONL);
+        term_attrs.c_iflag &= ~ (ICRNL | INLCR | ISTRIP | INPCK | IXON);
+        term_attrs.c_oflag &= ~ (OCRNL | ONLCR);
+        if (tcsetattr(opts->p_stdout[1], TCSANOW, &term_attrs) == -1) {
+            return PMIX_ERR_SYS_OTHER;
+        }
+        ret = dup2(opts->p_stdout[1], fileno(stdout));
+        if (ret < 0) {
+            return PMIX_ERR_SYS_OTHER;
+        }
+        close(opts->p_stdout[1]);
+    } else {
+        if(opts->p_stdout[1] != fileno(stdout)) {
+            ret = dup2(opts->p_stdout[1], fileno(stdout));
+            if (ret < 0) {
+                return PMIX_ERR_SYS_OTHER;
+            }
+            close(opts->p_stdout[1]);
+        }
+    }
+    if (opts->connect_stdin) {
+        if(opts->p_stdin[0] != fileno(stdin)) {
+            ret = dup2(opts->p_stdin[0], fileno(stdin));
+            if (ret < 0) {
+                return PMIX_ERR_SYS_OTHER;
+            }
+            close(opts->p_stdin[0]);
+        }
+    } else {
+        int fd;
+
+        /* connect input to /dev/null */
+        fd = open("/dev/null", O_RDONLY, 0);
+        if(fd != fileno(stdin)) {
+            dup2(fd, fileno(stdin));
+            close(fd);
+        }
+    }
+
+    if (opts->p_stderr[1] != fileno(stderr)) {
+        ret = dup2(opts->p_stderr[1], fileno(stderr));
+        if (ret < 0) {
+            return PMIX_ERR_SYS_OTHER;
+        }
+        close(opts->p_stderr[1]);
+    }
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2011 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2010-2011 Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2011-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2011-2013 Los Alamos National Security, LLC.
+ *                         All rights reserved.
+ * Copyright (c) 2014-2018 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+#include "src/include/types.h"
+
+#include <string.h>
+#include <signal.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+#include "src/threads/threads.h"
+#include "src/include/pmix_globals.h"
+#include "src/common/pmix_iof.h"
+#include "src/client/pmix_client_ops.h"
+#include "src/util/error.h"
+
+#include "src/mca/pfexec/base/base.h"
+
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "src/mca/pfexec/base/static-components.h"
+
+/*
+ * Instantiate globals
+ */
+pmix_pfexec_base_module_t pmix_pfexec = {0};
+
+/*
+ * Framework global variables
+ */
+pmix_pfexec_globals_t pmix_pfexec_globals = {0};
+
+static int pmix_pfexec_base_close(void)
+{
+    PMIX_LIST_DESTRUCT(&pmix_pfexec_globals.children);
+    if (pmix_pfexec_globals.active) {
+        pmix_event_del(&pmix_pfexec_globals.handler);
+    }
+    pmix_pfexec_globals.active = false;
+
+    return pmix_mca_base_framework_components_close(&pmix_pfexec_base_framework, NULL);
+}
+
+/* callback from the event library whenever a SIGCHLD is received */
+static void wait_signal_callback(int fd, short event, void *arg)
+{
+    pmix_event_t *signal = (pmix_event_t*) arg;
+    int status;
+    pid_t pid;
+    pmix_pfexec_child_t *child;
+
+    PMIX_ACQUIRE_OBJECT(signal);
+
+    if (SIGCHLD != PMIX_EVENT_SIGNAL(signal)) {
+        return;
+    }
+
+    /* if we haven't spawned anyone, then ignore this */
+    if (0 == pmix_list_get_size(&pmix_pfexec_globals.children)) {
+        return;
+    }
+
+    /* reap all queued waitpids until we
+     * don't get anything valid back */
+    while (1) {
+        pid = waitpid(-1, &status, WNOHANG);
+        if (-1 == pid && EINTR == errno) {
+            /* try it again */
+            continue;
+        }
+        /* if we got garbage, then nothing we can do */
+        if (pid <= 0) {
+            return;
+        }
+
+        /* we are already in an event, so it is safe to access globals */
+        PMIX_LIST_FOREACH(child, &pmix_pfexec_globals.children, pmix_pfexec_child_t) {
+            if (pid == child->pid) {
+                /* record the exit status */
+                if (WIFEXITED(status)) {
+                    child->exitcode = WEXITSTATUS(status);
+                } else {
+                    if (WIFSIGNALED(status)) {
+                        child->exitcode = WTERMSIG(status) + 128;
+                    }
+                }
+                /* mark the child as complete */
+                child->completed = true;
+                PMIX_PFEXEC_CHK_COMPLETE(child);
+                break;
+            }
+        }
+    }
+}
+
+void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
+{
+    pmix_pfexec_cmpl_caddy_t *cd = (pmix_pfexec_cmpl_caddy_t*)cbdata;
+    pmix_info_t info[2];
+    pmix_status_t rc;
+
+    /* if the waitpid fired and the sink is empty, then that means
+     * it terminated and all output has been written, so remove
+     * it from the list of children */
+    if (cd->child->completed &&
+        (NULL == cd->child->stdoutev || !cd->child->stdoutev->active) &&
+        (NULL == cd->child->stderrev || !cd->child->stderrev->active)) {
+        if (NULL != cd->child->super.pmix_list_item_belong_to) {
+            pmix_list_remove_item(&pmix_pfexec_globals.children, &cd->child->super);
+            PMIX_RELEASE(cd->child);
+        }
+        if (0 == pmix_list_get_size(&pmix_pfexec_globals.children)) {
+            /* generate a local event indicating job terminated */
+            PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);
+            PMIX_INFO_LOAD(&info[1], PMIX_EVENT_AFFECTED_PROC, &pmix_globals.myid, PMIX_PROC);
+            rc = PMIx_Notify_event(PMIX_ERR_JOB_TERMINATED,
+                                   &pmix_globals.myid, PMIX_RANGE_PROC_LOCAL,
+                                   info, 2, NULL, NULL);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+            }
+        }
+    }
+    PMIX_RELEASE(cd);
+}
+
+static int pmix_pfexec_register(pmix_mca_base_register_flag_t flags)
+{
+    pmix_pfexec_globals.timeout_before_sigkill = 1;
+    pmix_mca_base_var_register("pmix", "pfexec", "base", "sigkill_timeout",
+                                 "Time to wait for a process to die after issuing a kill signal to it",
+                               PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                               PMIX_INFO_LVL_2,
+                               PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                               &pmix_pfexec_globals.timeout_before_sigkill);
+    return PMIX_SUCCESS;
+}
+
+/**
+ * Function for finding and opening either all MCA components, or the one
+ * that was specifically requested via a MCA parameter.
+ */
+static int pmix_pfexec_base_open(pmix_mca_base_open_flag_t flags)
+{
+    sigset_t unblock;
+
+    memset(&pmix_pfexec_globals, 0, sizeof(pmix_pfexec_globals_t));
+
+    /* setup the list of children */
+    PMIX_CONSTRUCT(&pmix_pfexec_globals.children, pmix_list_t);
+    pmix_pfexec_globals.next = 1;
+
+    /* ensure that SIGCHLD is unblocked as we need to capture it */
+    if (0 != sigemptyset(&unblock)) {
+        return PMIX_ERROR;
+    }
+    if (0 != sigaddset(&unblock, SIGCHLD)) {
+        return PMIX_ERROR;
+    }
+    if (0 != sigprocmask(SIG_UNBLOCK, &unblock, NULL)) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
+    /* set to catch SIGCHLD events */
+    pmix_event_set(pmix_globals.evbase,
+                   &pmix_pfexec_globals.handler,
+                   SIGCHLD, PMIX_EV_SIGNAL|PMIX_EV_PERSIST,
+                   wait_signal_callback,
+                   &pmix_pfexec_globals.handler);
+    pmix_pfexec_globals.active = true;
+    pmix_event_add(&pmix_pfexec_globals.handler, NULL);
+
+     /* Open up all available components */
+    return pmix_mca_base_framework_components_open(&pmix_pfexec_base_framework, flags);
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pfexec, "PMIx fork/exec Subsystem",
+                                pmix_pfexec_register, pmix_pfexec_base_open, pmix_pfexec_base_close,
+                                mca_pfexec_base_static_components, 0);
+
+
+/**** FRAMEWORK CLASS INSTANTIATIONS ****/
+
+static void chcon(pmix_pfexec_child_t *p)
+{
+    pmix_proc_t proc;
+
+    p->rank = pmix_pfexec_globals.next;
+    PMIX_LOAD_PROCID(&proc, pmix_globals.myid.nspace, p->rank);
+    pmix_pfexec_globals.next++;
+    p->pid = 0;
+}
+static void chdes(pmix_pfexec_child_t *p)
+{
+    if (NULL != p->stdoutev) {
+        PMIX_RELEASE(p->stdoutev);
+    }
+    if (NULL != p->stderrev) {
+        PMIX_RELEASE(p->stderrev);
+    }
+}
+PMIX_CLASS_INSTANCE(pmix_pfexec_child_t,
+                    pmix_list_item_t,
+                    chcon, chdes);
+
+static void fccon(pmix_pfexec_fork_caddy_t *p)
+{
+    p->jobinfo = NULL;
+    p->njinfo = 0;
+    p->apps = NULL;
+    p->napps = 0;
+}
+PMIX_CLASS_INSTANCE(pmix_pfexec_fork_caddy_t,
+                    pmix_object_t,
+                    fccon, NULL);
+
+PMIX_CLASS_INSTANCE(pmix_pfexec_signal_caddy_t,
+                    pmix_object_t,
+                    NULL, NULL);
+
+PMIX_CLASS_INSTANCE(pmix_pfexec_cmpl_caddy_t,
+                    pmix_object_t,
+                    NULL, NULL);

--- a/src/mca/pfexec/base/pfexec_base_frame.c
+++ b/src/mca/pfexec/base/pfexec_base_frame.c
@@ -30,6 +30,9 @@
 
 #include <string.h>
 #include <signal.h>
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
 
 #include "src/mca/mca.h"
 #include "src/mca/base/base.h"
@@ -135,10 +138,8 @@ void pmix_pfexec_check_complete(int sd, short args, void *cbdata)
     if (cd->child->completed &&
         (NULL == cd->child->stdoutev || !cd->child->stdoutev->active) &&
         (NULL == cd->child->stderrev || !cd->child->stderrev->active)) {
-        if (NULL != cd->child->super.pmix_list_item_belong_to) {
-            pmix_list_remove_item(&pmix_pfexec_globals.children, &cd->child->super);
-            PMIX_RELEASE(cd->child);
-        }
+        pmix_list_remove_item(&pmix_pfexec_globals.children, &cd->child->super);
+        PMIX_RELEASE(cd->child);
         if (0 == pmix_list_get_size(&pmix_pfexec_globals.children)) {
             /* generate a local event indicating job terminated */
             PMIX_INFO_LOAD(&info[0], PMIX_EVENT_NON_DEFAULT, NULL, PMIX_BOOL);

--- a/src/mca/pfexec/base/pfexec_base_select.c
+++ b/src/mca/pfexec/base/pfexec_base_select.c
@@ -1,0 +1,57 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/pfexec/base/base.h"
+
+
+/**
+ * Function for selecting one component from all those that are
+ * available.
+ */
+int pmix_pfexec_base_select(void)
+{
+    pmix_pfexec_base_component_t *best_component = NULL;
+    pmix_pfexec_base_module_t *best_module = NULL;
+
+    /*
+     * Select the best component
+     */
+    if (PMIX_SUCCESS != pmix_mca_base_select("pfexec", pmix_pfexec_base_framework.framework_output,
+                                             &pmix_pfexec_base_framework.framework_components,
+                                             (pmix_mca_base_module_t **) &best_module,
+                                             (pmix_mca_base_component_t **) &best_component, NULL) ) {
+        /* This will only happen if no component was selected */
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    /* Save the winner */
+    pmix_pfexec = *best_module;
+
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pfexec/linux/Makefile.am
+++ b/src/mca/pfexec/linux/Makefile.am
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017      IBM Corporation.  All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+dist_pmixdata_DATA = help-pfexec-linux.txt
+
+sources = \
+        pfexec_linux.h \
+        pfexec_linux_component.c \
+        pfexec_linux.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pfexec_linux_DSO
+component_noinst =
+component_install = mca_pfexec_linux.la
+else
+component_noinst = libmca_pfexec_linux.la
+component_install =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_pfexec_linux_la_SOURCES = $(sources)
+mca_pfexec_linux_la_LDFLAGS = -module -avoid-version
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_pfexec_linux_la_SOURCES =$(sources)
+libmca_pfexec_linux_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pfexec/linux/configure.m4
+++ b/src/mca/pfexec/linux/configure.m4
@@ -1,0 +1,34 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2011      Los Alamos National Security, LLC.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_pfexec_linux_CONFIG([action-if-found], [action-if-not-found])
+# -----------------------------------------------------------
+AC_DEFUN([MCA_pmix_pfexec_linux_CONFIG],[
+    AC_CONFIG_FILES([src/mca/pfexec/linux/Makefile])
+
+    AC_CHECK_FUNC([fork], [pfexec_linux_happy="yes"], [pfexec_linux_happy="no"])
+
+    AS_IF([test "$pfexec_linux_happy" = "yes"], [$1], [$2])
+
+])dnl
+

--- a/src/mca/pfexec/linux/help-pfexec-linux.txt
+++ b/src/mca/pfexec/linux/help-pfexec-linux.txt
@@ -1,0 +1,147 @@
+# -*- text -*-
+#
+# Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2009      Sun Microsystems, Inc.  All rights reserved.
+# Copyright (c) 2010-2011 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+# This is a US/English help file.
+#
+[execve error]
+PMIx tried to fork a new process via the "execve" system call but
+failed.  PMIx checks many things before attempting to launch a
+child process, but nothing is perfect. This error may be indicative
+of another problem on the target host, or even something as silly as
+having specified a directory for your application. Your job will now
+abort.
+
+  Local host:        %s
+  Working dir:       %s
+  Application name:  %s
+  Error:             %s
+#
+[binding not supported]
+PMIx tried to bind a new process, but process binding is not
+supported on the host where it was launched.  The process was killed
+without launching the target application.  Your job will now abort.
+
+  Local host:        %s
+  Application name:  %s
+#
+[binding generic error]
+PMIx tried to bind a new process, but something went wrong.  The
+process was killed without launching the target application.  Your job
+will now abort.
+
+  Local host:        %s
+  Application name:  %s
+  Error message:     %s
+  Location:          %s:%d
+#
+[bound to everything]
+PMIx tried to bind a new process to a specific set of processors,
+but ended up binding it to *all* processors.  This means that the new
+process is effectively unbound.
+
+This is only a warning -- your job will continue.  You can suppress
+this warning in the future by setting the odls_warn_if_not_bound MCA
+parameter to 0.
+
+  Local host:        %s
+  Application name:  %s
+  Location:          %s:%d
+#
+[slot list and paffinity_alone]
+PMIx detected that both a slot list was specified and the MCA
+parameter "paffinity_alone" was set to true.  Only one of these can be
+used at a time.  Your job will now abort.
+
+  Local host:        %s
+  Application name:  %s
+#
+[iof setup failed]
+PMIx tried to launch a child process but the "IOF child setup"
+failed.  This should not happen.  Your job will now abort.
+
+  Local host:        %s
+  Application name:  %s
+#
+[not bound]
+WARNING: PMIx tried to bind a process but failed.  This is a
+warning only; your job will continue.
+
+  Local host:        %s
+  Application name:  %s
+  Error message:     %s
+  Location:          %s:%d
+#
+[syscall fail]
+A system call failed that should not have.  In this particular case,
+a warning or error message was not displayed that should have been.
+Your job may behave unpredictably after this, or abort.
+
+  Local host:        %s
+  Application name:  %s
+  Function:          %s
+  Location:          %s:%d
+#
+[memory not bound]
+WARNING: PMIx tried to bind a process but failed.  This is a
+warning only; your job will continue, though performance may
+be degraded.
+
+  Local host:        %s
+  Application name:  %s
+  Error message:     %s
+  Location:          %s:%d
+
+#
+[memory binding error]
+PMIx tried to bind memory for a new process but something went
+wrong. The process was killed without launching the target
+application. Your job will now abort.
+
+  Local host:        %s
+  Application name:  %s
+  Error message: %s
+  Location:  %s:%d
+#
+[set limit]
+Error message received from:
+
+  Local host:        %s
+  Application name:  %s
+  Location:  %s:%d
+
+Message:
+
+%s
+#
+[incorrectly-bound]
+WARNING: PMIx incorrectly bound a process to the daemon's cores.
+This is a warning only; your job will continue.
+
+  Local host:        %s
+  Application name:  %s
+  Location:          %s:%d
+#
+[wdir-not-found]
+PMIx was unable to launch the specified application as it could not
+change to the specified working directory:
+
+Working directory: %s
+Node: %s

--- a/src/mca/pfexec/linux/pfexec_linux.c
+++ b/src/mca/pfexec/linux/pfexec_linux.c
@@ -1,0 +1,593 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2008 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2007-2010 Oracle and/or its affiliates.  All rights reserved.
+ * Copyright (c) 2007      Evergrid, Inc. All rights reserved.
+ * Copyright (c) 2008-2017 Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2010      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
+ *                         reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2017      Rutgers, The State University of New Jersey.
+ *                         All rights reserved.
+ * Copyright (c) 2017      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/*
+ * There is a complicated sequence of events that occurs when the
+ * parent forks a child process that is intended to launch the target
+ * executable.
+ *
+ * Before the child process exec's the target executable, it might tri
+ * to set the affinity of that new child process according to a
+ * complex series of rules.  This binding may fail in a myriad of
+ * different ways.  A lot of this code deals with reporting that error
+ * occurately to the end user.  This is a complex task in itself
+ * because the child process is not "really" an PMIX process -- all
+ * error reporting must be proxied up to the parent who can use normal
+ * PMIX error reporting mechanisms.
+ *
+ * Here's a high-level description of what is occurring in this file:
+ *
+ * - parent opens a pipe
+ * - parent forks a child
+ * - parent blocks reading on the pipe: the pipe will either close
+ *   (indicating that the child successfully exec'ed) or the child will
+ *   write some proxied error data up the pipe
+ *
+ * - the child tries to set affinity and do other housekeeping in
+ *   preparation of exec'ing the target executable
+ * - if the child fails anywhere along the way, it sends a message up
+ *   the pipe to the parent indicating what happened -- including a
+ *   rendered error message detailing the problem (i.e., human-readable).
+ * - it is important that the child renders the error message: there
+ *   are so many errors that are possible that the child is really the
+ *   only entity that has enough information to make an accuate error string
+ *   to report back to the user.
+ * - the parent reads this message + rendered string in and uses PMIX
+ *   reporting mechanisms to display it to the user
+ * - if the problem was only a warning, the child continues processing
+ *   (potentially eventually exec'ing the target executable).
+ * - if the problem was an error, the child exits and the parent
+ *   handles the death of the child as appropriate (i.e., this PFEXEC
+ *   simply reports the error -- other things decide what to do).
+ */
+
+#include "pmix_config.h"
+#include "pmix.h"
+#include "src/include/types.h"
+
+#include <string.h>
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <errno.h>
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+#include <signal.h>
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif
+#include <stdlib.h>
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif  /* HAVE_SYS_STAT_H */
+#include <stdarg.h>
+#ifdef HAVE_SYS_SELECT_H
+#include <sys/select.h>
+#endif
+#ifdef HAVE_DIRENT_H
+#include <dirent.h>
+#endif
+#include <ctype.h>
+
+#include "src/hwloc/hwloc-internal.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/pmix_environ.h"
+#include "src/util/show_help.h"
+#include "src/util/fd.h"
+#include "src/util/error.h"
+
+#include "src/include/pmix_globals.h"
+#include "src/util/name_fns.h"
+#include "src/threads/threads.h"
+
+#include "src/mca/pfexec/base/base.h"
+#include "src/mca/pfexec/linux/pfexec_linux.h"
+
+/*
+ * Module functions (function pointers used in a struct)
+ */
+static pmix_status_t spawn_proc(const pmix_info_t job_info[], size_t ninfo,
+                                const pmix_app_t apps[], size_t napps);
+static pmix_status_t kill_proc(pmix_rank_t rank);
+static pmix_status_t signal_proc(pmix_rank_t rank, int32_t signal);
+
+/*
+ * Explicitly declared functions so that we can get the noreturn
+ * attribute registered with the compiler.
+ */
+static void send_error_show_help(int fd, int exit_status,
+                                 const char *file, const char *topic, ...)
+    __pmix_attribute_noreturn__;
+
+static void do_child(pmix_app_t *cd, char **env, pmix_pfexec_child_t *child, int write_fd)
+    __pmix_attribute_noreturn__;
+
+
+/*
+ * Module
+ */
+pmix_pfexec_base_module_t pmix_pfexec_linux_module = {
+    .spawn_proc = spawn_proc,
+    .kill_proc = kill_proc,
+    .signal_proc = signal_proc,
+};
+
+
+/* deliver a signal to a specified pid. */
+static pmix_status_t sigproc(pid_t pd, int signum)
+{
+    pid_t pgrp;
+    pid_t pid;
+
+    pid = pd;
+
+#if HAVE_SETPGID
+    pgrp = getpgid(pd);
+    if (-1 != pgrp) {
+        /* target the lead process of the process
+         * group so we ensure that the signal is
+         * seen by all members of that group. This
+         * ensures that the signal is seen by any
+         * child processes our child may have
+         * started
+         */
+        pid = -pgrp;
+    }
+#endif
+
+    if (0 != kill(pid, signum)) {
+        if (ESRCH != errno) {
+            PMIX_OUTPUT_VERBOSE((2, pmix_pfexec_base_framework.framework_output,
+                                 "%s pfexec:linux:SENT SIGNAL %d TO PID %d GOT ERRNO %d",
+                                 PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int)pid, errno));
+            return errno;
+        }
+    }
+    PMIX_OUTPUT_VERBOSE((2, pmix_pfexec_base_framework.framework_output,
+                         "%s pfexec:linux:SENT SIGNAL %d TO PID %d SUCCESS",
+                         PMIX_NAME_PRINT(&pmix_globals.myid), signum, (int)pid));
+    return 0;
+}
+
+static pmix_status_t kill_proc(pmix_rank_t rank)
+{
+    pmix_status_t rc;
+    pmix_lock_t mylock;
+    pmix_pfexec_signal_caddy_t *kcd;
+
+    PMIX_CONSTRUCT_LOCK(&mylock);
+    PMIX_PFEXEC_KILL(kcd, rank, sigproc, &mylock);
+    PMIX_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    PMIX_DESTRUCT_LOCK(&mylock);
+    PMIX_RELEASE(kcd);
+
+    return rc;
+}
+
+static pmix_status_t signal_proc(pmix_rank_t rank, int32_t signal)
+{
+    pmix_status_t rc;
+    pmix_lock_t mylock;
+    pmix_pfexec_signal_caddy_t *scd;
+
+    PMIX_CONSTRUCT_LOCK(&mylock);
+    PMIX_PFEXEC_SIGNAL(scd, rank, signal, sigproc, &mylock);
+    PMIX_WAIT_THREAD(&mylock);
+    rc = mylock.status;
+    PMIX_DESTRUCT_LOCK(&mylock);
+    PMIX_RELEASE(scd);
+
+    return rc;
+}
+
+static void set_handler_linux(int sig)
+{
+    struct sigaction act;
+
+    act.sa_handler = SIG_DFL;
+    act.sa_flags = 0;
+    sigemptyset(&act.sa_mask);
+
+    sigaction(sig, &act, (struct sigaction *)0);
+}
+
+/*
+ * Internal function to write a rendered show_help message back up the
+ * pipe to the waiting parent.
+ */
+static int write_help_msg(int fd, pmix_pfexec_pipe_err_msg_t *msg, const char *file,
+                          const char *topic, va_list ap)
+{
+    int ret;
+    char *str;
+
+    if (NULL == file || NULL == topic) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    str = pmix_show_help_vstring(file, topic, true, ap);
+
+    msg->file_str_len = (int) strlen(file);
+    if (msg->file_str_len > PMIX_PFEXEC_MAX_FILE_LEN) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    msg->topic_str_len = (int) strlen(topic);
+    if (msg->topic_str_len > PMIX_PFEXEC_MAX_TOPIC_LEN) {
+        PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+        return PMIX_ERR_BAD_PARAM;
+    }
+    msg->msg_str_len = (int) strlen(str);
+
+    /* Only keep writing if each write() succeeds */
+    if (PMIX_SUCCESS != (ret = pmix_fd_write(fd, sizeof(*msg), msg))) {
+        goto out;
+    }
+    if (msg->file_str_len > 0 &&
+        PMIX_SUCCESS != (ret = pmix_fd_write(fd, msg->file_str_len, file))) {
+        goto out;
+    }
+    if (msg->topic_str_len > 0 &&
+        PMIX_SUCCESS != (ret = pmix_fd_write(fd, msg->topic_str_len, topic))) {
+        goto out;
+    }
+    if (msg->msg_str_len > 0 &&
+        PMIX_SUCCESS != (ret = pmix_fd_write(fd, msg->msg_str_len, str))) {
+        goto out;
+    }
+
+ out:
+    free(str);
+    return ret;
+}
+
+
+/* Called from the child to send an error message up the pipe to the
+   waiting parent. */
+static void send_error_show_help(int fd, int exit_status,
+                                 const char *file, const char *topic, ...)
+{
+    va_list ap;
+    pmix_pfexec_pipe_err_msg_t msg;
+
+    msg.fatal = true;
+    msg.exit_status = exit_status;
+
+    /* Send it */
+    va_start(ap, topic);
+    write_help_msg(fd, &msg, file, topic, ap);
+    va_end(ap);
+
+    exit(exit_status);
+}
+
+/* close all open file descriptors w/ exception of stdin/stdout/stderr
+   and the pipe up to the parent. */
+static int close_open_file_descriptors(int write_fd) {
+    DIR *dir = opendir("/proc/self/fd");
+    if (NULL == dir) {
+        return PMIX_ERR_FILE_OPEN_FAILURE;
+    }
+    struct dirent *files;
+
+    /* grab the fd of the opendir above so we don't close in the
+     * middle of the scan. */
+    int dir_scan_fd = dirfd(dir);
+    if(dir_scan_fd < 0 ) {
+        return PMIX_ERR_FILE_OPEN_FAILURE;
+    }
+
+
+    while (NULL != (files = readdir(dir))) {
+        if (!isdigit(files->d_name[0])) {
+            continue;
+        }
+        int fd = strtol(files->d_name, NULL, 10);
+        if (errno == EINVAL || errno == ERANGE) {
+            closedir(dir);
+            return PMIX_ERR_TYPE_MISMATCH;
+        }
+        if (fd >=3 &&
+            fd != write_fd &&
+	        fd != dir_scan_fd) {
+            close(fd);
+        }
+    }
+    closedir(dir);
+    return PMIX_SUCCESS;
+}
+
+static void do_child(pmix_app_t *app, char **env,
+                     pmix_pfexec_child_t *child, int write_fd)
+{
+    int i, errval;
+    sigset_t sigs;
+    long fd, fdmax = sysconf(_SC_OPEN_MAX);
+    char dir[MAXPATHLEN];
+
+#if HAVE_SETPGID
+    /* Set a new process group for this child, so that any
+     * signals we send to it will reach any children it spawns */
+    setpgid(0, 0);
+#endif
+
+    /* Setup the pipe to be close-on-exec */
+    pmix_fd_set_cloexec(write_fd);
+
+    /* setup stdout/stderr so that any error messages that we
+       may print out will get displayed back at pmixrun.
+
+       NOTE: Definitely do this AFTER we check contexts so
+       that any error message from those two functions doesn't
+       come out to the user. IF we didn't do it in this order,
+       THEN a user who gives us a bad executable name or
+       working directory would get N error messages, where
+       N=num_procs. This would be very annoying for large
+       jobs, so instead we set things up so that pmixrun
+       always outputs a nice, single message indicating what
+       happened
+    */
+    if (PMIX_SUCCESS != (i = pmix_pfexec_base_setup_child(child))) {
+        PMIX_ERROR_LOG(i);
+        send_error_show_help(write_fd, 1,
+                             "help-pfexec-linux.txt",
+                             "iof setup failed",
+                             pmix_globals.hostname, app->cmd);
+        /* Does not return */
+    }
+
+    /* close all open file descriptors w/ exception of stdin/stdout/stderr,
+       the pipe used for the IOF INTERNAL messages, and the pipe up to
+       the parent. */
+    if (PMIX_SUCCESS != close_open_file_descriptors(write_fd)) {
+        // close *all* file descriptors -- slow
+        for(fd=3; fd<fdmax; fd++) {
+            if (
+                fd != write_fd) {
+                close(fd);
+            }
+        }
+    }
+
+    /* Set signal handlers back to the default.  Do this close to
+       the exev() because the event library may (and likely will)
+       reset them.  If we don't do this, the event library may
+       have left some set that, at least on some OS's, don't get
+       reset via fork() or exec().  Hence, the launched process
+       could be unkillable (for example). */
+
+    set_handler_linux(SIGTERM);
+    set_handler_linux(SIGINT);
+    set_handler_linux(SIGHUP);
+    set_handler_linux(SIGPIPE);
+    set_handler_linux(SIGCHLD);
+
+    /* Unblock all signals, for many of the same reasons that we
+       set the default handlers, above.  This is noticable on
+       Linux where the event library blocks SIGTERM, but we don't
+       want that blocked by the launched process. */
+    sigprocmask(0, 0, &sigs);
+    sigprocmask(SIG_UNBLOCK, &sigs, 0);
+
+    /* take us to the correct wdir */
+    if (NULL != app->cwd) {
+        if (0 != chdir(app->cwd)) {
+            send_error_show_help(write_fd, 1,
+                                 "help-pfexec-linux.txt",
+                                 "wdir-not-found",
+                                 "pmixd",
+                                 app->cwd,
+                                 pmix_globals.hostname);
+            /* Does not return */
+        }
+    }
+
+    /* Exec the new executable */
+    execve(app->cmd, app->argv, env);
+    errval = errno;
+    getcwd(dir, sizeof(dir));
+    send_error_show_help(write_fd, 1,
+                         "help-pfexec-linux.txt", "execve error",
+                         pmix_globals.hostname, dir, app->cmd, strerror(errval));
+    /* Does not return */
+}
+
+
+static pmix_status_t do_parent(pmix_app_t *app, pmix_pfexec_child_t *child, int read_fd)
+{
+    pmix_status_t rc;
+    pmix_pfexec_pipe_err_msg_t msg;
+    char file[PMIX_PFEXEC_MAX_FILE_LEN + 1], topic[PMIX_PFEXEC_MAX_TOPIC_LEN + 1], *str = NULL;
+
+    if (child->opts.connect_stdin) {
+        close(child->opts.p_stdin[0]);
+    }
+    close(child->opts.p_stdout[1]);
+    close(child->opts.p_stderr[1]);
+
+    /* Block reading a message from the pipe */
+    while (1) {
+        rc = pmix_fd_read(read_fd, sizeof(msg), &msg);
+
+        /* If the pipe closed, then the child successfully launched */
+        if (PMIX_ERR_TIMEOUT == rc) {
+            break;
+        }
+
+        /* If Something Bad happened in the read, error out */
+        if (PMIX_SUCCESS != rc) {
+            PMIX_ERROR_LOG(rc);
+            close(read_fd);
+            return rc;
+        }
+
+        /* Read in the strings; ensure to terminate them with \0 */
+        if (msg.file_str_len > 0) {
+            rc = pmix_fd_read(read_fd, msg.file_str_len, file);
+            if (PMIX_SUCCESS != rc) {
+                pmix_show_help("help-pfexec-linux.txt", "syscall fail",
+                               true,
+                               pmix_globals.hostname, app->cmd,
+                               "pmix_fd_read", __FILE__, __LINE__);
+                return rc;
+            }
+            file[msg.file_str_len] = '\0';
+        }
+        if (msg.topic_str_len > 0) {
+            rc = pmix_fd_read(read_fd, msg.topic_str_len, topic);
+            if (PMIX_SUCCESS != rc) {
+                pmix_show_help("help-pfexec-linux.txt", "syscall fail",
+                               true,
+                               pmix_globals.hostname, app->cmd,
+                               "pmix_fd_read", __FILE__, __LINE__);
+                return rc;
+            }
+            topic[msg.topic_str_len] = '\0';
+        }
+        if (msg.msg_str_len > 0) {
+            str = calloc(1, msg.msg_str_len + 1);
+            if (NULL == str) {
+                pmix_show_help("help-pfexec-linux.txt", "syscall fail",
+                               true,
+                               pmix_globals.hostname, app->cmd,
+                               "pmix_fd_read", __FILE__, __LINE__);
+                return rc;
+            }
+            rc = pmix_fd_read(read_fd, msg.msg_str_len, str);
+        }
+
+        /* Print out what we got.  We already have a rendered string,
+           so use pmix_show_help_norender(). */
+        if (msg.msg_str_len > 0) {
+            fprintf(stderr, "%s\n", str);
+            free(str);
+            str = NULL;
+        }
+
+        /* If msg.fatal is true, then the child exited with an error.
+           Otherwise, whatever we just printed was a warning, so loop
+           around and see what else is on the pipe (or if the pipe
+           closed, indicating that the child launched
+           successfully). */
+        if (msg.fatal) {
+            close(read_fd);
+            return PMIX_ERR_SYS_OTHER;
+        }
+    }
+
+    /* If we got here, it means that the pipe closed without
+       indication of a fatal error, meaning that the child process
+       launched successfully. */
+    close(read_fd);
+    return PMIX_SUCCESS;
+}
+
+
+/**
+ *  Fork/exec the specified processes
+ */
+static int fork_proc(pmix_app_t *app, pmix_pfexec_child_t *child, char **env)
+{
+    int p[2];
+
+    /* A pipe is used to communicate between the parent and child to
+       indicate whether the exec ultimately succeeded or failed.  The
+       child sets the pipe to be close-on-exec; the child only ever
+       writes anything to the pipe if there is an error (e.g.,
+       executable not found, exec() fails, etc.).  The parent does a
+       blocking read on the pipe; if the pipe closed with no data,
+       then the exec() succeeded.  If the parent reads something from
+       the pipe, then the child was letting us know why it failed. */
+    if (pipe(p) < 0) {
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+        return PMIX_ERR_SYS_OTHER;
+    }
+
+    /* Fork off the child */
+    child->pid = fork();
+
+    if (child->pid < 0) {
+        PMIX_ERROR_LOG(PMIX_ERR_SYS_OTHER);
+        return PMIX_ERR_SYS_OTHER;
+    }
+
+    if (child->pid == 0) {
+        close(p[0]);
+        do_child(app, env, child, p[1]);
+        /* Does not return */
+    }
+
+    close(p[1]);
+    return do_parent(app, child, p[0]);
+}
+
+
+/**
+ * Launch all processes allocated to the current node.
+ */
+
+static pmix_status_t spawn_proc(const pmix_info_t job_info[], size_t ninfo,
+                                const pmix_app_t apps[], size_t napps)
+{
+    pmix_status_t rc;
+    pmix_lock_t mylock;
+    pmix_pfexec_fork_caddy_t *scd;
+
+    pmix_output_verbose(5, pmix_pfexec_base_framework.framework_output,
+                        "%s pfexec:linux spawning child job",
+                        PMIX_NAME_PRINT(&pmix_globals.myid));
+
+    PMIX_CONSTRUCT_LOCK(&mylock);
+    PMIX_PFEXEC_SPAWN(scd, job_info, ninfo, apps, napps, fork_proc, (void*)&mylock);
+    PMIX_WAIT_THREAD(&mylock);
+    if (PMIX_SUCCESS == mylock.status) {
+        mylock.status = PMIX_OPERATION_SUCCEEDED;
+    }
+    rc = mylock.status;
+    PMIX_DESTRUCT_LOCK(&mylock);
+    PMIX_RELEASE(scd);
+
+    return rc;
+}

--- a/src/mca/pfexec/linux/pfexec_linux.h
+++ b/src/mca/pfexec/linux/pfexec_linux.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file:
+ */
+
+#ifndef PMIX_PFEXEC_LINUX_H
+#define PMIX_PFEXEC_LINUX_H
+
+#include "pmix_config.h"
+
+#include "src/mca/mca.h"
+
+#include "src/mca/pfexec/pfexec.h"
+
+BEGIN_C_DECLS
+
+/*
+ * PFEXEC Linux module
+ */
+extern pmix_pfexec_base_module_t pmix_pfexec_linux_module;
+extern pmix_pfexec_base_component_t mca_pfexec_linux_component;
+
+END_C_DECLS
+
+#endif /* PMIX_PFEXEC_H */

--- a/src/mca/pfexec/linux/pfexec_linux_component.c
+++ b/src/mca/pfexec/linux/pfexec_linux_component.c
@@ -1,0 +1,98 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#include <ctype.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/pfexec/pfexec.h"
+#include "src/mca/pfexec/linux/pfexec_linux.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+
+pmix_pfexec_base_component_t mca_pfexec_linux_component = {
+    /* First, the mca_component_t struct containing meta information
+    about the component itself */
+    .version = {
+        PMIX_PFEXEC_BASE_VERSION_1_0_0,
+        /* Component name and version */
+        .pmix_mca_component_name = "linux",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_query_component = component_query,
+    },
+};
+
+
+
+static pmix_status_t component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_close(void)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    /* the base open/select logic protects us against operation when
+     * we are NOT in a daemon, so we don't have to check that here
+     */
+
+    /* we have built some logic into the configure.m4 file that checks
+     * to see if we have "fork" support and only builds this component
+     * if we do. Hence, we only get here if we CAN build - in which
+     * case, we definitely should be considered for selection
+     */
+    *priority = 10; /* let others override us - we are the linux */
+    *module = (pmix_mca_base_module_t *) &pmix_pfexec_linux_module;
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pfexec/pfexec.h
+++ b/src/mca/pfexec/pfexec.h
@@ -1,0 +1,92 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2011-2015 Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/**
+ * @file
+ *
+ * The PMIx Fork/Exec Subsystem
+ *
+ */
+
+#ifndef PMIX_MCA_PFEXEC_H
+#define PMIX_MCA_PFEXEC_H
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+#include "src/include/types.h"
+
+#include "src/mca/mca.h"
+
+BEGIN_C_DECLS
+
+/*
+ * pfexec module functions
+ */
+
+/**
+ * Locally fork/exec the provided process
+ */
+typedef pmix_status_t (*pmix_pfexec_base_module_spawn_process_fn_t)(const pmix_info_t job_info[], size_t ninfo,
+                                                                    const pmix_app_t apps[], size_t napps);
+
+/**
+ * Kill the local process we started
+ */
+typedef pmix_status_t (*pmix_pfexec_base_module_kill_process_fn_t)(pmix_rank_t rank);
+
+/**
+ * Signal local process we started
+ */
+typedef pmix_status_t (*pmix_pfexec_base_module_signal_process_fn_t)(pmix_rank_t rank, int signum);
+
+/**
+ * pfexec module version
+ */
+typedef struct {
+    pmix_pfexec_base_module_spawn_process_fn_t       spawn_proc;
+    pmix_pfexec_base_module_kill_process_fn_t        kill_proc;
+    pmix_pfexec_base_module_signal_process_fn_t      signal_proc;
+} pmix_pfexec_base_module_t;
+
+/**
+ * pfexec component
+ */
+typedef struct {
+    /** component version */
+    pmix_mca_base_component_t version;
+    /** component data */
+    pmix_mca_base_component_data_t base_data;
+} pmix_pfexec_base_component_t;
+
+
+/**
+ * Macro for use in modules that are of type pfexec
+ */
+#define PMIX_PFEXEC_BASE_VERSION_1_0_0 \
+    PMIX_MCA_BASE_VERSION_1_0_0("pfexec", 1, 0, 0)
+
+/* Global structure for accessing PFEXEC functions
+*/
+PMIX_EXPORT extern pmix_pfexec_base_module_t pmix_pfexec;  /* holds selected module's function pointers */
+
+END_C_DECLS
+
+#endif /* MCA_PFEXEC_H */

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -337,6 +337,14 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env)
  * tool connections - in that case, we will take a non-loopback
  * device by default, if one is available after filtering directives
  *
+ * If we are a tool and were give a rendezvous file, then we first
+ * check to see if it already exists. If it does, then this is the
+ * connection info we are to use. If it doesn't, then this is the
+ * name of the file we are to use to store our listener info.
+ *
+ * If we are a server and are given a rendezvous file, then that is
+ * is the name of the file we are to use to store our listener info.
+ *
  * NOTE: we accept MCA parameters, but info keys override them
  */
 static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -279,6 +279,14 @@ static pmix_status_t component_open(void)
         0 != strcmp(mca_ptl_tcp_component.report_uri, "+")) {
         urifile = strdup(mca_ptl_tcp_component.report_uri);
     }
+
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (NULL != (tdir = getenv("PMIX_LAUNCHER_RENDEZVOUS_FILE"))) {
+            mca_ptl_tcp_component.rendezvous_filename = strdup(tdir);
+        }
+    }
+
     return PMIX_SUCCESS;
 }
 
@@ -424,6 +432,9 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
                 system_tool = PMIX_INFO_TRUE(&info[n]);
             } else if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer) &&
                        PMIX_CHECK_KEY(&info[n], PMIX_LAUNCHER_RENDEZVOUS_FILE)) {
+                if (NULL != mca_ptl_tcp_component.rendezvous_filename) {
+                    free(mca_ptl_tcp_component.rendezvous_filename);
+                }
                 mca_ptl_tcp_component.rendezvous_filename = strdup(info[n].value.data.string);
             }
         }
@@ -689,7 +700,15 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     /* if we were given a rendezvous file, then drop it */
     if (NULL != mca_ptl_tcp_component.rendezvous_filename) {
         FILE *fp;
-
+        /* if we are a tool and the file already exists, then we
+         * just use it as providing the rendezvous info for our
+         * server */
+        if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+            struct stat buf;
+            if (0 == stat(mca_ptl_tcp_component.rendezvous_filename, &buf)) {
+                goto nextstep;
+            }
+        }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "WRITING RENDEZVOUS FILE %s",
                             mca_ptl_tcp_component.rendezvous_filename);
@@ -718,6 +737,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
         }
     }
 
+  nextstep:
     /* if we are going to support tools, then drop contact file(s) */
     if (system_tool) {
         FILE *fp;

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2018      IBM Corporation.  All rights reserved.
@@ -150,7 +150,11 @@ pmix_status_t component_close(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
+    if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
     *module = (pmix_mca_base_module_t*)&pmix_ptl_usock_module;
+    *priority = mca_ptl_usock_component.super.priority;
     return PMIX_SUCCESS;
 }
 

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -166,6 +166,7 @@ int pmix_rte_init(pmix_proc_type_t type,
     /* setup the globals structure */
     gethostname(hostname, PMIX_MAXHOSTNAMELEN);
     pmix_globals.hostname = strdup(hostname);
+    pmix_globals.pid = getpid();
     memset(&pmix_globals.myid.nspace, 0, PMIX_MAX_NSLEN+1);
     pmix_globals.myid.rank = PMIX_RANK_INVALID;
     PMIX_CONSTRUCT(&pmix_globals.events, pmix_events_t);
@@ -302,6 +303,10 @@ int pmix_rte_init(pmix_proc_type_t type,
     }
 
     /* open the ptl and select the active plugins */
+    if (NULL != (evar = getenv("PMIX_PTL_MODULE"))) {
+        /* convert to an MCA param, but don't overwrite something already there */
+        pmix_setenv("PMIX_MCA_ptl", evar, false, &environ);
+    }
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_ptl_base_framework, 0)) ) {
         error = "pmix_ptl_base_open";
         goto return_error;
@@ -317,6 +322,10 @@ int pmix_rte_init(pmix_proc_type_t type,
     }
 
     /* open the psec and select the active plugins */
+    if (NULL != (evar = getenv("PMIX_SECURITY_MODE"))) {
+        /* convert to an MCA param, but don't overwrite something already there */
+        pmix_setenv("PMIX_MCA_psec", evar, false, &environ);
+    }
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_psec_base_framework, 0))) {
         error = "pmix_psec_base_open";
         goto return_error;
@@ -327,6 +336,10 @@ int pmix_rte_init(pmix_proc_type_t type,
     }
 
     /* open the gds and select the active plugins */
+    if (NULL != (evar = getenv("PMIX_GDS_MODULE"))) {
+        /* convert to an MCA param, but don't overwrite something already there */
+        pmix_setenv("PMIX_MCA_gds", evar, false, &environ);
+    }
     if (PMIX_SUCCESS != (ret = pmix_mca_base_framework_open(&pmix_gds_base_framework, 0)) ) {
         error = "pmix_gds_base_open";
         goto return_error;

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -59,6 +59,7 @@
 #include "src/runtime/pmix_rte.h"
 #include "src/mca/bfrops/base/base.h"
 #include "src/mca/gds/base/base.h"
+#include "src/mca/pfexec/base/base.h"
 #include "src/mca/pnet/base/base.h"
 #include "src/mca/ptl/base/base.h"
 #include "src/mca/psec/psec.h"
@@ -265,6 +266,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     bool nspace_in_enviro = false;
     bool rank_given = false;
     bool fwd_stdin = false;
+    bool connect_optional = false;
     pmix_info_t ginfo;
     size_t n;
     pmix_ptl_posted_recv_t *rcv;
@@ -321,13 +323,17 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
                 rank_given = true;
             } else if (0 == strncmp(info[n].key, PMIX_FWD_STDIN, PMIX_MAX_KEYLEN)) {
                 /* they want us to forward our stdin to someone */
-                fwd_stdin = true;
+                fwd_stdin = PMIX_INFO_TRUE(&info[n]);
             } else if (0 == strncmp(info[n].key, PMIX_LAUNCHER, PMIX_MAX_KEYLEN)) {
-                ptype |= PMIX_PROC_LAUNCHER;
+                if (PMIX_INFO_TRUE(&info[n])) {
+                    ptype |= PMIX_PROC_LAUNCHER;
+                }
             } else if (0 == strncmp(info[n].key, PMIX_SERVER_TMPDIR, PMIX_MAX_KEYLEN)) {
                 pmix_server_globals.tmpdir = strdup(info[n].value.data.string);
             } else if (0 == strncmp(info[n].key, PMIX_SYSTEM_TMPDIR, PMIX_MAX_KEYLEN)) {
                 pmix_server_globals.system_tmpdir = strdup(info[n].value.data.string);
+            } else if (0 == strncmp(info[n].key, PMIX_TOOL_CONNECT_OPTIONAL, PMIX_MAX_KEYLEN)) {
+                connect_optional = PMIX_INFO_TRUE(&info[n]);
             }
         }
     }
@@ -398,24 +404,6 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
             PMIX_RELEASE_THREAD(&pmix_global_lock);
             return PMIX_ERR_BAD_PARAM;
         }
-    }
-
-    /* if we are a launcher, then we also need to act as a server,
-     * so setup the server-related structures here */
-    if (PMIX_PROC_LAUNCHER_ACT & ptype) {
-        if (PMIX_SUCCESS != (rc = pmix_server_initialize())) {
-            PMIX_ERROR_LOG(rc);
-            if (NULL != nspace) {
-                free(nspace);
-            }
-            if (gdsfound) {
-                PMIX_INFO_DESTRUCT(&ginfo);
-            }
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return rc;
-        }
-        /* setup the function pointers */
-        memset(&pmix_host_server, 0, sizeof(pmix_server_module_t));
     }
 
     /* setup the runtime - this init's the globals,
@@ -571,6 +559,24 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         return PMIX_ERR_INIT;
     }
 
+    /* if we are a launcher, then we also need to act as a server,
+     * so setup the server-related structures here */
+    if (PMIX_PROC_LAUNCHER_ACT & ptype) {
+        if (PMIX_SUCCESS != (rc = pmix_server_initialize())) {
+            PMIX_ERROR_LOG(rc);
+            if (NULL != nspace) {
+                free(nspace);
+            }
+            if (gdsfound) {
+                PMIX_INFO_DESTRUCT(&ginfo);
+            }
+            PMIX_RELEASE_THREAD(&pmix_global_lock);
+            return rc;
+        }
+        /* setup the function pointers */
+        memset(&pmix_host_server, 0, sizeof(pmix_server_module_t));
+    }
+
     if (do_not_connect) {
         /* ensure we mark that we are not connected */
         pmix_globals.connected = false;
@@ -582,9 +588,25 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     } else {
         /* connect to the server */
         rc = pmix_ptl_base_connect_to_peer((struct pmix_peer_t*)pmix_client_globals.myserver, info, ninfo);
-        if (PMIX_SUCCESS != rc){
-            PMIX_RELEASE_THREAD(&pmix_global_lock);
-            return rc;
+        if (PMIX_SUCCESS != rc) {
+            if (!connect_optional) {
+                PMIX_RELEASE_THREAD(&pmix_global_lock);
+                return rc;
+            }
+            /* if connection was optional, then we need to self-assign
+             * a namespace and rank for ourselves. Use our hostname:pid
+             * for the nspace, and rank clearly is 0 */
+            snprintf(pmix_globals.myid.nspace, PMIX_MAX_NSLEN-1, "%s:%lu", pmix_globals.hostname, (unsigned long)pmix_globals.pid);
+            pmix_globals.myid.rank = 0;
+            nspace_given = false;
+            rank_given = false;
+            /* also setup the client myserver to point to ourselves */
+            pmix_client_globals.myserver->nptr->nspace = strdup(pmix_globals.myid.nspace);
+            pmix_client_globals.myserver->info = PMIX_NEW(pmix_rank_info_t);
+            pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_globals.myid.nspace);
+            pmix_client_globals.myserver->info->pname.rank = pmix_globals.myid.rank;
+            pmix_client_globals.myserver->info->uid = pmix_globals.uid;
+            pmix_client_globals.myserver->info->gid = pmix_globals.gid;
         }
     }
     if (!nspace_given) {
@@ -736,7 +758,7 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
         /* quick check to see if we got something back. If this
          * is a launcher that is being executed multiple times
          * in a job-script, then the original registration data
-         * will have been deleted after the first invocation. In
+         * may have been deleted after the first invocation. In
          * such a case, we simply regenerate it locally as it is
          * well-known */
         pmix_cb_t cb;
@@ -768,6 +790,14 @@ PMIX_EXPORT int PMIx_tool_init(pmix_proc_t *proc,
     }
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
+    /* setup the fork/exec framework */
+    if (PMIX_SUCCESS != (rc = pmix_mca_base_framework_open(&pmix_pfexec_base_framework, 0)) ) {
+        return rc;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_pfexec_base_select()) ) {
+        return rc;
+    }
+
     /* if we are acting as a server, then start listening */
     if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         /* start listening for connections */
@@ -790,7 +820,7 @@ pmix_status_t pmix_tool_init_info(void)
     char hostname[PMIX_MAX_NSLEN];
 
     pmix_strncpy(wildcard.nspace, pmix_globals.myid.nspace, PMIX_MAX_NSLEN);
-    wildcard.rank = pmix_globals.myid.rank;
+    wildcard.rank = PMIX_RANK_WILDCARD;
 
     /* the jobid is just our nspace */
     kptr = PMIX_NEW(pmix_kval_t);
@@ -1145,8 +1175,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     /* flush anything that is still trying to be written out */
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stdout);
     pmix_iof_static_dump_output(&pmix_client_globals.iof_stderr);
-    PMIX_DESTRUCT(&pmix_client_globals.iof_stdout);
-    PMIX_DESTRUCT(&pmix_client_globals.iof_stderr);
 
     /* if we are connected, then disconnect */
     if (pmix_globals.connected) {
@@ -1230,6 +1258,7 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
     }
 
     /* shutdown services */
+    (void)pmix_mca_base_framework_close(&pmix_pfexec_base_framework);
     pmix_rte_finalize();
     if (NULL != pmix_globals.mypeer) {
         PMIX_RELEASE(pmix_globals.mypeer);

--- a/src/util/Makefile.include
+++ b/src/util/Makefile.include
@@ -51,7 +51,9 @@ headers += \
         util/name_fns.h \
         util/net.h \
         util/pif.h \
-        util/parse_options.h
+        util/parse_options.h \
+        util/context_fns.h \
+        util/pmix_pty.h
 
 sources += \
         util/alfg.c \
@@ -76,7 +78,9 @@ sources += \
         util/name_fns.c \
         util/net.c \
         util/pif.c \
-        util/parse_options.c
+        util/parse_options.c \
+        util/context_fns.c \
+        util/pmix_pty.c
 
 libpmix_la_LIBADD += \
         util/keyval/libpmixutilkeyval.la

--- a/src/util/context_fns.c
+++ b/src/util/context_fns.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2008 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2008-2010 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+#include <string.h>
+#include <stdlib.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_NETDB_H
+#include <netdb.h>
+#endif
+#include <errno.h>
+
+#include "src/util/basename.h"
+#include "src/util/path.h"
+#include "src/util/pmix_environ.h"
+
+#include "src/util/context_fns.h"
+
+int pmix_util_check_context_cwd(pmix_app_t *app)
+{
+    /* If we want to chdir and the chdir fails (for any reason -- such
+       as if the dir doesn't exist, it isn't a dir, we don't have
+       permissions, etc.), then return error. */
+    if (NULL != app->cwd && 0 != chdir(app->cwd)) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* All happy */
+    return PMIX_SUCCESS;
+}
+
+int pmix_util_check_context_app(pmix_app_t *app, char **env)
+{
+    char *tmp;
+
+    /* Here's the possibilities:
+
+        1. The caller specified an absolute pathname for the executable.
+        We simply need to verify that it exists and we can run it.
+
+        2. The caller specified a relative pathname for the executable.
+        Ditto with #1 -- based on the cwd, we need to verify that it
+        exists and we can run it.
+
+        3. The caller specified a naked filename.  We need to search the
+        path, find a match, and verify that we can run it.
+    */
+
+    tmp = pmix_basename(app->cmd);
+    if (strlen(tmp) == strlen(app->cmd)) {
+        /* If this is a naked executable -- no relative or absolute
+        pathname -- then search the PATH for it */
+        free(tmp);
+        tmp = pmix_path_findv(app->cmd, X_OK, env, app->cwd);
+        if (NULL == tmp) {
+            return PMIX_ERR_NOT_FOUND;
+        }
+        free(app->cmd);
+        app->cmd = tmp;
+    } else {
+        free(tmp);
+        if (0 != access(app->cmd, X_OK)) {
+            return PMIX_ERR_NO_PERMISSIONS;
+        }
+    }
+
+    /* All was good */
+    return PMIX_SUCCESS;
+}

--- a/src/util/context_fns.h
+++ b/src/util/context_fns.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2008      Sun Microsystems, Inc.  All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/** @file:
+ *
+ */
+
+#ifndef _PMIX_CONTEXT_FNS_H_
+#define _PMIX_CONTEXT_FNS_H_
+
+#include "pmix_config.h"
+#include "pmix_common.h"
+
+BEGIN_C_DECLS
+
+PMIX_EXPORT int pmix_util_check_context_app(pmix_app_t *app, char **env);
+
+PMIX_EXPORT int pmix_util_check_context_cwd(pmix_app_t *app);
+
+END_C_DECLS
+#endif

--- a/src/util/pmix_pty.c
+++ b/src/util/pmix_pty.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2018      Cisco Systems, Inc.  All rights reserved
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/*-
+ * Copyright (c) 1990, 1993
+ *      The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 4. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <src/include/pmix_config.h>
+
+#ifdef HAVE_SYS_CDEFS_H
+# include <sys/cdefs.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#include <sys/stat.h>
+#ifdef HAVE_SYS_IOCTL_H
+#include <sys/ioctl.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_TERMIOS_H
+# include <termios.h>
+#else
+# ifdef HAVE_TERMIO_H
+#  include <termio.h>
+# endif
+#endif
+#include <errno.h>
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
+#include <stdio.h>
+# include <string.h>
+#ifdef HAVE_GRP_H
+#include <grp.h>
+#endif
+#ifdef HAVE_PTY_H
+#include <pty.h>
+#endif
+#ifdef HAVE_UTMP_H
+#include <utmp.h>
+#endif
+
+#ifdef HAVE_PTSNAME
+# include <stdlib.h>
+# ifdef HAVE_STROPTS_H
+#  include <stropts.h>
+# endif
+#endif
+
+#ifdef HAVE_UTIL_H
+#include <util.h>
+#endif
+
+#include "src/util/pmix_pty.h"
+
+/* The only public interface is openpty - all others are to support
+   openpty() */
+
+#if PMIX_ENABLE_PTY_SUPPORT == 0
+
+int pmix_openpty(int *amaster, int *aslave, char *name,
+                 void *termp, void *winpp)
+{
+    return -1;
+}
+
+#elif defined(HAVE_OPENPTY)
+
+int pmix_openpty(int *amaster, int *aslave, char *name,
+                 struct termios *termp, struct winsize *winp)
+{
+    return openpty(amaster, aslave, name, termp, winp);
+}
+
+#else
+
+/* implement openpty in terms of ptym_open and ptys_open */
+
+static int ptym_open(char *pts_name);
+static int ptys_open(int fdm, char *pts_name);
+
+int pmix_openpty(int *amaster, int *aslave, char *name,
+                 struct termios *termp, struct winsize *winp)
+{
+    char line[20];
+    *amaster = ptym_open(line);
+    if (*amaster < 0) {
+        return -1;
+    }
+    *aslave = ptys_open(*amaster, line);
+    if (*aslave < 0) {
+        close(*amaster);
+        return -1;
+    }
+    if (name) {
+        // We don't know the max length of name, but we do know the
+        // max length of the source, so at least use that.
+        pmix_string_copy(name, line, sizeof(line));
+    }
+#ifndef TCSAFLUSH
+#define TCSAFLUSH TCSETAF
+#endif
+    if (termp) {
+        (void) tcsetattr(*aslave, TCSAFLUSH, termp);
+    }
+#ifdef TIOCSWINSZ
+    if (winp) {
+        (void) ioctl(*aslave, TIOCSWINSZ, (char *) winp);
+    }
+#endif
+    return 0;
+}
+
+
+static int ptym_open(char *pts_name)
+{
+    int fdm;
+#ifdef HAVE_PTSNAME
+    char *ptr;
+
+#ifdef _AIX
+    strcpy(pts_name, "/dev/ptc");
+#else
+    strcpy(pts_name, "/dev/ptmx");
+#endif
+    fdm = open(pts_name, O_RDWR);
+    if (fdm < 0) {
+        return -1;
+    }
+    if (grantpt(fdm) < 0) {     /* grant access to slave */
+        close(fdm);
+        return -2;
+    }
+    if (unlockpt(fdm) < 0) {    /* clear slave's lock flag */
+        close(fdm);
+        return -3;
+    }
+    ptr = ptsname(fdm);
+    if (ptr == NULL) {          /* get slave's name */
+        close(fdm);
+        return -4;
+    }
+    strcpy(pts_name, ptr);      /* return name of slave */
+    return fdm;                 /* return fd of master */
+#else
+    char *ptr1, *ptr2;
+
+    strcpy(pts_name, "/dev/ptyXY");
+    /* array index: 012345689 (for references in following code) */
+    for (ptr1 = "pqrstuvwxyzPQRST"; *ptr1 != 0; ptr1++) {
+        pts_name[8] = *ptr1;
+        for (ptr2 = "0123456789abcdef"; *ptr2 != 0; ptr2++) {
+            pts_name[9] = *ptr2;
+            /* try to open master */
+            fdm = open(pts_name, O_RDWR);
+            if (fdm < 0) {
+                if (errno == ENOENT) {  /* different from EIO */
+                    return -1;  /* out of pty devices */
+                } else {
+                    continue;   /* try next pty device */
+                }
+            }
+            pts_name[5] = 't';  /* chage "pty" to "tty" */
+            return fdm;         /* got it, return fd of master */
+        }
+    }
+    return -1;                  /* out of pty devices */
+#endif
+}
+
+
+static int ptys_open(int fdm, char *pts_name)
+{
+    int fds;
+#ifdef HAVE_PTSNAME
+    /* following should allocate controlling terminal */
+    fds = open(pts_name, O_RDWR);
+    if (fds < 0) {
+        close(fdm);
+        return -5;
+    }
+#if defined(__SVR4) && defined(__sun)
+    if (ioctl(fds, I_PUSH, "ptem") < 0) {
+        close(fdm);
+        close(fds);
+        return -6;
+    }
+    if (ioctl(fds, I_PUSH, "ldterm") < 0) {
+        close(fdm);
+        close(fds);
+        return -7;
+    }
+#endif
+
+    return fds;
+#else
+    int gid;
+    struct group *grptr;
+
+    grptr = getgrnam("tty");
+    if (grptr != NULL) {
+        gid = grptr->gr_gid;
+    } else {
+        gid = -1;               /* group tty is not in the group file */
+    }
+    /* following two functions don't work unless we're root */
+    chown(pts_name, getuid(), gid);
+    chmod(pts_name, S_IRUSR | S_IWUSR | S_IWGRP);
+    fds = open(pts_name, O_RDWR);
+    if (fds < 0) {
+        close(fdm);
+        return -1;
+    }
+    return fds;
+#endif
+}
+
+#endif /* #ifdef HAVE_OPENPTY */

--- a/src/util/pmix_pty.h
+++ b/src/util/pmix_pty.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2004-2006 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2019      Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_UTIL_PTY_H
+#define PMIX_UTIL_PTY_H
+
+#include <src/include/pmix_config.h>
+#include "pmix_common.h"
+
+#ifdef HAVE_UTIL_H
+#include <util.h>
+#endif
+#ifdef HAVE_LIBUTIL_H
+#include <libutil.h>
+#endif
+#ifdef HAVE_TERMIOS_H
+# include <termios.h>
+#else
+# ifdef HAVE_TERMIO_H
+#  include <termio.h>
+# endif
+#endif
+
+BEGIN_C_DECLS
+
+#if PMIX_ENABLE_PTY_SUPPORT
+
+PMIX_EXPORT int pmix_openpty(int *amaster, int *aslave, char *name,
+                             struct termios *termp, struct winsize *winp);
+
+#else
+
+PMIX_EXPORT int pmix_openpty(int *amaster, int *aslave, char *name,
+                             void *termp, void *winpp);
+
+#endif
+
+END_C_DECLS
+
+#endif /* PMIX_UTIL_PTY_H */

--- a/src/util/show_help.c
+++ b/src/util/show_help.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2008      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,15 +48,6 @@ static char **search_dirs = NULL;
 /*
  * Local functions
  */
-static int pmix_show_vhelp_internal(const char *filename, const char *topic,
-                                    int want_error_header, va_list arglist);
-static int pmix_show_help_internal(const char *filename, const char *topic,
-                                   int want_error_header, ...);
-
-pmix_show_help_fn_t pmix_show_help = pmix_show_help_internal;
-pmix_show_vhelp_fn_t pmix_show_vhelp = pmix_show_vhelp_internal;
-
-
 int pmix_show_help_init(void)
 {
     pmix_output_stream_t lds;
@@ -337,8 +328,8 @@ char *pmix_show_help_string(const char *filename, const char *topic,
     return output;
 }
 
-static int pmix_show_vhelp_internal(const char *filename, const char *topic,
-                                    int want_error_header, va_list arglist)
+int pmix_show_vhelp(const char *filename, const char *topic,
+                    int want_error_header, va_list arglist)
 {
     char *output;
 
@@ -355,18 +346,25 @@ static int pmix_show_vhelp_internal(const char *filename, const char *topic,
     return (NULL == output) ? PMIX_ERROR : PMIX_SUCCESS;
 }
 
-static int pmix_show_help_internal(const char *filename, const char *topic,
-                                   int want_error_header, ...)
+int pmix_show_help(const char *filename, const char *topic,
+                   int want_error_header, ...)
 {
     va_list arglist;
-    int rc;
+    char *output;
 
-    /* Convert it to a single string */
     va_start(arglist, want_error_header);
-    rc = pmix_show_vhelp(filename, topic, want_error_header, arglist);
+    output = pmix_show_help_vstring(filename, topic, want_error_header,
+                                    arglist);
     va_end(arglist);
 
-    return rc;
+    /* If nothing came back, there's nothing to do */
+    if (NULL == output) {
+        return PMIX_SUCCESS;
+    }
+
+    fprintf(stderr, "%s\n", output);
+    free(output);
+    return PMIX_SUCCESS;
 }
 
 int pmix_show_help_add_dir(const char *directory)

--- a/src/util/show_help.h
+++ b/src/util/show_help.h
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2008-2011 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -135,17 +135,15 @@ PMIX_EXPORT int pmix_show_help_finalize(void);
  * promotion to va_start() has undefined behavior (according to clang
  * warnings on MacOS High Sierra).
  */
-typedef int (*pmix_show_help_fn_t)(const char *filename, const char *topic,
-                                   int want_error_header, ...);
-PMIX_EXPORT extern pmix_show_help_fn_t pmix_show_help;
+PMIX_EXPORT int pmix_show_help(const char *filename, const char *topic,
+                               int want_error_header, ...);
 
 /**
  * This function does the same thing as pmix_show_help(), but accepts
  * a va_list form of varargs.
  */
-typedef int (*pmix_show_vhelp_fn_t)(const char *filename, const char *topic,
-                                    int want_error_header, va_list ap);
-PMIX_EXPORT extern pmix_show_vhelp_fn_t pmix_show_vhelp;
+PMIX_EXPORT int pmix_show_vhelp(const char *filename, const char *topic,
+                                int want_error_header, va_list ap);
 
 /**
  * This function does the same thing as pmix_show_help(), but returns


### PR DESCRIPTION
Tools such as debuggers need the ability to execute a local fork/exec of
a subprocess - e.g., a launcher such as "prun" - when operating in an
environment where there is no PMIx server available. When doing so, the
"child" retains the same nspace as the tool and we simply increment the
rank for each child. Note that this feature is ONLY available when the
tool is not connected to a server or else tracking of proc IDs would
become confused.

Implementing this exposed several errors involving assumptions about
tool-server connectivity that had to be fixed.