### PR TITLE
Allow servers to pass NULL module

### DIFF
--- a/src/mca/gds/base/gds_base_fns.c
+++ b/src/mca/gds/base/gds_base_fns.c
@@ -80,7 +80,8 @@ pmix_status_t pmix_gds_base_setup_fork(const pmix_proc_t *proc,
         if (NULL == active->module->setup_fork) {
             continue;
         }
-        if (PMIX_SUCCESS != (rc = active->module->setup_fork(proc, env))) {
+        rc = active->module->setup_fork(proc, env);
+        if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_AVAILABLE != rc) {
             return rc;
         }
     }

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -207,7 +207,8 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
 
     PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
         if (NULL != active->module->setup_fork) {
-            if (PMIX_SUCCESS != (rc = active->module->setup_fork(nptr, proc, env))) {
+            rc = active->module->setup_fork(nptr, proc, env);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_NOT_AVAILABLE != rc) {
                 return rc;
             }
         }

--- a/src/server/pmix_server.c
+++ b/src/server/pmix_server.c
@@ -169,6 +169,8 @@ pmix_status_t pmix_server_initialize(void)
     return PMIX_SUCCESS;
 }
 
+static pmix_server_module_t myhostserver = {0};
+
 PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                                            pmix_info_t info[], size_t ninfo)
 {
@@ -197,7 +199,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_init(pmix_server_module_t *module,
                         "pmix:server init called");
 
     /* setup the function pointers */
-    pmix_host_server = *module;
+    if (NULL == module) {
+        pmix_host_server = myhostserver;
+    } else {
+        pmix_host_server = *module;
+    }
 
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {


### PR DESCRIPTION
Servers are not required to pass a function pointer module.

Signed-off-by: Ralph Castain <rhc@pmix.org>