### PR TITLE
PTL: Fix connection establishment protocol (with refactoring)

### DIFF
--- a/src/mca/ptl/usock/ptl_usock.c
+++ b/src/mca/ptl/usock/ptl_usock.c
@@ -566,7 +566,7 @@ void pmix_usock_send_handler(int sd, short flags, void *cbdata)
     pmix_peer_t *peer = (pmix_peer_t*)cbdata;
     pmix_ptl_send_t *msg = peer->send_msg;
     pmix_status_t rc;
-    uint32_t nbytes;
+    size_t nbytes;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(peer);

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -601,6 +601,8 @@ static void connection_handler(int sd, short args, void *cbdata)
         psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V21;
     } else if (3 == major) {
         psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V3;
+    } else if (4 == major) {
+        psave->proc_type = PMIX_PROC_CLIENT | PMIX_PROC_V3;
     } else {
         /* we don't recognize this version */
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,


### PR DESCRIPTION
On the server side the folowing messages are sent to the client during connection:
* (4B) Security verification
* (4B) Status
* (4B) Server-local index of the peer

client only receives 2 messgaes:
* (4B) Status
* (4B) Server-local index of the peer

For unknown reason in most of the time extra 4 bytes were consumed by the client.
But sometimes these extra bytes were prepending a valid message shifting tag and
size away and PMIx_Init hangs were observed.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>