### PR TITLE
Update the tool handshake procedure to match v3.1 series

### DIFF
--- a/src/mca/ptl/base/ptl_base_frame.c
+++ b/src/mca/ptl/base/ptl_base_frame.c
@@ -11,7 +11,7 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015-2017 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * $COPYRIGHT$
@@ -198,9 +198,13 @@ PMIX_EXPORT PMIX_CLASS_INSTANCE(pmix_ptl_sr_t,
 
 static void pccon(pmix_pending_connection_t *p)
 {
+    p->sd = 0;
+    p->need_id = false;
+    p->flag = 0;
     memset(p->nspace, 0, PMIX_MAX_NSLEN+1);
     p->info = NULL;
     p->ninfo = 0;
+    p->peer = NULL;
     p->bfrops = NULL;
     p->psec = NULL;
     p->gds = NULL;

--- a/src/mca/ptl/ptl_types.h
+++ b/src/mca/ptl/ptl_types.h
@@ -12,7 +12,7 @@
  *                         All rights reserved.
  * Copyright (c) 2007-2011 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2012-2013 Los Alamos National Security, Inc. All rights reserved.
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -196,11 +196,14 @@ typedef struct {
     pmix_event_t ev;
     pmix_listener_protocol_t protocol;
     int sd;
+    bool need_id;
+    uint8_t flag;
     char nspace[PMIX_MAX_NSLEN+1];
     pmix_info_t *info;
     size_t ninfo;
     pmix_status_t status;
     struct sockaddr_storage addr;
+    struct pmix_peer_t *peer;
     char *bfrops;
     char *psec;
     char *gds;

--- a/src/mca/ptl/tcp/ptl_tcp.c
+++ b/src/mca/ptl/tcp/ptl_tcp.c
@@ -13,7 +13,8 @@
  * Copyright (c) 2011-2014 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -42,7 +43,12 @@
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
+#ifdef HAVE_DIRENT_H
 #include <dirent.h>
+#endif
+#ifdef HAVE_SYS_SYSCTL_H
+#include <sys/sysctl.h>
+#endif
 
 #include "src/include/pmix_globals.h"
 #include "src/include/pmix_socket_errno.h"
@@ -53,6 +59,7 @@
 #include "src/util/os_path.h"
 #include "src/util/show_help.h"
 #include "src/mca/bfrops/base/base.h"
+#include "src/mca/gds/gds.h"
 
 #include "src/mca/ptl/base/base.h"
 #include "ptl_tcp.h"
@@ -77,8 +84,8 @@ pmix_ptl_module_t pmix_ptl_tcp_module = {
     .connect_to_peer = connect_to_peer
 };
 
-static pmix_status_t recv_connect_ack(int sd);
-static pmix_status_t send_connect_ack(int sd);
+static pmix_status_t recv_connect_ack(int sd, uint8_t myflag);
+static pmix_status_t send_connect_ack(int sd, uint8_t *myflag, pmix_info_t info[], size_t ninfo);
 
 
 static pmix_status_t init(void)
@@ -109,10 +116,11 @@ static pmix_status_t parse_uri_file(char *filename,
                                     char **uri,
                                     char **nspace,
                                     pmix_rank_t *rank);
-static pmix_status_t try_connect(char *uri, int *sd);
+static pmix_status_t try_connect(char *uri, int *sd, pmix_info_t info[], size_t ninfo);
 static pmix_status_t df_search(char *dirname, char *prefix,
+                               pmix_info_t info[], size_t ninfo,
                                int *sd, char **nspace,
-                               pmix_rank_t *rank);
+                               pmix_rank_t *rank, char **uri);
 
 static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                                      pmix_info_t *info, size_t ninfo)
@@ -127,7 +135,12 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     bool system_level = false;
     bool system_level_only = false;
     bool reconnect = false;
-    pid_t pid = 0;
+    pid_t pid = 0, mypid;
+    pmix_list_t ilist;
+    pmix_info_caddy_t *kv;
+    pmix_info_t *iptr = NULL, mypidinfo, launcher;
+    size_t niptr = 0;
+    pmix_kval_t *urikv = NULL;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tcp: connecting to server");
@@ -200,14 +213,16 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         ++p2;
         nspace = strdup(p);
         rank = strtoull(p2, NULL, 10);
+        suri = strdup(uri[1]);
 
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "ptl:tcp:client attempt connect to %s", uri[1]);
 
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(uri[1], &sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(uri[1], &sd, info, ninfo))) {
             free(nspace);
             pmix_argv_free(uri);
+            free(suri);
             return rc;
         }
         pmix_argv_free(uri);
@@ -218,16 +233,17 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
     /* get here if we are a tool - check any provided directives
      * to see where they want us to connect to */
     suri = NULL;
+    PMIX_CONSTRUCT(&ilist, pmix_list_t);
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
-            if (0 == strcmp(info[n].key, PMIX_CONNECT_TO_SYSTEM)) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_TO_SYSTEM)) {
                 system_level_only = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_SYSTEM_FIRST, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_SYSTEM_FIRST)) {
                 /* try the system-level */
                 system_level = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strncmp(info[n].key, PMIX_SERVER_PIDINFO, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_PIDINFO)) {
                 pid = info[n].value.data.pid;
-            } else if (0 == strncmp(info[n].key, PMIX_SERVER_NSPACE, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_NSPACE)) {
                 if (NULL != server_nspace) {
                     /* they included it more than once */
                     if (0 == strcmp(server_nspace, info[n].value.data.string)) {
@@ -242,7 +258,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                     return PMIX_ERR_BAD_PARAM;
                 }
                 server_nspace = strdup(info[n].value.data.string);
-            } else if (0 == strncmp(info[n].key, PMIX_SERVER_URI, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_URI)) {
                 if (NULL != suri) {
                     /* they included it more than once */
                     if (0 == strcmp(suri, info[n].value.data.string)) {
@@ -257,15 +273,47 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                     return PMIX_ERR_BAD_PARAM;
                 }
                 suri = strdup(info[n].value.data.string);
-            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_RETRY_DELAY, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_RETRY_DELAY)) {
                 mca_ptl_tcp_component.wait_to_connect = info[n].value.data.uint32;
-            } else if (0 == strncmp(info[n].key, PMIX_CONNECT_MAX_RETRIES, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_CONNECT_MAX_RETRIES)) {
                 mca_ptl_tcp_component.max_retries = info[n].value.data.uint32;
-            } else if (0 == strncmp(info[n].key, PMIX_RECONNECT_SERVER, PMIX_MAX_KEYLEN)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_RECONNECT_SERVER)) {
                 reconnect = true;
+            } else {
+                /* need to pass this to server */
+                kv = PMIX_NEW(pmix_info_caddy_t);
+                kv->info = &info[n];
+                pmix_list_append(&ilist, &kv->super);
             }
         }
     }
+    /* add our pid to the array */
+    kv = PMIX_NEW(pmix_info_caddy_t);
+    mypid = getpid();
+    PMIX_INFO_LOAD(&mypidinfo, PMIX_PROC_PID, &mypid, PMIX_PID);
+    kv->info = &mypidinfo;
+    pmix_list_append(&ilist, &kv->super);
+
+    /* if I am a launcher, tell them so */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        kv = PMIX_NEW(pmix_info_caddy_t);
+        PMIX_INFO_LOAD(&launcher, PMIX_LAUNCHER, NULL, PMIX_BOOL);
+        kv->info = &launcher;
+        pmix_list_append(&ilist, &kv->super);
+    }
+
+    /* if we need to pass anything, setup an array */
+    if (0 < (niptr = pmix_list_get_size(&ilist))) {
+        PMIX_INFO_CREATE(iptr, niptr);
+        n = 0;
+        while (NULL != (kv = (pmix_info_caddy_t*)pmix_list_remove_first(&ilist))) {
+            PMIX_INFO_XFER(&iptr[n], kv->info);
+            PMIX_RELEASE(kv);
+            ++n;
+        }
+    }
+    PMIX_LIST_DESTRUCT(&ilist);
+
     if (NULL == suri && !reconnect && NULL != mca_ptl_tcp_component.super.uri) {
         suri = strdup(mca_ptl_tcp_component.super.uri);
     }
