### PR TITLE
Remove arbitrary limit on linux_ipv6 if_inet6 interface name length

### DIFF
--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -80,20 +80,24 @@ static int if_linux_ipv6_open(void)
 {
     FILE *f;
     if ((f = fopen("/proc/net/if_inet6", "r"))) {
-        char ifname[21];  // note: IF_NAMESIZE might be too small, e.g. 10;
+        char ifname[IF_NAMESIZE];
+        char *ifnameptr;
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;
         int iter;
         uint32_t flag;
         unsigned int addrbyte[16];
 
-        while (fscanf(f, "%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x %x %x %x %x %20s\n",
+        while (fscanf(f, "%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x%2x %x %x %x %x %ms\n",
                       &addrbyte[0], &addrbyte[1], &addrbyte[2], &addrbyte[3],
                       &addrbyte[4], &addrbyte[5], &addrbyte[6], &addrbyte[7],
                       &addrbyte[8], &addrbyte[9], &addrbyte[10], &addrbyte[11],
                       &addrbyte[12], &addrbyte[13], &addrbyte[14], &addrbyte[15],
-                      &idx, &pfxlen, &scope, &dadstat, ifname) != EOF) {
+                      &idx, &pfxlen, &scope, &dadstat, &ifnameptr) != EOF) {
             pmix_pif_t *intf;
+
+            pmix_strncpy(ifname, ifnameptr, IF_NAMESIZE-1);
+            free(ifnameptr);
 
             pmix_output_verbose(1, pmix_pif_base_framework.framework_output,
                                 "found interface %2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x scope %x\n",


### PR DESCRIPTION
Address sanitizer has reported potential stack buffer overflow in the OpenMPI code base (https://github.com/open-mpi/ompi/blob/v4.0.1/opal/mca/if/linux_ipv6/if_linux_ipv6.c#L106). I have found that this issues was already fixed in pmix by #1275, but it added a misleading [comment](https://github.com/pmix/pmix/pull/1275/files#diff-23cc7c5cd65a9ece0cb57339957fb087R83) ([explanation](https://github.com/pmix/pmix/pull/1275#issuecomment-497997915)) so I could not copy it verbatim. Besides, the numbers 21 and 20 used in the current `pif_linux_ipv6.c` do not correspond to the Linux limit on network interface names, which is 15:
https://elixir.bootlin.com/linux/v5.1/source/include/linux/netdevice.h#L1790
https://elixir.bootlin.com/linux/v5.1/source/include/uapi/linux/if.h#L33

The possible fixes include:
1. Hardcode current limits (16 byte buffer, 15 byte name length).
2. Generate correct scanf format string based on `IF_NAMESIZE` in runtime.
3. Generate off-by-one scanf format string based on `IF_NAMESIZE` using the preprocessor.
4. Let scanf allocate the buffer of the right size. (Implemented in this PR.)

The first option has the smallest diff, but it hardcodes two constants.

The second has the largest diff.

The third looks like this:
```c
char ifname[IF_NAMESIZE+1];
scanf("… %x %"STRINGIFY(IF_NAMESIZE)"s\n");
strncpy(intf->if_name, ifname, IF_NAMESIZE+1);
```
This would work in the current pmix codebase which has (surprisingly) increased `pmix_pif_t.if_name` size from `IF_NAMESIZE` to `IF_NAMESIZE+1` in 1e85a0fd58a8aceb2bba5072d8bfa2d00f160081, but it would be incorrect in the OpenMPI codebase which has not.

The forth option involves a dynamic memory allocation, but since it happens at initialization it seems OK.