### PR TITLE
examples: swat compiler warnings

### DIFF
--- a/examples/asyncgroup.c
+++ b/examples/asyncgroup.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -126,7 +128,7 @@ static void invitefn(size_t evhdlr_registration_id,
                      void *cbdata)
 {
     size_t n;
-    char *grp;
+    char *grp = NULL;
     pmix_status_t rc;
 
     /* if I am the leader, I can ignore this event */

--- a/examples/fault.c
+++ b/examples/fault.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -45,7 +47,7 @@ static void notification_fn(size_t evhdlr_registration_id,
 {
     myrel_t *lock;
     bool found;
-    int exit_code;
+    int exit_code = 0;
     size_t n;
     pmix_proc_t *affected = NULL;
 

--- a/examples/tool.c
+++ b/examples/tool.c
@@ -15,6 +15,8 @@
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
  * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
+ * Copyright (c) 2019      Triad National Security, LLC. All rights
+ *                         reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -80,7 +82,7 @@ static void release_fn(size_t evhdlr_registration_id,
 {
     myrel_t *lock;
     bool found;
-    int exit_code;
+    int exit_code = 0;
     size_t n;
     pmix_proc_t *affected = NULL;
 


### PR DESCRIPTION
since they show up near the end of the build, they are kind
of noticeable.

Signed-off-by: Howard Pritchard <howardp@lanl.gov>