@@ -288,6 +336,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             rc = parse_uri_file(&suri[5], &suri2, &nspace, &rank);
             if (PMIX_SUCCESS != rc) {
                 free(suri);
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 return PMIX_ERR_UNREACH;
             }
             free(suri);
@@ -297,6 +348,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             p = strchr(suri, ';');
             if (NULL == p) {
                 free(suri);
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 return PMIX_ERR_BAD_PARAM;
             }
             *p = '\0';
@@ -308,6 +362,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             if (NULL == p) {
                 free(suri2);
                 free(suri);
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 return PMIX_ERR_BAD_PARAM;
             }
             *p = '\0';
@@ -321,74 +378,31 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "ptl:tcp:tool attempt connect using given URI %s", suri);
         /* go ahead and try to connect */
-        if (PMIX_SUCCESS != (rc = try_connect(suri, &sd))) {
+        if (PMIX_SUCCESS != (rc = try_connect(suri, &sd, iptr, niptr))) {
             if (NULL != nspace) {
                 free(nspace);
             }
             free(suri);
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return rc;
         }
+        /* cleanup */
         free(suri);
         suri = NULL;
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         goto complete;
     }
 
-    /* if they gave us a pid, then look for it */
-    if (0 != pid) {
-        if (NULL != server_nspace) {
-            free(server_nspace);
-            server_nspace = NULL;
-        }
-        if (0 > asprintf(&filename, "pmix.%s.tool.%d", myhost, pid)) {
-            return PMIX_ERR_NOMEM;
-        }
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "ptl:tcp:tool searching for given session server %s",
-                            filename);
-        nspace = NULL;
-        rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                       filename, &sd, &nspace, &rank);
-        free(filename);
-        if (PMIX_SUCCESS == rc) {
-            goto complete;
-        }
-        if (NULL != nspace) {
-            free(nspace);
-        }
-        /* since they gave us a specific pid and we couldn't
-         * connect to it, return an error */
-        return PMIX_ERR_UNREACH;
-    }
-
-    /* if they gave us an nspace, then look for it */
-    if (NULL != server_nspace) {
-        if (0 > asprintf(&filename, "pmix.%s.tool.%s", myhost, server_nspace)) {
-            free(server_nspace);
-            return PMIX_ERR_NOMEM;
-        }
-        free(server_nspace);
-        server_nspace = NULL;
-        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                            "ptl:tcp:tool searching for given session server %s",
-                            filename);
-        nspace = NULL;
-        rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                       filename, &sd, &nspace, &rank);
-        free(filename);
-        if (PMIX_SUCCESS == rc) {
-            goto complete;
-        }
-        if (NULL != nspace) {
-            free(nspace);
-        }
-        /* since they gave us a specific nspace and we couldn't
-         * connect to it, return an error */
-        return PMIX_ERR_UNREACH;
-    }
-
-    /* if they asked for system-level, we start there */
+    /* if they asked for system-level first or only, we start there */
     if (system_level || system_level_only) {
         if (0 > asprintf(&filename, "%s/pmix.sys.%s", mca_ptl_tcp_component.system_tmpdir, myhost)) {
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
             return PMIX_ERR_NOMEM;
         }
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -401,8 +415,11 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
             pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                 "ptl:tcp:tool attempt connect to system server at %s", suri);
             /* go ahead and try to connect */
-            if (PMIX_SUCCESS == try_connect(suri, &sd)) {
+            if (PMIX_SUCCESS == try_connect(suri, &sd, iptr, niptr)) {
                 /* don't free nspace - we will use it below */
+                if (NULL != iptr) {
+                    PMIX_INFO_FREE(iptr, niptr);
+                }
                 goto complete;
             }
             free(nspace);
@@ -418,6 +435,80 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
+        return PMIX_ERR_UNREACH;
+    }
+
+    /* if they gave us a pid, then look for it */
+    if (0 != pid) {
+        if (NULL != server_nspace) {
+            free(server_nspace);
+            server_nspace = NULL;
+        }
+        if (0 > asprintf(&filename, "pmix.%s.tool.%d", myhost, pid)) {
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "ptl:tcp:tool searching for given session server %s",
+                            filename);
+        nspace = NULL;
+        rc = df_search(mca_ptl_tcp_component.system_tmpdir,
+                       filename, iptr, niptr, &sd, &nspace, &rank, &suri);
+        free(filename);
+        if (PMIX_SUCCESS == rc) {
+            goto complete;
+        }
+        if (NULL != suri) {
+            free(suri);
+        }
+        if (NULL != nspace) {
+            free(nspace);
+        }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
+        /* since they gave us a specific pid and we couldn't
+         * connect to it, return an error */
+        return PMIX_ERR_UNREACH;
+    }
+
+    /* if they gave us an nspace, then look for it */
+    if (NULL != server_nspace) {
+        if (0 > asprintf(&filename, "pmix.%s.tool.%s", myhost, server_nspace)) {
+            free(server_nspace);
+            if (NULL != iptr) {
+                PMIX_INFO_FREE(iptr, niptr);
+            }
+            return PMIX_ERR_NOMEM;
+        }
+        free(server_nspace);
+        server_nspace = NULL;
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "ptl:tcp:tool searching for given session server %s",
+                            filename);
+        nspace = NULL;
+        rc = df_search(mca_ptl_tcp_component.system_tmpdir,
+                       filename, iptr, niptr, &sd, &nspace, &rank, &suri);
+        free(filename);
+        if (PMIX_SUCCESS == rc) {
+            goto complete;
+        }
+        if (NULL != suri) {
+            free(suri);
+        }
+        if (NULL != nspace) {
+            free(nspace);
+        }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
+        /* since they gave us a specific nspace and we couldn't
+         * connect to it, return an error */
         return PMIX_ERR_UNREACH;
     }
 
@@ -430,6 +521,9 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         return PMIX_ERR_NOMEM;
     }
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
@@ -437,7 +531,7 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
                         filename);
     nspace = NULL;
     rc = df_search(mca_ptl_tcp_component.system_tmpdir,
-                   filename, &sd, &nspace, &rank);
+                   filename, iptr, niptr, &sd, &nspace, &rank, &suri);
     free(filename);
     if (PMIX_SUCCESS != rc) {
         if (NULL != nspace){
@@ -446,12 +540,18 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         if (NULL != suri) {
             free(suri);
         }
+        if (NULL != iptr) {
+            PMIX_INFO_FREE(iptr, niptr);
+        }
         return PMIX_ERR_UNREACH;
+    }
+    if (NULL != iptr) {
+        PMIX_INFO_FREE(iptr, niptr);
     }
 
   complete:
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "sock_peer_try_connect: Connection across to server succeeded");
+                        "tcp_peer_try_connect: Connection across to server succeeded");
 
     /* do a final bozo check */
     if (NULL == nspace || PMIX_RANK_WILDCARD == rank) {
@@ -489,6 +589,16 @@ static pmix_status_t connect_to_peer(struct pmix_peer_t *peer,
         pmix_client_globals.myserver->info->pname.nspace = strdup(pmix_client_globals.myserver->nptr->nspace);
         pmix_client_globals.myserver->info->pname.rank = rank;
     }
+    /* store the URI for subsequent lookups */
+    urikv = PMIX_NEW(pmix_kval_t);
+    urikv->key = strdup(PMIX_SERVER_URI);
+    PMIX_VALUE_CREATE(urikv->value, 1);
+    urikv->value->type = PMIX_STRING;
+    asprintf(&urikv->value->data.string, "%s.%u;%s", nspace, rank, suri);
+    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                      &pmix_globals.myid, PMIX_INTERNAL,
+                      urikv);
+    PMIX_RELEASE(urikv);  // maintain accounting
 
     pmix_ptl_base_set_nonblocking(sd);
 
