### PR TITLE
Fix potential integer overflow in regex

### DIFF
--- a/src/mca/preg/native/preg_native.c
+++ b/src/mca/preg/native/preg_native.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2018      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -893,7 +893,7 @@ static pmix_status_t regex_parse_value_range(char *base, char *range,
     for (found = false, i = 0; i < len; ++i) {
         if (isdigit((int) range[i])) {
             if (!found) {
-                start = atoi(range + i);
+                start = strtol(range + i, NULL, 10);
                 found = true;
                 break;
             }


### PR DESCRIPTION
Backport of https://github.com/open-mpi/ompi/pull/6739

Signed-off-by: Ralph Castain <rhc@pmix.org>