### PR TITLE
v1.2/test: eliminated the usage of through ranking for namespaces

### DIFF
--- a/test/cli_stages.c
+++ b/test/cli_stages.c
@@ -3,6 +3,8 @@
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -21,17 +23,26 @@ int cli_rank(cli_info_t *cli)
     int i;
     for(i=0; i < cli_info_cnt; i++){
         if( cli == &cli_info[i] ){
-            return i;
+            return cli->rank;
         }
     }
     return -1;
 }
 
-void cli_init(int nprocs, cli_state_t order[])
+void cli_init(int nprocs)
 {
     int n, i;
+    cli_state_t order[CLI_TERM+1];
+
     cli_info = malloc( sizeof(cli_info_t) * nprocs);
     cli_info_cnt = nprocs;
+
+    order[CLI_UNINIT] = CLI_FORKED;
+    order[CLI_FORKED] = CLI_FIN;
+    order[CLI_CONNECTED] = CLI_UNDEF;
+    order[CLI_FIN] = CLI_TERM;
+    order[CLI_DISCONN] = CLI_UNDEF;
+    order[CLI_TERM] = CLI_UNDEF;
 
     for (n=0; n < nprocs; n++) {
         cli_info[n].sd = -1;
@@ -198,8 +209,9 @@ void cli_wait_all(double timeout)
             TEST_VERBOSE(("waitpid = %d", pid));
             for(i=0; i < cli_info_cnt; i++){
                 if( cli_info[i].pid == pid ){
-                    TEST_VERBOSE(("the child with pid = %d has rank = %d\n"
-                                "\t\texited = %d, signalled = %d", pid, i,
+                    TEST_VERBOSE(("the child with pid = %d has rank = %d, ns = %s\n"
+                                "\t\texited = %d, signalled = %d", pid,
+                                  cli_info[i].rank, cli_info[i].ns,
                                 WIFEXITED(status), WIFSIGNALED(status) ));
                     if( WIFEXITED(status) || WIFSIGNALED(status) ){
                         cli_cleanup(&cli_info[i]);
@@ -211,6 +223,9 @@ void cli_wait_all(double timeout)
             if( errno == ECHILD ){
                 TEST_VERBOSE(("No more children to wait. Happens on the last cli_wait_all call "
                             "which is used to ensure that all children terminated.\n"));
+                if (pmix_test_verbose) {
+                    sleep(1);
+                }
                 break;
             } else {
                 TEST_ERROR(("waitpid(): %d : %s", errno, strerror(errno)));

--- a/test/cli_stages.h
+++ b/test/cli_stages.h
@@ -3,12 +3,17 @@
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
  *
  * $HEADER$
  */
+
+#ifndef CLI_STAGES_H
+#define CLI_STAGES_H
 
 #include <src/include/pmix_config.h>
 #include <signal.h>
@@ -50,7 +55,7 @@ extern int cli_info_cnt;
 extern bool test_abort;
 
 int cli_rank(cli_info_t *cli);
-void cli_init(int nprocs, cli_state_t order[]);
+void cli_init(int nprocs);
 void cli_connect(cli_info_t *cli, int sd, struct event_base * ebase, event_callback_fn callback);
 void cli_finalize(cli_info_t *cli);
 void cli_disconnect(cli_info_t *cli);
@@ -73,3 +78,4 @@ void errhandler_reg_callbk (pmix_status_t status,
                             void *cbdata);
 
 
+#endif // CLI_STAGES_H

--- a/test/pmix_test.c
+++ b/test/pmix_test.c
@@ -47,7 +47,6 @@ int main(int argc, char **argv)
     struct stat stat_buf;
     struct timeval tv;
     double test_start;
-    cli_state_t order[CLI_TERM+1];
     test_params params;
     INIT_TEST_PARAMS(params);
     int test_fail = 0;
@@ -97,13 +96,7 @@ int main(int argc, char **argv)
     /* register the errhandler */
     PMIx_Register_errhandler(NULL, 0, errhandler, errhandler_reg_callbk, NULL);
 
-    order[CLI_UNINIT] = CLI_FORKED;
-    order[CLI_FORKED] = CLI_FIN;
-    order[CLI_CONNECTED] = CLI_UNDEF;
-    order[CLI_FIN] = CLI_TERM;
-    order[CLI_DISCONN] = CLI_UNDEF;
-    order[CLI_TERM] = CLI_UNDEF;
-    cli_init(params.nprocs, order);
+    cli_init(params.nprocs);
 
     /* set common argv and env */
     client_env = pmix_argv_copy(environ);

--- a/test/server_callbacks.c
+++ b/test/server_callbacks.c
@@ -91,12 +91,25 @@ pmix_status_t connected(const pmix_proc_t *proc, void *server_object)
 pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
               pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    if( CLI_TERM <= cli_info[proc->rank].state ){
+    cli_info_t *cli = NULL;
+    int i;
+    for (i = 0; i < cli_info_cnt; i++) {
+        if((proc->rank == cli_info[i].rank) &&
+                (0 == strcmp(proc->nspace, cli_info[i].ns))){
+            cli = &cli_info[i];
+            break;
+        }
+    }
+    if (NULL == cli) {
+        TEST_ERROR(("cannot found rank %d", proc->rank));
+        return PMIX_SUCCESS;
+    }
+    if( CLI_TERM <= cli->state ){
         TEST_ERROR(("double termination of rank %d", proc->rank));
         return PMIX_SUCCESS;
     }
-    TEST_VERBOSE(("Rank %d terminated", proc->rank));
-    cli_finalize(&cli_info[proc->rank]);
+    TEST_VERBOSE(("Rank %s:%d terminated", proc->nspace, proc->rank));
+    cli_finalize(cli);
     finalized_count++;
     if (finalized_count == cli_info_cnt) {
         if (NULL != pmix_test_published_list) {
@@ -307,10 +320,9 @@ pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     if (NULL != cbfunc) {
-        /* return PMIX_EXISTS here just to ensure we get the correct status on the client */
-        cbfunc(PMIX_EXISTS, cbdata);
+        cbfunc(PMIX_SUCCESS, cbdata);
     }
-   return PMIX_SUCCESS;
+    return PMIX_SUCCESS;
 }
 
 pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,

--- a/test/test_common.c
+++ b/test/test_common.c
@@ -592,7 +592,6 @@ int get_total_ns_number(test_params params)
 
 int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t **ranks, size_t *nranks)
 {
-    int base_rank = 0;
     size_t num_ranks = 0;
     int num = -1;
     size_t j;
@@ -608,7 +607,6 @@ int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t *
         char *pch = tmp;
         int ns_id = (int)strtol(nspace + strlen(TEST_NAMESPACE) + 1, NULL, 10);
         while (NULL != pch && num != ns_id) {
-            base_rank += num_ranks;
             pch = strtok((-1 == num ) ? tmp : NULL, ":");
             if (NULL == pch) {
                 break;
@@ -621,7 +619,7 @@ int get_all_ranks_from_namespace(test_params params, char *nspace, pmix_proc_t *
             PMIX_PROC_CREATE(*ranks, num_ranks);
             for (j = 0; j < num_ranks; j++) {
                 (void)strncpy((*ranks)[j].nspace, nspace, PMIX_MAX_NSLEN);
-                (*ranks)[j].rank = base_rank+j;
+                (*ranks)[j].rank = j;
             }
         } else {
             free(tmp);

--- a/test/test_resolve_peers.c
+++ b/test/test_resolve_peers.c
@@ -96,9 +96,9 @@ int test_resolve_peers(char *my_nspace, int my_rank, test_params params)
         /* make a connection between processes from own namespace and processes from this namespace. */
         rc = test_cd_common(procs, 2, 1, 0);
         if (PMIX_SUCCESS == rc) {
-            TEST_VERBOSE(("%s:%d: Connect to %s succeeded %s.", my_nspace, my_rank, nspace));
+            TEST_VERBOSE(("%s:%d: Connect to %s succeeded %s.", my_nspace, my_rank, nspace, PMIx_Error_string(rc)));
         } else {
-            TEST_ERROR(("%s:%d: Connect to %s failed %s.", my_nspace, my_rank, nspace));
+            TEST_ERROR(("%s:%d: Connect to %s failed %s.", my_nspace, my_rank, nspace, PMIx_Error_string(rc)));
             return PMIX_ERROR;
         }
         /* then resolve peers from this namespace. */

--- a/test/utils.c
+++ b/test/utils.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
- * Copyright (c) 2015-2017 Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -86,7 +86,9 @@ static void set_namespace(int nprocs, char *ranks, char *name)
     info[7].value.data.uint32 = getpid ();
 
     int in_progress = 1, rc;
-    if (PMIX_SUCCESS == (rc = PMIx_server_register_nspace(name, nprocs, info, ninfo, release_cb, &in_progress))) {
+    if (PMIX_SUCCESS == (rc = PMIx_server_register_nspace(name, nprocs, info,
+                                                          ninfo, release_cb,
+                                                          &in_progress))) {
         PMIX_WAIT_FOR_COMPLETION(in_progress);
     }
     PMIX_INFO_FREE(info, ninfo);
@@ -165,7 +167,7 @@ void set_client_argv(test_params *params, char ***argv)
     }
 }
 
-int launch_clients(int num_procs, char *binary, char *** client_env, char ***base_argv)
+int launch_clients(int nprocs, char *binary, char *** client_env, char ***base_argv)
 {
     int n;
     uid_t myuid;
@@ -176,16 +178,17 @@ int launch_clients(int num_procs, char *binary, char *** client_env, char ***bas
     static int counter = 0;
     static int num_ns = 0;
     pmix_proc_t proc;
+    int base_rank = 0;
 
     TEST_VERBOSE(("Setting job info"));
-    fill_seq_ranks_array(num_procs, counter, &ranks);
+    fill_seq_ranks_array(nprocs, base_rank, &ranks);
     if (NULL == ranks) {
         PMIx_server_finalize();
         TEST_ERROR(("fill_seq_ranks_array failed"));
         return PMIX_ERROR;
     }
     (void)snprintf(proc.nspace, PMIX_MAX_NSLEN, "%s-%d", TEST_NAMESPACE, num_ns);
-    set_namespace(num_procs, ranks, proc.nspace);
+    set_namespace(nprocs, ranks, proc.nspace);
     if (NULL != ranks) {
         free(ranks);
     }
@@ -194,8 +197,8 @@ int launch_clients(int num_procs, char *binary, char *** client_env, char ***bas
     mygid = getgid();
 
     /* fork/exec the test */
-    for (n = 0; n < num_procs; n++) {
-        proc.rank = counter;
+    for (n = 0; n < nprocs; n++) {
+        proc.rank = n;
         if (PMIX_SUCCESS != (rc = PMIx_server_setup_fork(&proc, client_env))) {//n
             TEST_ERROR(("Server fork setup failed with error %d", rc));
             PMIx_server_finalize();
@@ -216,20 +219,20 @@ int launch_clients(int num_procs, char *binary, char *** client_env, char ***bas
             cli_kill_all();
             return -1;
         }
-        cli_info[counter].rank = counter;//n
+        cli_info[counter].rank = proc.rank;
         cli_info[counter].ns = strdup(proc.nspace);
 
         char **client_argv = pmix_argv_copy(*base_argv);
 
         /* add two last arguments: -r <rank> */
-        sprintf(digit, "%d", counter);//n
+        sprintf(digit, "%d", proc.rank);
         pmix_argv_append_nosize(&client_argv, "-r");
         pmix_argv_append_nosize(&client_argv, digit);
 
         pmix_argv_append_nosize(&client_argv, "-s");
         pmix_argv_append_nosize(&client_argv, proc.nspace);
 
-        sprintf(digit, "%d", num_procs);
+        sprintf(digit, "%d", nprocs);
         pmix_argv_append_nosize(&client_argv, "--ns-size");
         pmix_argv_append_nosize(&client_argv, digit);
 
@@ -237,7 +240,7 @@ int launch_clients(int num_procs, char *binary, char *** client_env, char ***bas
         pmix_argv_append_nosize(&client_argv, "--ns-id");
         pmix_argv_append_nosize(&client_argv, digit);
 
-        sprintf(digit, "%d", (counter-n));
+        sprintf(digit, "%d", base_rank);
         pmix_argv_append_nosize(&client_argv, "--base-rank");
         pmix_argv_append_nosize(&client_argv, digit);
 

--- a/test/utils.h
+++ b/test/utils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2015      Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Mellanox Technologies, Inc.
+ * Copyright (c) 2015-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -19,4 +19,4 @@
 #include "test_common.h"
 
 void set_client_argv(test_params *params, char ***argv);
-int launch_clients(int num_procs, char *binary, char *** client_env, char ***client_argv);
+int launch_clients(int nprocs, char *binary, char *** client_env, char ***base_argv);


### PR DESCRIPTION
Corresponds to 83b3d0dccd932a3bf40adf11df87d5e1cf4c9abf