@@ -680,14 +790,15 @@ static pmix_status_t parse_uri_file(char *filename,
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t try_connect(char *uri, int *sd)
+static pmix_status_t try_connect(char *uri, int *sd, pmix_info_t iptr[], size_t niptr)
 {
     char *p, *p2, *host;
     struct sockaddr_in *in;
     struct sockaddr_in6 *in6;
     size_t len;
     pmix_status_t rc;
-    bool retried = false;
+    int retries = 0;
+    uint8_t myflag;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:tcp try connect to %s", uri);
@@ -771,29 +882,28 @@ static pmix_status_t try_connect(char *uri, int *sd)
     }
 
     /* send our identity and any authentication credentials to the server */
-    if (PMIX_SUCCESS != (rc = send_connect_ack(*sd))) {
+    if (PMIX_SUCCESS != (rc = send_connect_ack(*sd, &myflag, iptr, niptr))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(*sd);
         return rc;
     }
 
     /* do whatever handshake is required */
-    if (PMIX_SUCCESS != (rc = recv_connect_ack(*sd))) {
+    if (PMIX_SUCCESS != (rc = recv_connect_ack(*sd, myflag))) {
         CLOSE_THE_SOCKET(*sd);
         if (PMIX_ERR_TEMP_UNAVAILABLE == rc) {
-            /* give it two tries */
-            if (!retried) {
-                retried = true;
+            ++retries;
+            if( retries < mca_ptl_tcp_component.handshake_max_retries ) {
                 goto retry;
             }
         }
-        PMIX_ERROR_LOG(rc);
         return rc;
     }
 
     return PMIX_SUCCESS;
 }
-static pmix_status_t send_connect_ack(int sd)
+static pmix_status_t send_connect_ack(int sd, uint8_t *myflag,
+                                      pmix_info_t iptr[], size_t niptr)
 {
     char *msg;
     pmix_ptl_hdr_t hdr;
@@ -806,7 +916,7 @@ static pmix_status_t send_connect_ack(int sd)
     uid_t euid;
     gid_t egid;
     uint32_t u32;
-    bool self_defined = false;
+    pmix_buffer_t buf;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix:tcp SEND CONNECT ACK");
@@ -814,6 +924,7 @@ static pmix_status_t send_connect_ack(int sd)
     /* if we are a server, then we shouldn't be here */
     if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
@@ -837,35 +948,68 @@ static pmix_status_t send_connect_ack(int sd)
     /* allow space for a marker indicating client vs tool */
     sdsize = 1;
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    /* Defined marker values:
+     *
+     * 0 => simple client process
+     * 1 => legacy tool - may or may not have an identifier
+     * 2 => legacy launcher - may or may not have an identifier
+     * ------------------------------------------
+     * 3 => self-started tool process that needs an identifier
+     * 4 => self-started tool process that was given an identifier by caller
+     * 5 => tool that was started by a PMIx server - identifier specified by server
+     * 6 => self-started launcher that needs an identifier
+     * 7 => self-started launcher that was given an identifier by caller
+     * 8 => launcher that was started by a PMIx server - identifier specified by server
+     */
+    if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
+        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+            /* if we are both launcher and client, then we need
+             * to tell the server we are both */
+            flag = 8;
+            /* add space for our uid/gid for ACL purposes */
+            sdsize += 2*sizeof(uint32_t);
+            /* add space for our identifier */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+        } else {
+            /* add space for our uid/gid for ACL purposes */
+            sdsize += 2*sizeof(uint32_t);
+            /* if they gave us an identifier, we need to pass it */
+            if (0 < strlen(pmix_globals.myid.nspace) &&
+                PMIX_RANK_INVALID != pmix_globals.myid.rank) {
+                flag = 7;
+                sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            } else {
+                flag = 6;
+            }
+        }
+
+    } else if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer) &&
+               !PMIX_PROC_IS_TOOL(pmix_globals.mypeer)) {
+        /* we are a simple client */
         flag = 0;
         /* reserve space for our nspace and rank info */
         sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-    } else if (PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
-        flag = 2;
+
+    } else {  // must be a tool of some sort
         /* add space for our uid/gid for ACL purposes */
         sdsize += 2*sizeof(uint32_t);
-        /* if we already have an identifier, we need to pass it */
-        if (0 < strlen(pmix_globals.myid.nspace) &&
+        if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+            /* if we are both tool and client, then we need
+             * to tell the server we are both */
+            flag = 5;
+            /* add space for our identifier */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+        } else if (0 < strlen(pmix_globals.myid.nspace) &&
             PMIX_RANK_INVALID != pmix_globals.myid.rank) {
-            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t) + 1;
-            self_defined = true;
+            /* we were given an identifier by the caller, pass it */
+            sdsize += strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
+            flag = 4;
         } else {
-            ++sdsize; // need space for the flag indicating if have id
-        }
-    } else {  // must be a simple tool
-        flag = 1;
-        /* add space for our uid/gid for ACL purposes */
-        sdsize += 2*sizeof(uint32_t);
-        /* if we self-defined an identifier, we need to pass it */
-        if (0 < strlen(pmix_globals.myid.nspace) &&
-            PMIX_RANK_INVALID != pmix_globals.myid.rank) {
-            sdsize += 1 + strlen(pmix_globals.myid.nspace) + 1 + sizeof(uint32_t);
-            self_defined = true;
-        } else {
-            ++sdsize; // need space for the flag indicating if have id
+            /* we are a self-started tool that needs an identifier */
+            flag = 3;
         }
     }
+    *myflag = flag;
 
     /* add the name of our active sec module - we selected it
      * in pmix_client.c prior to entering here */
@@ -879,16 +1023,26 @@ static pmix_status_t send_connect_ack(int sd)
     /* add our active gds module for working with the server */
     gds = (char*)pmix_client_globals.myserver->nptr->compat.gds->name;
 
-    /* set the number of bytes to be read beyond the header */
+    /* if we were given info structs to pass to the server, pack them */
+    PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+    if (NULL != iptr) {
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, &niptr, 1, PMIX_SIZE);
+        PMIX_BFROPS_PACK(rc, pmix_globals.mypeer, &buf, iptr, niptr, PMIX_INFO);
+    }
+
+    /* set the number of bytes to be read beyond the header - must
+     * NULL terminate the strings! */
     hdr.nbytes = sdsize + strlen(PMIX_VERSION) + 1 + strlen(sec) + 1 \
                 + strlen(bfrops) + 1 + sizeof(bftype) \
-                + strlen(gds) + 1 + sizeof(uint32_t) + cred.size;  // must NULL terminate the strings!
+                + strlen(gds) + 1 + sizeof(uint32_t) + cred.size \
+                + buf.bytes_used;
 
     /* create a space for our message */
     sdsize = (sizeof(hdr) + hdr.nbytes);
     if (NULL == (msg = (char*)malloc(sdsize))) {
         PMIX_BYTE_OBJECT_DESTRUCT(&cred);
         free(sec);
+        PMIX_DESTRUCT(&buf);
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
     memset(msg, 0, sdsize);
@@ -920,7 +1074,7 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, &flag, 1);
     csize += 1;
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (0 == flag) {
         /* if we are a client, provide our nspace/rank */
         memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
         csize += strlen(pmix_globals.myid.nspace)+1;
@@ -928,9 +1082,8 @@ static pmix_status_t send_connect_ack(int sd)
         u32 = htonl((uint32_t)pmix_globals.myid.rank);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
         csize += sizeof(uint32_t);
-    } else {
-        /* if we are a tool, provide our uid/gid for ACL support - note
-         * that we have to convert so we can handle heterogeneity */
+    } else if (3 == flag || 6 == flag) {
+        /* we are a tool or launcher that needs an identifier - add our ACLs */
         euid = geteuid();
         u32 = htonl(euid);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
@@ -939,6 +1092,27 @@ static pmix_status_t send_connect_ack(int sd)
         u32 = htonl(egid);
         memcpy(msg+csize, &u32, sizeof(uint32_t));
         csize += sizeof(uint32_t);
+    } else if (4 == flag || 5 == flag || 7 == flag || 8 == flag) {
+        /* we are a tool or launcher that has an identifier - start with our ACLs */
+        euid = geteuid();
+        u32 = htonl(euid);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+        egid = getegid();
+        u32 = htonl(egid);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+        /* now add our identifier */
+        memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
+        csize += strlen(pmix_globals.myid.nspace)+1;
+        /* again, need to convert */
+        u32 = htonl((uint32_t)pmix_globals.myid.rank);
+        memcpy(msg+csize, &u32, sizeof(uint32_t));
+        csize += sizeof(uint32_t);
+    } else {
+        /* not a valid flag */
+        PMIX_DESTRUCT(&buf);
+        return PMIX_ERR_NOT_SUPPORTED;
     }
 
     /* provide our version */
