### PR TITLE
Fix comment: IPv6 IF_NAMESIZE

### DIFF
--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -80,7 +80,9 @@ static int if_linux_ipv6_open(void)
 {
     FILE *f;
     if ((f = fopen("/proc/net/if_inet6", "r"))) {
-        char ifname[21];  // note: IF_NAMESIZE might be too small, e.g. 10;
+        /* IF_NAMESIZE is normally 16 on Linux,
+           but the next scanf allows up to 21 bytes */
+        char ifname[21];
         unsigned int idx, pfxlen, scope, dadstat;
         struct in6_addr a6;
         int iter;


### PR DESCRIPTION
Seams to commonly be defined to 16 in glibc and musl.
Thanks to @orivej for catching this!

Follow-up to #1275