### PR TITLE
IPv6 IF Read: Buffer Overflow

### DIFF
--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -80,7 +80,7 @@ static int if_linux_ipv6_open(void)
 {
     FILE *f;
     if ((f = fopen("/proc/net/if_inet6", "r"))) {
-        char ifname[IF_NAMESIZE];
+        char ifname[21];  // note: IF_NAMESIZE might be too small, e.g. 10;
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;
         int iter;


### PR DESCRIPTION
Fix a buffer overflow on some systems on which `IF_NAMESIZE` is defined to 10 but we read 20 chars in `fscanf`.

First seen in #1265.

Note: it's probably better to modify the `fscanf` line instead, e.g. by pre-processor math and pre-processor stringification.