@@ -957,46 +1131,33 @@ static pmix_status_t send_connect_ack(int sd)
     memcpy(msg+csize, gds, strlen(gds));
     csize += strlen(gds)+1;
 
-    /* if we are not a client and self-defined an identifier, we need to pass it */
-    if (!PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
-        if (self_defined) {
-            flag = 1;
-            memcpy(msg+csize, &flag, 1);
-            ++csize;
-            memcpy(msg+csize, pmix_globals.myid.nspace, strlen(pmix_globals.myid.nspace));
-            csize += strlen(pmix_globals.myid.nspace)+1;
-            /* again, need to convert */
-            u32 = htonl((uint32_t)pmix_globals.myid.rank);
-            memcpy(msg+csize, &u32, sizeof(uint32_t));
-            csize += sizeof(uint32_t);
-        } else {
-            flag = 0;
-            memcpy(msg+csize, &flag, 1);
-            ++csize;
-        }
-    }
+    /* provide the info struct bytes */
+    memcpy(msg+csize, buf.base_ptr, buf.bytes_used);
+    csize += buf.bytes_used;
 
     /* send the entire message across */
     if (PMIX_SUCCESS != pmix_ptl_base_send_blocking(sd, msg, sdsize)) {
         free(msg);
+        PMIX_DESTRUCT(&buf);
         return PMIX_ERR_UNREACH;
     }
     free(msg);
+    PMIX_DESTRUCT(&buf);
     return PMIX_SUCCESS;
 }
 
 /* we receive a connection acknowledgement from the server,
  * consisting of nothing more than a status report. If success,
  * then we initiate authentication method */
-static pmix_status_t recv_connect_ack(int sd)
+static pmix_status_t recv_connect_ack(int sd, uint8_t myflag)
 {
     pmix_status_t reply;
     pmix_status_t rc;
     struct timeval tv, save;
     pmix_socklen_t sz;
     bool sockopt = true;
-    uint32_t u32;
     char nspace[PMIX_MAX_NSLEN+1];
+    uint32_t u32;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "pmix: RECV CONNECT ACK FROM SERVER");
@@ -1011,12 +1172,16 @@ static pmix_status_t recv_connect_ack(int sd)
        }
    } else {
         /* set a timeout on the blocking recv so we don't hang */
-        tv.tv_sec  = 2;
+        tv.tv_sec  = mca_ptl_tcp_component.handshake_wait_time;
         tv.tv_usec = 0;
         if (0 != setsockopt(sd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv))) {
-            pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                                "pmix: recv_connect_ack could not setsockopt SO_RCVTIMEO");
-            return PMIX_ERR_UNREACH;
+            if (ENOPROTOOPT == errno || EOPNOTSUPP == errno) {
+                sockopt = false;
+            } else {
+                pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                                    "pmix: recv_connect_ack could not setsockopt SO_RCVTIMEO");
+                return PMIX_ERR_UNREACH;
+            }
         }
     }
 
@@ -1033,7 +1198,7 @@ static pmix_status_t recv_connect_ack(int sd)
     }
     reply = ntohl(u32);
 
