### PR TITLE
Fix schedular example in python bindings

### DIFF
--- a/bindings/python/sched.py.in
+++ b/bindings/python/sched.py.in
@@ -66,7 +66,7 @@ def main():
     kyvals = {PMIX_NODE_MAP: (regex, PMIX_STRING), PMIX_PROC_MAP: (ppn, PMIX_STRING), PMIX_ALLOC_NETWORK: (darray, PMIX_DATA_ARRAY)}
 
     appinfo = []
-    rc = foo.setup_application("SIMPSCHED", kyvals, appinfo)
+    rc, appinfo = foo.setup_application("SIMPSCHED", kyvals)
     print("SETUPAPP: ", appinfo)
 
     rc = foo.setup_local_support("SIMPSCHED", appinfo)


### PR DESCRIPTION
The setup_application call only requires two arguments, and was
being passed three. This fix removes the appinfo from the call,
and stores the returned list from setup_application in appinfo.