### PR TITLE
Add -fPIC to static builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -162,6 +162,9 @@ LT_PREREQ([2.2.6])
 
 pmix_enable_shared="$enable_shared"
 pmix_enable_static="$enable_static"
+AS_IF([test ! -z "$enable_static" && test "$enable_static" == "yes"],
+      [CFLAGS="$CFLAGS -fPIC"])
+
 AM_ENABLE_SHARED
 AM_DISABLE_STATIC
 


### PR DESCRIPTION
For static builds, we need -fPIC so PRRTE and friends can correctly
absorb it.

Signed-off-by: Ralph Castain <rhc@pmix.org>