### PR TITLE
Travis: Clang and Undefined Behavior Sanitizer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ dist: xenial
 cache:
   apt: true
 
-env:
-  global:
-    # TODO: -Werror
-    # TODOL -fsanitize=address -fsanitize=undefined
-    - CFLAGS: "-Wall -Wextra"
-    - CXXFLAGS: "-Wall -Wextra"
+language: c
 
 addons:
   apt:
@@ -21,8 +16,32 @@ addons:
 jobs:
   fast_finish: true
   include:
-    - script:
+    - compiler: gcc
+      env:
+        - CFLAGS="-Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers -Wno-sign-compare -Wno-missing-braces"
+          ENABLE_WERROR="--enable-werror"
+    - compiler: gcc
+      env:
+        - CFLAGS="-fsanitize=undefined"  # TODO: add -fsanitize=address
+    - compiler: clang
+      env:
+        - CFLAGS="-Wall -Wextra -Wno-unused-function -Wno-unused-parameter -Wno-type-limits -Wno-missing-field-initializers -Wno-sign-compare -Wno-missing-braces"
+          ENABLE_WERROR="--enable-werror"
+    # TODO:
+    #- compiler: clang
+    #  env:
+    #    - CFLAGS="-fsanitize=address"
+    #      ASAN_OPTIONS=detect_stack_use_after_return=1:detect_leaks=1:check_initialization_order=true:strict_init_order=true:detect_stack_use_after_scope=1
+    - compiler: clang
+      env:
+        - CFLAGS="-fsanitize=undefined"
+
+script:
+        # prepare
+        # build
         - ./autogen.pl
-        - ./configure
+        - ./configure ${ENABLE_WERROR}
+        - if [ $? -ne 0 ]; then cat config.log; fi
         - make all
+        # test
         - make check

--- a/configure.ac
+++ b/configure.ac
@@ -248,6 +248,17 @@ AC_MSG_CHECKING([final LIBS])
 AC_MSG_RESULT([$LIBS])
 
 ####################################################################
+# -Werror for CI scripts
+####################################################################
+
+AC_ARG_ENABLE(werror,
+    AC_HELP_STRING([--enable-werror],
+                   [Treat compiler warnings as errors]),
+[
+    CFLAGS="$CFLAGS -Werror"
+])
+
+####################################################################
 # Version information
 ####################################################################
 

--- a/src/common/pmix_iof.h
+++ b/src/common/pmix_iof.h
@@ -209,7 +209,7 @@ pmix_iof_fd_always_ready(int fd)
         if (NULL != (d)) {                                              \
             PMIX_INFO_CREATE((rev)->directives, (nd));                  \
             (rev)->ndirs = (nd);                                        \
-            for (_ii=0; _ii < (nd); _ii++) {                            \
+            for (_ii=0; _ii < (size_t)nd; _ii++) {                      \
                 PMIX_INFO_XFER(&((rev)->directives[_ii]), &((d)[_ii])); \
             }                                                           \
         }                                                               \

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -128,7 +128,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     char *evar, **uri, *suri = NULL, *suri2 = NULL;
     char *filename, *nspace=NULL;
     pmix_rank_t rank = PMIX_RANK_WILDCARD;
-    char *p, *p2, *server_nspace = NULL, *rendfile = NULL;
+    char *p = NULL, *p2, *server_nspace = NULL, *rendfile = NULL;
     int sd, rc;
     size_t n;
     char myhost[PMIX_MAXHOSTNAMELEN];

--- a/src/tools/pattrs/pattrs.c
+++ b/src/tools/pattrs/pattrs.c
@@ -270,7 +270,7 @@ int main(int argc, char **argv)
     pmix_info_t *info;
     mylock_t mylock;
     pmix_cmd_line_t cmd_line;
-    char **fns;
+    char **fns = NULL;
     size_t n, m;
     myquery_data_t mq;
     pmix_query_t query;


### PR DESCRIPTION
Adds Clang compile routines and `-fsantize=undefined` checks to Travis-CI.

Fix small warnings in sign compare and sometimes uninitialized variables.

Over the next development steps, we should try to remove the amount of `-Wno-...` flags provided to CI by fixing the warnings.