-    if (PMIX_PROC_IS_CLIENT(pmix_globals.mypeer)) {
+    if (0 == myflag) {
         /* see if they want us to do the handshake */
         if (PMIX_ERR_READY_FOR_HANDSHAKE == reply) {
             PMIX_PSEC_CLIENT_HANDSHAKE(rc, pmix_client_globals.myserver, sd);
@@ -1055,26 +1220,24 @@ static pmix_status_t recv_connect_ack(int sd)
     } else {  // we are a tool
         /* if the status indicates an error, then we are done */
         if (PMIX_SUCCESS != reply) {
-            PMIX_ERROR_LOG(reply);
             return reply;
         }
-        /* recv our nspace */
-        rc = pmix_ptl_base_recv_blocking(sd, nspace, PMIX_MAX_NSLEN+1);
-        if (PMIX_SUCCESS != rc) {
-            return rc;
-        }
-        /* if we already have our nspace, then just verify it matches */
-        if (0 < strlen(pmix_globals.myid.nspace)) {
-            if (0 != strncmp(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN)) {
-                return PMIX_ERR_INIT;
+        /* if we needed an identifier, recv it */
+        if (3 == myflag || 6 == myflag) {
+            /* first the nspace */
+            rc = pmix_ptl_base_recv_blocking(sd, (char*)&nspace, PMIX_MAX_NSLEN+1);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
             }
-        } else {
-            (void)strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
-        }
-        /* if we already have a rank, then leave it alone */
-        if (PMIX_RANK_INVALID == pmix_globals.myid.rank) {
-            /* our rank is always zero */
-            pmix_globals.myid.rank = 0;
+            memset(pmix_globals.myid.nspace, 0, PMIX_MAX_NSLEN+1);
+            strncpy(pmix_globals.myid.nspace, nspace, PMIX_MAX_NSLEN);
+            /* now the rank */
+            rc = pmix_ptl_base_recv_blocking(sd, (char*)&u32, sizeof(uint32_t));
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            /* convert and store */
+            pmix_globals.myid.rank = htonl(u32);
         }
 
         /* get the server's nspace and rank so we can send to it */
@@ -1093,7 +1256,8 @@ static pmix_status_t recv_connect_ack(int sd)
             free(pmix_client_globals.myserver->info->pname.nspace);
         }
         pmix_client_globals.myserver->info->pname.nspace = strdup(nspace);
-        pmix_ptl_base_recv_blocking(sd, (char*)&(pmix_client_globals.myserver->info->pname.rank), sizeof(int));
+        pmix_ptl_base_recv_blocking(sd, (char*)&u32, sizeof(uint32_t));
+        pmix_client_globals.myserver->info->pname.rank = htonl(u32);
 
         pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                             "pmix: RECV CONNECT CONFIRMATION FOR TOOL %s:%d FROM SERVER %s:%d",
@@ -1138,8 +1302,9 @@ static pmix_status_t recv_connect_ack(int sd)
 }
 
 static pmix_status_t df_search(char *dirname, char *prefix,
+                               pmix_info_t info[], size_t ninfo,
                                int *sd, char **nspace,
-                               pmix_rank_t *rank)
+                               pmix_rank_t *rank, char **uri)
 {
     char *suri, *nsp, *newdir;
     pmix_rank_t rk;
@@ -1169,7 +1334,7 @@ static pmix_status_t df_search(char *dirname, char *prefix,
         }
         /* if it is a directory, down search */
         if (S_ISDIR(buf.st_mode)) {
-            rc = df_search(newdir, prefix, sd, nspace, rank);
+            rc = df_search(newdir, prefix, info, ninfo, sd, nspace, rank, uri);
             free(newdir);
             if (PMIX_SUCCESS == rc) {
                 closedir(cur_dirp);
@@ -1189,11 +1354,11 @@ static pmix_status_t df_search(char *dirname, char *prefix,
                 /* go ahead and try to connect */
                 pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                                     "pmix:tcp: attempting to connect to %s", suri);
-                if (PMIX_SUCCESS == try_connect(suri, sd)) {
+                if (PMIX_SUCCESS == try_connect(suri, sd, info, ninfo)) {
                     (*nspace) = nsp;
                     *rank = rk;
                     closedir(cur_dirp);
-                    free(suri);
+                    *uri = suri;
                     free(newdir);
                     return PMIX_SUCCESS;
                 }

--- a/src/mca/ptl/tcp/ptl_tcp.h
+++ b/src/mca/ptl/tcp/ptl_tcp.h
@@ -9,7 +9,8 @@
  *                         University of Stuttgart.  All rights reserved.
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -48,10 +49,13 @@ typedef struct {
     char *session_filename;
     char *nspace_filename;
     char *system_filename;
+    char *rendezvous_filename;
     int wait_to_connect;
     int max_retries;
     char *report_uri;
     bool remote_connections;
+    int handshake_wait_time;
+    int handshake_max_retries;
 } pmix_ptl_tcp_component_t;
 
 extern pmix_ptl_tcp_component_t mca_ptl_tcp_component;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -12,9 +12,10 @@
  *                         All rights reserved.
  * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
  *                         reserved.
- * Copyright (c) 2016-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2017-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2019 IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc. All rights reserved.
  * $COPYRIGHT$
  *
@@ -61,6 +62,7 @@
 #include "src/util/os_path.h"
 #include "src/util/parse_options.h"
 #include "src/util/pif.h"
+#include "src/util/pmix_environ.h"
 #include "src/util/show_help.h"
 #include "src/util/strnlen.h"
 #include "src/common/pmix_iof.h"
@@ -117,10 +119,13 @@ static pmix_status_t setup_fork(const pmix_proc_t *proc, char ***env);
     .session_filename = NULL,
     .nspace_filename = NULL,
     .system_filename = NULL,
+    .rendezvous_filename = NULL,
     .wait_to_connect = 4,
     .max_retries = 2,
     .report_uri = NULL,
-    .remote_connections = false
+    .remote_connections = false,
+    .handshake_wait_time = 4,
+    .handshake_max_retries = 2
 };
 
 static char **split_and_resolve(char **orig_str, char *name);
@@ -221,6 +226,20 @@ static int component_register(void)
                                           PMIX_MCA_BASE_VAR_SCOPE_READONLY,
                                           &mca_ptl_tcp_component.max_retries);
 
+    (void)pmix_mca_base_component_var_register(component, "handshake_wait_time",
+                                          "Number of seconds to wait for the server reply to the handshake request",
+                                          PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                          PMIX_INFO_LVL_4,
+                                          PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                          &mca_ptl_tcp_component.handshake_wait_time);
+
+    (void)pmix_mca_base_component_var_register(component, "handshake_max_retries",
+                                          "Number of times to retry the handshake request before giving up",
+                                          PMIX_MCA_BASE_VAR_TYPE_INT, NULL, 0, 0,
+                                          PMIX_INFO_LVL_4,
+                                          PMIX_MCA_BASE_VAR_SCOPE_READONLY,
+                                          &mca_ptl_tcp_component.handshake_max_retries);
+
     return PMIX_SUCCESS;
 }
 
@@ -234,31 +253,23 @@ static pmix_status_t component_open(void)
 
     /* check for environ-based directives
      * on system tmpdir to use */
-    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer)) {
+    if (PMIX_PROC_IS_SERVER(pmix_globals.mypeer) ||
+        PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
         mca_ptl_tcp_component.session_tmpdir = strdup(pmix_server_globals.tmpdir);
     } else {
         if (NULL != (tdir = getenv("PMIX_SERVER_TMPDIR"))) {
             mca_ptl_tcp_component.session_tmpdir = strdup(tdir);
+        } else {
+            mca_ptl_tcp_component.session_tmpdir = strdup(pmix_tmp_directory());
         }
     }
 
     if (NULL != (tdir = getenv("PMIX_SYSTEM_TMPDIR"))) {
         mca_ptl_tcp_component.system_tmpdir = strdup(tdir);
+    } else {
+        mca_ptl_tcp_component.system_tmpdir = strdup(pmix_tmp_directory());
     }
 
-    if (NULL == (tdir = getenv("TMPDIR"))) {
-        if (NULL == (tdir = getenv("TEMP"))) {
-            if (NULL == (tdir = getenv("TMP"))) {
-                tdir = "/tmp";
-            }
-        }
-    }
-    if (NULL == mca_ptl_tcp_component.session_tmpdir) {
-        mca_ptl_tcp_component.session_tmpdir = strdup(tdir);
-    }
-    if (NULL == mca_ptl_tcp_component.system_tmpdir) {
-        mca_ptl_tcp_component.system_tmpdir = strdup(tdir);
-    }
     if (NULL != mca_ptl_tcp_component.report_uri &&
         0 != strcmp(mca_ptl_tcp_component.report_uri, "-") &&
         0 != strcmp(mca_ptl_tcp_component.report_uri, "+")) {
@@ -272,12 +283,19 @@ pmix_status_t component_close(void)
 {
     if (NULL != mca_ptl_tcp_component.system_filename) {
         unlink(mca_ptl_tcp_component.system_filename);
+        free(mca_ptl_tcp_component.system_filename);
     }
     if (NULL != mca_ptl_tcp_component.session_filename) {
         unlink(mca_ptl_tcp_component.session_filename);
+        free(mca_ptl_tcp_component.session_filename);
     }
     if (NULL != mca_ptl_tcp_component.nspace_filename) {
         unlink(mca_ptl_tcp_component.nspace_filename);
+        free(mca_ptl_tcp_component.nspace_filename);
+    }
+    if (NULL != mca_ptl_tcp_component.rendezvous_filename) {
+        unlink(mca_ptl_tcp_component.rendezvous_filename);
+        free(mca_ptl_tcp_component.rendezvous_filename);
     }
     if (NULL != urifile) {
         /* remove the file */
@@ -335,6 +353,7 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     char *prefix, myhost[PMIX_MAXHOSTNAMELEN];
     char myconnhost[PMIX_MAXHOSTNAMELEN];
     int myport;
+    pmix_kval_t *urikv;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tcp setup_listener");
@@ -347,51 +366,51 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     /* scan the info keys and process any override instructions */
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
-            if (0 == strcmp(info[n].key, PMIX_TCP_IF_INCLUDE)) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_INCLUDE)) {
                 if (NULL != mca_ptl_tcp_component.if_include) {
                     free(mca_ptl_tcp_component.if_include);
                 }
                 mca_ptl_tcp_component.if_include = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_IF_EXCLUDE)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IF_EXCLUDE)) {
                 if (NULL != mca_ptl_tcp_component.if_exclude) {
                     free(mca_ptl_tcp_component.if_exclude);
                 }
                 mca_ptl_tcp_component.if_exclude = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_IPV4_PORT)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV4_PORT)) {
                 mca_ptl_tcp_component.ipv4_port = info[n].value.data.integer;
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_IPV6_PORT)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_IPV6_PORT)) {
                 mca_ptl_tcp_component.ipv6_port = info[n].value.data.integer;
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_DISABLE_IPV4)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV4)) {
                 mca_ptl_tcp_component.disable_ipv4_family = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_DISABLE_IPV6)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_DISABLE_IPV6)) {
                 mca_ptl_tcp_component.disable_ipv6_family = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_SERVER_REMOTE_CONNECTIONS)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_REMOTE_CONNECTIONS)) {
                 mca_ptl_tcp_component.remote_connections = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_URI)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_URI)) {
                 if (NULL != mca_ptl_tcp_component.super.uri) {
                     free(mca_ptl_tcp_component.super.uri);
                 }
                 mca_ptl_tcp_component.super.uri = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_TCP_REPORT_URI)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TCP_REPORT_URI)) {
                 if (NULL != mca_ptl_tcp_component.report_uri) {
                     free(mca_ptl_tcp_component.report_uri);
                 }
                 mca_ptl_tcp_component.report_uri = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_SERVER_TMPDIR)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_TMPDIR)) {
                 if (NULL != mca_ptl_tcp_component.session_tmpdir) {
                     free(mca_ptl_tcp_component.session_tmpdir);
                 }
                 mca_ptl_tcp_component.session_tmpdir = strdup(info[n].value.data.string);
-            } else if (0 == strcmp(info[n].key, PMIX_SYSTEM_TMPDIR)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SYSTEM_TMPDIR)) {
                 if (NULL != mca_ptl_tcp_component.system_tmpdir) {
                     free(mca_ptl_tcp_component.system_tmpdir);
                 }
                 mca_ptl_tcp_component.system_tmpdir = strdup(info[n].value.data.string);
             } else if (0 == strcmp(info[n].key, PMIX_SERVER_TOOL_SUPPORT)) {
                 session_tool = PMIX_INFO_TRUE(&info[n]);
-            } else if (0 == strcmp(info[n].key, PMIX_SERVER_SYSTEM_SUPPORT)) {
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_SERVER_SYSTEM_SUPPORT)) {
                 system_tool = PMIX_INFO_TRUE(&info[n]);
-           }
+            }
         }
     }
 
