### PR TITLE
ptl: Fix message header `nbytes` field ambiguity

### DIFF
--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -110,7 +110,10 @@ typedef uint32_t pmix_ptl_tag_t;
 typedef struct {
     int32_t pindex;
     pmix_ptl_tag_t tag;
-    size_t nbytes;
+    uint32_t nbytes;
+#if SIZEOF_SIZE_T == 8
+    uint32_t padding;
+#endif
 } pmix_ptl_hdr_t;
 
 /* define the messaging cbfunc */


### PR DESCRIPTION
Use fixed 32-bit field to represent the message size as opposed to
floating `size_t` type.
Preserve backward compatibility by adding a padding.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>