### PR TITLE
Fix xversion spawn test

### DIFF
--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -768,7 +768,14 @@ pmix_status_t pmix_bfrops_base_pack_app(pmix_pointer_array_t *regtypes,
         }
         /* argv */
         nvals = pmix_argv_count(app[i].argv);
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, &nvals, 1, PMIX_INT32, regtypes);
+        /* although nvals is technically an int32, we have to pack it
+         * as a generic int due to a typo in earlier release series. This
+         * preserves the ordering of bytes in the packed buffer as it
+         * includes a tag indicating the actual size of the value. No
+         * harm is done as generic int is equivalent to int32 on all
+         * current systems - just something to watch out for in the
+         * future should someone someday change the size of "int" */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &nvals, 1, PMIX_INT, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -944,7 +944,14 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes,
         }
         /* unpack argc */
         m=1;
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nval, &m, PMIX_INT32, regtypes);
+        /* although nval is technically an int32, we have to unpack it
+         * as a generic int due to a typo in earlier release series. This
+         * preserves the ordering of bytes in the packed buffer as it
+         * includes a tag indicating the actual size of the value. No
+         * harm is done as generic int is equivalent to int32 on all
+         * current systems - just something to watch out for in the
+         * future should someone someday change the size of "int" */
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nval, &m, PMIX_INT, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }


### PR DESCRIPTION
Although the number of argvs is technically an int32, we have
to pack/unpack it as a generic int due to a typo in earlier
release series. This preserves the ordering of bytes in the
packed buffer as it includes a tag indicating the actual size
of the value. No harm is done as generic int is equivalent to
int32 on all current systems - just something to watch out
for in the future should someone someday change the size of "int"

Signed-off-by: Ralph Castain <rhc@pmix.org>