@@ -615,6 +634,16 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
                         "ptl:tcp URI %s", lt->uri);
 
+    /* save the URI internally so we can report it */
+    urikv = PMIX_NEW(pmix_kval_t);
+    urikv->key = strdup(PMIX_SERVER_URI);
+    PMIX_VALUE_CREATE(urikv->value, 1);
+    PMIX_VALUE_LOAD(urikv->value, lt->uri, PMIX_STRING);
+    PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer,
+                      &pmix_globals.myid, PMIX_INTERNAL,
+                      urikv);
+    PMIX_RELEASE(urikv);  // maintain accounting
+
     if (NULL != mca_ptl_tcp_component.report_uri) {
         /* if the string is a "-", then output to stdout */
         if (0 == strcmp(mca_ptl_tcp_component.report_uri, "-")) {
@@ -639,6 +668,38 @@ static pmix_status_t setup_listener(pmix_info_t info[], size_t ninfo,
             /* add a flag that indicates we accept v2.1 protocols */
             fprintf(fp, "v%s\n", PMIX_VERSION);
             fclose(fp);
+        }
+    }
+
+    /* if we were given a rendezvous file, then drop it */
+    if (NULL != mca_ptl_tcp_component.rendezvous_filename) {
+        FILE *fp;
+
+        pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
+                            "WRITING RENDEZVOUS FILE %s",
+                            mca_ptl_tcp_component.rendezvous_filename);
+        fp = fopen(mca_ptl_tcp_component.rendezvous_filename, "w");
+        if (NULL == fp) {
+            pmix_output(0, "Impossible to open the file %s in write mode\n", mca_ptl_tcp_component.rendezvous_filename);
+            PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
+            CLOSE_THE_SOCKET(lt->socket);
+            free(mca_ptl_tcp_component.rendezvous_filename);
+            mca_ptl_tcp_component.rendezvous_filename = NULL;
+            goto sockerror;
+        }
+
+        /* output my nspace and rank plus the URI */
+        fprintf(fp, "%s\n", lt->uri);
+        /* add a flag that indicates we accept v3.0 protocols */
+        fprintf(fp, "v%s\n", PMIX_VERSION);
+        fclose(fp);
+        /* set the file mode */
+        if (0 != chmod(mca_ptl_tcp_component.rendezvous_filename, S_IRUSR | S_IWUSR | S_IRGRP)) {
+            PMIX_ERROR_LOG(PMIX_ERR_FILE_OPEN_FAILURE);
+            CLOSE_THE_SOCKET(lt->socket);
+            free(mca_ptl_tcp_component.rendezvous_filename);
+            mca_ptl_tcp_component.rendezvous_filename = NULL;
+            goto sockerror;
         }
     }
 
@@ -896,7 +957,6 @@ static void connection_handler(int sd, short args, void *cbdata)
     char *nspace;
     uint32_t len, u32;
     size_t cnt, msglen, n;
-    uint8_t flag;
     pmix_nspace_t *nptr, *tmp;
     bool found;
     pmix_rank_info_t *info;
@@ -904,6 +964,7 @@ static void connection_handler(int sd, short args, void *cbdata)
     pmix_info_t ginfo;
     pmix_proc_type_t proc_type;
     pmix_byte_object_t cred;
+    pmix_buffer_t buf;
 
     /* acquire the object */
     PMIX_ACQUIRE_OBJECT(pnd);
@@ -998,7 +1059,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* get the process type of the connecting peer */
     if (1 <= cnt) {
-        memcpy(&flag, mg, 1);
+        memcpy(&pnd->flag, mg, 1);
         ++mg;
         --cnt;
     } else {
@@ -1008,7 +1069,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         goto error;
     }
 
-    if (0 == flag) {
+    if (0 == pnd->flag) {
         /* they must be a client, so get their nspace/rank */
         proc_type = PMIX_PROC_CLIENT;
         PMIX_STRNLEN(msglen, mg, cnt);
@@ -1035,7 +1096,7 @@ static void connection_handler(int sd, short args, void *cbdata)
             rc = PMIX_ERR_BAD_PARAM;
             goto error;
         }
-    } else if (1 == flag) {
+    } else if (1 == pnd->flag) {
         /* they are a tool */
         proc_type = PMIX_PROC_TOOL;
         /* extract the uid/gid */
@@ -1061,7 +1122,7 @@ static void connection_handler(int sd, short args, void *cbdata)
            rc = PMIX_ERR_BAD_PARAM;
            goto error;
         }
-    } else if (2 == flag) {
+    } else if (2 == pnd->flag) {
         /* they are a launcher */
         proc_type = PMIX_PROC_LAUNCHER;
         /* extract the uid/gid */
@@ -1087,8 +1148,95 @@ static void connection_handler(int sd, short args, void *cbdata)
            rc = PMIX_ERR_BAD_PARAM;
            goto error;
         }
+    } else if (3 == pnd->flag || 6 == pnd->flag) {
+        /* they are a tool or launcher that needs an identifier */
+        if (3 == pnd->flag) {
+            proc_type = PMIX_PROC_TOOL;
+        } else {
+            proc_type = PMIX_PROC_LAUNCHER;
+        }
+        /* extract the uid/gid */
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->uid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->gid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        /* they need an id */
+        pnd->need_id = true;
+    } else if (4 == pnd->flag || 5 == pnd->flag || 7 == pnd->flag || 8 == pnd->flag) {
+        /* they are a tool or launcher that has an identifier - start with our ACLs */
+        if (4 == pnd->flag || 5 == pnd->flag) {
+            proc_type = PMIX_PROC_TOOL;
+        } else {
+            proc_type = PMIX_PROC_LAUNCHER;
+        }
+        /* extract the uid/gid */
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->uid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        if (sizeof(uint32_t) <= cnt) {
+            memcpy(&u32, mg, sizeof(uint32_t));
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+            pnd->gid = ntohl(u32);
+        } else {
+           free(msg);
+           /* send an error reply to the client */
+           rc = PMIX_ERR_BAD_PARAM;
+           goto error;
+        }
+        PMIX_STRNLEN(msglen, mg, cnt);
+        if (msglen < cnt) {
+            nspace = mg;
+            mg += strlen(nspace) + 1;
+            cnt -= strlen(nspace) + 1;
+        } else {
+            free(msg);
+            /* send an error reply to the client */
+            rc = PMIX_ERR_BAD_PARAM;
+            goto error;
+        }
+
+        if (sizeof(pmix_rank_t) <= cnt) {
+            /* have to convert this to host order */
+            memcpy(&u32, mg, sizeof(uint32_t));
+            rank = ntohl(u32);
+            mg += sizeof(uint32_t);
+            cnt -= sizeof(uint32_t);
+        } else {
+            free(msg);
+            /* send an error reply to the client */
+            rc = PMIX_ERR_BAD_PARAM;
+            goto error;
+        }
     } else {
         /* we don't know what they are! */
+        PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
         rc = PMIX_ERR_NOT_SUPPORTED;
         free(msg);
         goto error;
@@ -1113,7 +1261,7 @@ static void connection_handler(int sd, short args, void *cbdata)
         proc_type = proc_type | PMIX_PROC_V20;
         bfrops = "v20";
         bftype = pmix_bfrops_globals.default_type;  // we can't know any better
-        gds = NULL;
+        gds = "ds12,hash";
     } else {
         int major;
         major = strtoul(version, NULL, 10);
@@ -1123,6 +1271,7 @@ static void connection_handler(int sd, short args, void *cbdata)
             proc_type = proc_type | PMIX_PROC_V3;
         } else {
             free(msg);
+            PMIX_ERROR_LOG(PMIX_ERR_NOT_SUPPORTED);
             rc = PMIX_ERR_NOT_SUPPORTED;
             goto error;
         }
@@ -1169,63 +1318,151 @@ static void connection_handler(int sd, short args, void *cbdata)
     }
 
     /* see if this is a tool connection request */
