### PR TITLE
Avoid output_verbose overhead when it won't print

### DIFF
--- a/include/pmix_rename.h.in
+++ b/include/pmix_rename.h.in
@@ -444,6 +444,7 @@
 #define pmix_output_close                                       @PMIX_RENAME@pmix_output_close
 #define pmix_output_finalize                                    @PMIX_RENAME@pmix_output_finalize
 #define pmix_output_get_verbosity                               @PMIX_RENAME@pmix_output_get_verbosity
+#define pmix_output_check_verbosity                             @PMIX_RENAME@pmix_output_check_verbosity
 #define pmix_output_hexdump                                     @PMIX_RENAME@pmix_output_hexdump
 #define pmix_output_init                                        @PMIX_RENAME@pmix_output_init
 #define pmix_output_open                                        @PMIX_RENAME@pmix_output_open
@@ -452,7 +453,6 @@
 #define pmix_output_set_output_file_info                        @PMIX_RENAME@pmix_output_set_output_file_info
 #define pmix_output_set_verbosity                               @PMIX_RENAME@pmix_output_set_verbosity
 #define pmix_output_switch                                      @PMIX_RENAME@pmix_output_switch
-#define pmix_output_verbose                                     @PMIX_RENAME@pmix_output_verbose
 #define pmix_output_vverbose                                    @PMIX_RENAME@pmix_output_vverbose
 #define pmix_path_access                                        @PMIX_RENAME@pmix_path_access
 #define pmix_path_df                                            @PMIX_RENAME@pmix_path_df

--- a/src/util/output.c
+++ b/src/util/output.c
@@ -10,7 +10,7 @@
  * Copyright (c) 2004-2006 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -332,15 +332,10 @@ PMIX_EXPORT void pmix_output(int output_id, const char *format, ...)
 /*
  * Send a message to a stream if the verbose level is high enough
  */
- PMIX_EXPORT void pmix_output_verbose(int level, int output_id, const char *format, ...)
+ PMIX_EXPORT bool pmix_output_check_verbosity(int level, int output_id)
 {
-    if (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS &&
-        info[output_id].ldi_verbose_level >= level) {
-        va_list arglist;
-        va_start(arglist, format);
-        output(output_id, format, arglist);
-        va_end(arglist);
-    }
+    return (output_id >= 0 && output_id < PMIX_OUTPUT_MAX_STREAMS &&
+        info[output_id].ldi_verbose_level >= level);
 }
 
 

--- a/src/util/output.h
+++ b/src/util/output.h
@@ -11,7 +11,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
- * Copyright (c) 2015-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -414,12 +414,13 @@ PMIX_EXPORT void pmix_output(int output_id, const char *format, ...) __pmix_attr
  *
  * @see pmix_output_set_verbosity()
  */
-PMIX_EXPORT void pmix_output_verbose(int verbose_level, int output_id,
-                                     const char *format, ...) __pmix_attribute_format__(__printf__, 3, 4);
+#define pmix_output_verbose(verbose_level, output_id, ...) \
+    if (pmix_output_check_verbosity(verbose_level, output_id)) { \
+        pmix_output(output_id, __VA_ARGS__); \
+    }
 
-/**
-* Same as pmix_output_verbose(), but takes a va_list form of varargs.
-*/
+PMIX_EXPORT bool pmix_output_check_verbosity(int verbose_level, int output_id);
+
 PMIX_EXPORT void pmix_output_vverbose(int verbose_level, int output_id,
                                       const char *format, va_list ap) __pmix_attribute_format__(__printf__, 3, 0);
 


### PR DESCRIPTION
Don't render the output if the verbosity is below the trigger level and
nothing will be output

Signed-off-by: Ralph Castain <rhc@pmix.org>