### PR TITLE
PTL: Fix connection establishment protocol

### DIFF
--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1389,7 +1389,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     /* the choice of PTL module is obviously us */
     peer->nptr->compat.ptl = &pmix_ptl_tcp_module;
 
-    /* validate the connection */
+    /* validate the connection - the macro will send the status result to the client */
     cred.bytes = pnd->cred;
     cred.size = pnd->len;
     PMIX_PSEC_VALIDATE_CONNECTION(rc, peer, NULL, 0, NULL, NULL, &cred);
@@ -1406,17 +1406,6 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "client connection validated");
 
-    /* tell the client all is good */
-    u32 = htonl(PMIX_SUCCESS);
-    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
-        PMIX_ERROR_LOG(rc);
-        info->proc_cnt--;
-        pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
-        PMIX_RELEASE(peer);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        return;
-    }
       /* send the client's array index */
     u32 = htonl(peer->index);
       if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {


### PR DESCRIPTION
On the server side the folowing messages are sent to the client during connection:
* (4B) Security verification
* (4B) Status
* (4B) Server-local index of the peer

client only receives 2 messgaes:
* (4B) Status
* (4B) Server-local index of the peer

For unknown reason in most of the time extra 4 bytes were consumed by the client.
But sometimes these extra bytes were prepending a valid message shifting tag and
size away and PMIx_Init hangs were observed.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>