-    if (0 != flag) {
-        /* does the server support tool connections? */
-        if (NULL == pmix_host_server.tool_connected) {
-            /* send an error reply to the client */
-            rc = PMIX_ERR_NOT_SUPPORTED;
-            goto error;
+    if (0 != pnd->flag) {
+        peer = PMIX_NEW(pmix_peer_t);
+        if (NULL == peer) {
+            /* probably cannot send an error reply if we are out of memory */
+            free(msg);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd);
+            return;
         }
-
-        if (PMIX_PROC_V3 & proc_type) {
-            /* the caller will have provided a flag indicating
-             * whether or not they have an assigned nspace/rank */
-            if (cnt < 1) {
-                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
-                free(msg);
-                /* send an error reply to the client */
-                rc = PMIX_ERR_BAD_PARAM;
-                goto error;
+        pnd->peer = peer;
+        /* if this is a tool we launched, then the host may
+         * have already registered it as a client - so check
+         * to see if we already have a peer for it */
+        if (5 == pnd->flag || 8 == pnd->flag) {
+            /* registration only adds the nspace and a rank in that
+             * nspace - it doesn't add the peer object to our array
+             * of local clients. So let's start by searching for
+             * the nspace object */
+            nptr = NULL;
+            PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_nspace_t) {
+                if (0 == strcmp(tmp->nspace, nspace)) {
+                    nptr = tmp;
+                    break;
+                }
             }
-            memcpy(&flag, mg, 1);
-            ++mg;
-            --cnt;
-            if (flag) {
-                PMIX_STRNLEN(msglen, mg, cnt);
-                if (msglen < cnt) {
-                    nspace = mg;
-                    mg += strlen(nspace) + 1;
-                    cnt -= strlen(nspace) + 1;
-                } else {
-                    free(msg);
-                    /* send an error reply to the client */
-                    rc = PMIX_ERR_BAD_PARAM;
+            if (NULL == nptr) {
+                /* it is possible that this is a tool inside of
+                 * a job-script as part of a multi-spawn operation.
+                 * Since each tool invocation may have finalized and
+                 * terminated, the tool will appear to "terminate", thus
+                 * causing us to cleanup all references to it, and then
+                 * reappear. So we don't reject this connection request.
+                 * Instead, we create the nspace and rank objects for
+                 * it and let the RM/host decide if this behavior
+                 * is allowed */
+                nptr = PMIX_NEW(pmix_nspace_t);
+                if (NULL == nptr) {
+                    rc = PMIX_ERR_NOMEM;
                     goto error;
                 }
-                if (sizeof(pmix_rank_t) <= cnt) {
-                    /* have to convert this to host order */
-                    memcpy(&u32, mg, sizeof(uint32_t));
-                    rank = ntohl(u32);
-                    mg += sizeof(uint32_t);
-                    cnt -= sizeof(uint32_t);
-                } else {
-                    free(msg);
-                    /* send an error reply to the client */
-                    rc = PMIX_ERR_BAD_PARAM;
-                    goto error;
+                nptr->nspace = strdup(nspace);
+            }
+            /* now look for the rank */
+            info = NULL;
+            found = false;
+            PMIX_LIST_FOREACH(info, &nptr->ranks, pmix_rank_info_t) {
+                if (info->pname.rank == rank) {
+                    found = true;
+                    break;
                 }
+            }
+            if (!found) {
+                /* see above note about not finding nspace */
+                info = PMIX_NEW(pmix_rank_info_t);
+                info->pname.nspace = strdup(nspace);
+                info->pname.rank = rank;
+                info->uid = pnd->uid;
+                info->gid = pnd->gid;
+                pmix_list_append(&nptr->ranks, &info->super);
+            }
+            PMIX_RETAIN(info);
+            peer->info = info;
+            PMIX_RETAIN(nptr);
+        } else {
+            nptr = PMIX_NEW(pmix_nspace_t);
+            if (NULL == nptr) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
+                CLOSE_THE_SOCKET(pnd->sd);
+                PMIX_RELEASE(pnd);
+                PMIX_RELEASE(peer);
+                return;
+            }
+        }
+        peer->nptr = nptr;
+        /* select their bfrops compat module */
+        peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(bfrops);
+        if (NULL == peer->nptr->compat.bfrops) {
+            PMIX_RELEASE(peer);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd);
+            return;
+        }
+        /* set the buffer type */
+        peer->nptr->compat.type = bftype;
+        n = 0;
+        /* if info structs need to be passed along, then unpack them */
+        if (0 < cnt) {
+            int32_t foo;
+            PMIX_CONSTRUCT(&buf, pmix_buffer_t);
+            PMIX_LOAD_BUFFER(peer, &buf, mg, cnt);
+            foo = 1;
+            PMIX_BFROPS_UNPACK(rc, peer, &buf, &pnd->ninfo, &foo, PMIX_SIZE);
+            foo = (int32_t)pnd->ninfo;
+            /* if we have an identifier, then we leave room to pass it */
+            if (!pnd->need_id) {
+                pnd->ninfo += 5;
+            } else {
+                pnd->ninfo += 3;
+            }
+            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+            PMIX_BFROPS_UNPACK(rc, peer, &buf, pnd->info, &foo, PMIX_INFO);
+            n = foo;
+        } else {
+            if (!pnd->need_id) {
                 pnd->ninfo = 5;
             } else {
                 pnd->ninfo = 3;
             }
-        } else {
-            pnd->ninfo = 3;
+            PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
+        }
+
+        /* pass along the proc_type */
+        pnd->proc_type = proc_type;
+        /* pass along the bfrop, buffer_type, and sec fields so
+         * we can assign them once we create a peer object */
+        pnd->psec = strdup(sec);
+        if (NULL != gds) {
+            pnd->gds = strdup(gds);
+        }
+
+        /* does the server support tool connections? */
+        if (NULL == pmix_host_server.tool_connected) {
+            if (pnd->need_id) {
+                /* we need someone to provide the tool with an
+                 * identifier and they aren't available */
+                /* send an error reply to the client */
+                rc = PMIX_ERR_NOT_SUPPORTED;
+                PMIX_RELEASE(peer);
+                /* release the msg */
+                free(msg);
+                goto error;
+            } else {
+                /* just process it locally */
+                memset(proc.nspace, 0, PMIX_MAX_NSLEN+1);
+                strncpy(proc.nspace, nspace, PMIX_MAX_NSLEN);
+                proc.rank = rank;
+                cnct_cbfunc(PMIX_SUCCESS, &proc, (void*)pnd);
+                /* release the msg */
+                free(msg);
+                return;
+            }
         }
 
         /* setup the info array to pass the relevant info
          * to the server */
-        n = 0;
-        PMIX_INFO_CREATE(pnd->info, pnd->ninfo);
         /* provide the version */
         PMIX_INFO_LOAD(&pnd->info[n], PMIX_VERSION_INFO, version, PMIX_STRING);
         ++n;
@@ -1235,30 +1472,17 @@ static void connection_handler(int sd, short args, void *cbdata)
         /* and the group id */
         PMIX_INFO_LOAD(&pnd->info[n], PMIX_GRPID, &pnd->gid, PMIX_UINT32);
         ++n;
-        /* if we have it, pass along our ID */
-        if (flag) {
+        /* if we have it, pass along their ID */
+        if (!pnd->need_id) {
             PMIX_INFO_LOAD(&pnd->info[n], PMIX_NSPACE, nspace, PMIX_STRING);
             ++n;
             PMIX_INFO_LOAD(&pnd->info[n], PMIX_RANK, &rank, PMIX_PROC_RANK);
             ++n;
         }
-        /* pass along the proc_type */
-        pnd->proc_type = proc_type;
-        /* pass along the bfrop, buffer_type, and sec fields so
-         * we can assign them once we create a peer object */
-        pnd->psec = strdup(sec);
-        if (NULL != bfrops) {
-            pnd->bfrops = strdup(bfrops);
-        }
-        pnd->buffer_type = bftype;
-        if (NULL != gds) {
-            pnd->gds = strdup(gds);
-        }
         /* release the msg */
         free(msg);
-        /* request an nspace for this requestor - it will
-         * automatically be assigned rank=0 if the rank
-         * isn't already known */
+
+        /* pass it up for processing */
         pmix_host_server.tool_connected(pnd->info, pnd->ninfo, cnct_cbfunc, pnd);
         return;
     }
@@ -1440,12 +1664,17 @@ static void connection_handler(int sd, short args, void *cbdata)
 
       /* let the host server know that this client has connected */
       if (NULL != pmix_host_server.client_connected) {
-          (void)strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
+          memset(proc.nspace, 0, PMIX_MAX_NSLEN + 1);
+          strncpy(proc.nspace, peer->info->pname.nspace, PMIX_MAX_NSLEN);
           proc.rank = peer->info->pname.rank;
           rc = pmix_host_server.client_connected(&proc, peer->info->server_object,
                                                  NULL, NULL);
-          if (PMIX_SUCCESS != rc) {
+          if (PMIX_SUCCESS != rc && PMIX_OPERATION_SUCCEEDED != rc) {
               PMIX_ERROR_LOG(rc);
+              info->proc_cnt--;
+              pmix_pointer_array_set_item(&pmix_server_globals.clients, peer->index, NULL);
+              PMIX_RELEASE(peer);
+              goto error;
           }
       }
 
@@ -1497,6 +1726,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
@@ -1504,24 +1734,41 @@ static void process_cbfunc(int sd, short args, void *cbdata)
 
     /* if the request failed, then we are done */
     if (PMIX_SUCCESS != cd->status) {
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
     }
 
-    /* send the nspace back to the tool */
-    if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN+1))) {
-        PMIX_ERROR_LOG(rc);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
+    /* if we got an identifier, send it back to the tool */
+    if (pnd->need_id) {
+        /* start with the nspace */
+        if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, cd->proc.nspace, PMIX_MAX_NSLEN+1))) {
+            PMIX_ERROR_LOG(rc);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd->peer);
+            PMIX_RELEASE(pnd);
+            PMIX_RELEASE(cd);
+            return;
+        }
+
+        /* now the rank, suitably converted */
+        u32 = ntohl(cd->proc.rank);
+        if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
+            PMIX_ERROR_LOG(rc);
+            CLOSE_THE_SOCKET(pnd->sd);
+            PMIX_RELEASE(pnd->peer);
+            PMIX_RELEASE(pnd);
+            PMIX_RELEASE(cd);
+            return;
+        }
     }
 
     /* send my nspace back to the tool */
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, pmix_globals.myid.nspace, PMIX_MAX_NSLEN+1))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
@@ -1532,61 +1779,41 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (PMIX_SUCCESS != (rc = pmix_ptl_base_send_blocking(pnd->sd, (char*)&u32, sizeof(uint32_t)))) {
         PMIX_ERROR_LOG(rc);
         CLOSE_THE_SOCKET(pnd->sd);
+        PMIX_RELEASE(pnd->peer);
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         return;
     }
 
