### PR TITLE
libev: wrap pmix_event_base_loopexit()

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -253,7 +253,6 @@ typedef struct event pmix_event_t;
 
 #define pmix_event_base_free(b) event_base_free(b)
 
-#define pmix_event_base_loopexit(b) event_base_loopexit(b, NULL)
 
 #if PMIX_HAVE_LIBEV
 #define pmix_event_use_threads()
@@ -279,12 +278,12 @@ PMIX_EXPORT int pmix_event_assign(struct event *ev, pmix_event_base_t *evbase,
 PMIX_EXPORT int pmix_event_add(struct event *ev, struct timeval *tv);
 PMIX_EXPORT int pmix_event_del(struct event *ev);
 PMIX_EXPORT void pmix_event_active (struct event *ev, int res, short ncalls);
-PMIX_EXPORT void pmix_event_base_loopbreak (pmix_event_base_t *b);
+PMIX_EXPORT void pmix_event_base_loopexit (pmix_event_base_t *b);
 #else
 #define pmix_event_add(ev, tv) event_add((ev), (tv))
 #define pmix_event_del(ev) event_del((ev))
 #define pmix_event_active(x, y, z) event_active((x), (y), (z))
-#define pmix_event_base_loopbreak(b) event_base_loopbreak(b)
+#define pmix_event_base_loopexit(b) event_base_loopexit(b, NULL)
 #endif
 
 PMIX_EXPORT pmix_event_t* pmix_event_new(pmix_event_base_t *b, int fd,

--- a/src/runtime/pmix_progress_threads.c
+++ b/src/runtime/pmix_progress_threads.c
@@ -194,7 +194,7 @@ void pmix_event_active (struct event *ev, int res, short ncalls) {
     }
 }
 
-void pmix_event_base_loopbreak (pmix_event_base_t *ev_base) {
+void pmix_event_base_loopexit (pmix_event_base_t *ev_base) {
     pmix_progress_tracker_t *trk = pmix_progress_tracker_get_by_base(ev_base);
     assert(NULL != trk);
     ev_async_send ((struct ev_loop *)trk->ev_base, &trk->async);


### PR DESCRIPTION
When libev is used, wrap pmix_event_base_loopexit() in order to support multithreading.
Since pmix_event_base_loopbreak() is not used anymore,
simply rename it into pmix_event_base_loopexit().

This fixes pmix/pmix@f652ae1d607b15ea89a0cb085c92275939499fd6 when libev is used
instead of libevent.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>