### PR TITLE
Correct dmodex example

### DIFF
--- a/examples/dmodex.c
+++ b/examples/dmodex.c
@@ -178,7 +178,6 @@ int main(int argc, char **argv)
         if (0 > asprintf(&tmp, "%s-%d-local", myproc.nspace, n)) {
             exit(1);
         }
-        (void)strncpy(proc.nspace, tmp, PMIX_MAX_NSLEN);
         proc.rank = n;
         if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp,
                                               NULL, 0, valcbfunc, tmp))) {
@@ -189,7 +188,6 @@ int main(int argc, char **argv)
         if (0 > asprintf(&tmp, "%s-%d-remote", myproc.nspace, n)) {
             exit(1);
         }
-        (void)strncpy(proc.nspace, tmp, PMIX_MAX_NSLEN);
         if (PMIX_SUCCESS != (rc = PMIx_Get_nb(&proc, tmp,
                                               NULL, 0, valcbfunc, tmp))) {
             fprintf(stderr, "Client ns %s rank %d: PMIx_Get %s failed: %d\n", myproc.nspace, n, tmp, rc);


### PR DESCRIPTION
Do not load the key into the proc nspace (duh).

Thanks to @krempel-pt for pointing it out.

Fixes #1247

Signed-off-by: Ralph Castain <rhc@pmix.org>