-    /* add this nspace to our pool */
-    nptr = PMIX_NEW(pmix_nspace_t);
-    if (NULL == nptr) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
-    }
-    nptr->nspace = strdup(cd->proc.nspace);
-    pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
-    /* add this tool rank to the nspace */
-    info = PMIX_NEW(pmix_rank_info_t);
-    if (NULL == info) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
-    }
-    info->pname.nspace = strdup(cd->proc.nspace);
-    info->pname.rank = 0;
-    /* need to include the uid/gid for validation */
-    info->uid = pnd->uid;
-    info->gid = pnd->gid;
-    pmix_list_append(&nptr->ranks, &info->super);
+    /* shortcuts */
+    peer = (pmix_peer_t*)pnd->peer;
+    nptr = peer->nptr;
 
-    /* setup a peer object for this tool */
-    peer = PMIX_NEW(pmix_peer_t);
-    if (NULL == peer) {
-        PMIX_ERROR_LOG(PMIX_ERR_NOMEM);
-        CLOSE_THE_SOCKET(pnd->sd);
-        PMIX_RELEASE(pnd);
-        PMIX_RELEASE(cd);
-        return;
+    /* if this tool wasn't initially registered as a client,
+     * then add some required structures */
+    if (5 != pnd->flag && 8 != pnd->flag) {
+        PMIX_RETAIN(nptr);
+        nptr->nspace = strdup(cd->proc.nspace);
+        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+        info = PMIX_NEW(pmix_rank_info_t);
+        info->pname.nspace = strdup(nptr->nspace);
+        info->pname.rank = cd->proc.rank;
+        info->uid = pnd->uid;
+        info->gid = pnd->gid;
+        pmix_list_append(&nptr->ranks, &info->super);
+        PMIX_RETAIN(info);
+        peer->info = info;
     }
+
     /* mark the peer proc type */
     peer->proc_type = pnd->proc_type;
     /* save the protocol */
     peer->protocol = pnd->protocol;
-    /* add in the nspace pointer */
-    PMIX_RETAIN(nptr);
-    peer->nptr = nptr;
-    PMIX_RETAIN(info);
-    peer->info = info;
     /* save the uid/gid */
-    peer->epilog.uid = info->uid;
-    peer->epilog.gid = info->gid;
-    nptr->epilog.uid = info->uid;
-    nptr->epilog.gid = info->gid;
+    peer->epilog.uid = peer->info->uid;
+    peer->epilog.gid = peer->info->gid;
+    nptr->epilog.uid = peer->info->uid;
+    nptr->epilog.gid = peer->info->gid;
     peer->proc_cnt = 1;
     peer->sd = pnd->sd;
 
@@ -1604,17 +1831,6 @@ static void process_cbfunc(int sd, short args, void *cbdata)
      * tool as we received this request via that channel, so simply
      * record it here for future use */
     peer->nptr->compat.ptl = &pmix_ptl_tcp_module;
-    /* select their bfrops compat module */
-    peer->nptr->compat.bfrops = pmix_bfrops_base_assign_module(pnd->bfrops);
-    if (NULL == peer->nptr->compat.bfrops) {
-        PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
-        PMIX_RELEASE(nptr);  // will release the info object
-        CLOSE_THE_SOCKET(pnd->sd);
-        goto done;
-    }
-    /* set the buffer type */
-    peer->nptr->compat.type = pnd->buffer_type;
     /* set the gds */
     PMIX_INFO_LOAD(&ginfo, PMIX_GDS_MODULE, pnd->gds, PMIX_STRING);
     peer->nptr->compat.gds = pmix_gds_base_assign_module(&ginfo, 1);
@@ -1694,7 +1910,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         /* probably cannot send an error reply if we are out of memory */
         return;
     }
-    info->peerid = peer->index;
+    peer->info->peerid = peer->index;
 
     /* start the events for this tool */
     pmix_event_assign(&peer->recv_event, pmix_globals.evbase, peer->sd,
@@ -1720,8 +1936,8 @@ static void cnct_cbfunc(pmix_status_t status,
     pmix_setup_caddy_t *cd;
 
     pmix_output_verbose(2, pmix_ptl_base_framework.framework_output,
-                        "pmix:tcp:cnct_cbfunc returning %s:%d",
-                        proc->nspace, proc->rank);
+                        "pmix:tcp:cnct_cbfunc returning %s:%d %s",
+                        proc->nspace, proc->rank, PMIx_Error_string(status));
 
     /* need to thread-shift this into our context */
     cd = PMIX_NEW(pmix_setup_caddy_t);
@@ -1730,7 +1946,9 @@ static void cnct_cbfunc(pmix_status_t status,
         return;
     }
     cd->status = status;
-    (void)strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    memset(cd->proc.nspace, 0, PMIX_MAX_NSLEN+1);
+    strncpy(cd->proc.nspace, proc->nspace, PMIX_MAX_NSLEN);
+    cd->proc.rank = proc->rank;
     cd->cbdata = cbdata;
     PMIX_THREADSHIFT(cd, process_cbfunc);
 }


### PR DESCRIPTION
The tool connection protocol was updated in v3.1 and v2.2 series, but
not v3.0. This PR syncs v3.0 with those branches so we don't have a
breakage in the middle.

Signed-off-by: Ralph Castain <rhc@pmix.org>