### PR TITLE
Testing PTL handshake

### DIFF
--- a/src/mca/psec/simphandshake/Makefile.am
+++ b/src/mca/psec/simphandshake/Makefile.am
@@ -1,0 +1,55 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2019      Mellanox Technologies, Inc.
+#                         All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = psec_simphandshake.h
+sources = \
+        psec_simphandshake_component.c \
+        psec_simphandshake.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_psec_simphandshake_DSO
+lib =
+lib_sources =
+component = mca_psec_simphandshake.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_psec_simphandshake.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_psec_simphandshake_la_SOURCES = $(component_sources)
+mca_psec_simphandshake_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_psec_simphandshake_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_psec_simphandshake_la_SOURCES = $(lib_sources)
+libmca_psec_simphandshake_la_LDFLAGS = -module -avoid-version

--- a/src/mca/psec/simphandshake/psec_simphandshake.c
+++ b/src/mca/psec/simphandshake/psec_simphandshake.c
@@ -1,0 +1,163 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <unistd.h>
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+
+#include <pmix_common.h>
+
+#include "src/include/pmix_globals.h"
+#include "src/util/error.h"
+#include "src/util/output.h"
+
+#include "src/mca/psec/base/base.h"
+#include "psec_simphandshake.h"
+
+#include "src/mca/ptl/base/base.h"
+
+#define PMIX_PSEC_SIMPLE_HNDSHK_STR "PMIX_PSEC_SIMPLE_HANDSHAKE_STRING"
+
+static pmix_status_t simple_init(void);
+static void simple_finalize(void);
+static pmix_status_t create_cred(struct pmix_peer_t *peer,
+                                 const pmix_info_t directives[], size_t ndirs,
+                                 pmix_info_t **info, size_t *ninfo,
+                                 pmix_byte_object_t *cred);
+static pmix_status_t client_hndshk(int sd);
+static pmix_status_t server_hndshk(int sd);
+
+pmix_psec_module_t pmix_simphandshake_module = {
+    .name = "simphandshake",
+    /** init/finalize */
+    .init = simple_init,
+    .finalize = simple_finalize,
+    /** Client-side */
+    .create_cred = create_cred,
+    .client_handshake = client_hndshk,
+    /** Server-side */
+    .validate_cred = NULL,
+    .server_handshake = server_hndshk
+};
+
+static pmix_status_t simple_init(void)
+{
+    pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
+                        "psec: simple init");
+    return PMIX_SUCCESS;
+}
+
+static void simple_finalize(void)
+{
+    pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
+                        "psec: simple finalize");
+}
+
+static pmix_status_t create_cred(struct pmix_peer_t *peer,
+                                 const pmix_info_t directives[], size_t ndirs,
+                                 pmix_info_t **info, size_t *ninfo,
+                                 pmix_byte_object_t *cred)
+{
+    char mycred[] = "dymmy_cred";
+
+    pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
+                        "psec: simple create_cred");
+
+    /* ensure initialization */
+    PMIX_BYTE_OBJECT_CONSTRUCT(cred);
+
+    cred->bytes = strdup(mycred);
+    cred->size = strlen(mycred) + 1;
+
+    return PMIX_SUCCESS;
+}
+
+static pmix_status_t server_hndshk(int sd)
+{
+    pmix_status_t rc, status = PMIX_SUCCESS;
+    char *hndshk_msg = NULL;
+    size_t size;
+
+    pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
+                        "psec: simple server_hndshk");
+
+    asprintf(&hndshk_msg, "%s", PMIX_PSEC_SIMPLE_HNDSHK_STR);
+    size = strlen(hndshk_msg);
+
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(sd, (char*)&size,
+                                                          sizeof(size)))) {
+        goto exit;
+    }
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(sd, hndshk_msg,
+                                                          size))) {
+        goto exit;
+    }
+
+exit:
+    if (NULL != hndshk_msg) {
+        free(hndshk_msg);
+    }
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_recv_blocking(sd, (char*)&status,
+                                                          sizeof(status)))) {
+        return PMIX_ERROR;
+    }
+    pmix_output(0, "[%s:%d] psec handshake status %d recv from client",
+                __FILE__, __LINE__, status);
+
+    return status;
+}
+
+static pmix_status_t client_hndshk(int sd)
+{
+    char *hndshk_msg = NULL;
+    size_t size;
+    pmix_status_t rc, status = PMIX_SUCCESS;
+
+    pmix_output_verbose(2, pmix_psec_base_framework.framework_output,
+                        "psec: simple client_hndshk");
+
+
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_recv_blocking(sd, (char*)&size,
+                                                          sizeof(size_t)))) {
+        return rc;
+    }
+    hndshk_msg = (char*)malloc(size);
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_recv_blocking(sd, (char*)hndshk_msg,
+                                                          size))) {
+        free(hndshk_msg);
+        return rc;
+    }
+
+    if (size != strlen(PMIX_PSEC_SIMPLE_HNDSHK_STR)) {
+        status = PMIX_ERR_HANDSHAKE_FAILED;
+        goto exit;
+    }
+    if (0 != strncmp(hndshk_msg, PMIX_PSEC_SIMPLE_HNDSHK_STR, size)) {
+        status = PMIX_ERR_HANDSHAKE_FAILED;
+        goto exit;
+    }
+
+exit:
+    if (NULL != hndshk_msg) {
+        free(hndshk_msg);
+    }
+    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(sd, (char*)&status,
+                                                          sizeof(status)))) {
+        return rc;
+    }
+    pmix_output(0, "[%s:%d] psec handshake status %d sent to server",
+                __FILE__, __LINE__, status);
+
+    return status;
+}

--- a/src/mca/psec/simphandshake/psec_simphandshake.h
+++ b/src/mca/psec/simphandshake/psec_simphandshake.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_SIMPLE_H
+#define PMIX_SIMPLE_H
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/mca/psec/psec.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_psec_base_component_t mca_psec_simphandshake_component;
+extern pmix_psec_module_t pmix_simphandshake_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/psec/simphandshake/psec_simphandshake_component.c
+++ b/src/mca/psec/simphandshake/psec_simphandshake_component.c
@@ -1,0 +1,72 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+#include "pmix_common.h"
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/psec/psec.h"
+#include "psec_simphandshake.h"
+
+static pmix_status_t component_open(void);
+static pmix_status_t component_close(void);
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+static pmix_psec_module_t* assign_module(void);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_psec_base_component_t mca_psec_simphandshake_component = {
+    .base = {
+        PMIX_PSEC_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "simphandshake",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_open_component = component_open,
+        .pmix_mca_close_component = component_close,
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+    .assign_module = assign_module
+};
+
+static int component_open(void)
+{
+    return PMIX_SUCCESS;
+}
+
+static int component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 100;
+    *module = (pmix_mca_base_module_t *)&pmix_simphandshake_module;
+    return PMIX_SUCCESS;
+}
+
+
+static int component_close(void)
+{
+    return PMIX_SUCCESS;
+}
+
+static pmix_psec_module_t* assign_module(void)
+{
+    return &pmix_simphandshake_module;
+}


### PR DESCRIPTION
Do not merge this PR, it is intended for testing PTL handshake scenario under CI.
This PR adds a `psec/simple` component, with a handshake implemented.
The priority of `psec/simple` set higher then other psec components to ensure testing the handshake with `psec/simple` in PTL.