### PR TITLE
PTL/usock: `usock` doesn't support Tools, fail query for this case.

### DIFF
--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -150,6 +150,10 @@ pmix_status_t component_close(void)
 
 static int component_query(pmix_mca_base_module_t **module, int *priority)
 {
+    if (PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+        return PMIX_ERR_NOT_SUPPORTED;
+    }
+
     *module = (pmix_mca_base_module_t*)&pmix_ptl_usock_module;
     return PMIX_SUCCESS;
 }


### PR DESCRIPTION
Port this portion from 6bbbb4bf0 in master.

Signed-off-by: Artem Polyakov <artpol84@gmail.com>