### PR TITLE
Correctly handle with-devel-headers

### DIFF
--- a/config/pmix_setup_hwloc.m4
+++ b/config/pmix_setup_hwloc.m4
@@ -63,7 +63,7 @@ AC_DEFUN([_PMIX_HWLOC_EXTERNAL],[
     if test "$with_hwloc" != "no"; then
         AC_MSG_CHECKING([for hwloc in])
         if test ! -z "$with_hwloc" && test "$with_hwloc" != "yes"; then
-            pmix_hwloc_dir=$with_hwloc
+            pmix_hwloc_dir=$with_hwloc/include
             pmix_hwloc_standard_header_location=no
             pmix_hwloc_standard_lib_location=no
             AS_IF([test -z "$with_hwloc_libdir" || test "$with_hwloc_libdir" = "yes"],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,7 +11,7 @@
 #                         All rights reserved.
 # Copyright (c) 2006-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -42,6 +42,8 @@ sources =
 nodist_headers =
 EXTRA_DIST =
 dist_pmixdata_DATA =
+nobase_pmix_HEADERS =
+pmixdir = $(pmixincludedir)/$(subdir)
 
 # place to capture sources for backward compatibility libs
 pmi1_sources =
@@ -104,6 +106,11 @@ include tool/Makefile.include
 include tools/Makefile.include
 include common/Makefile.include
 include hwloc/Makefile.include
+
+if WANT_INSTALL_HEADERS
+nobase_pmix_HEADERS += $(headers)
+endif
+
 
 MAINTAINERCLEANFILES = Makefile.in config.h config.h.in
 DISTCLEANFILES = Makefile

--- a/src/atomics/sys/atomic.h
+++ b/src/atomics/sys/atomic.h
@@ -16,7 +16,7 @@
  *                         reserved.
  * Copyright (c) 2017      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      Intel, Inc.  All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -52,7 +52,7 @@
 #ifndef PMIX_SYS_ATOMIC_H
 #define PMIX_SYS_ATOMIC_H 1
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 
 #include <stdbool.h>
 

--- a/src/include/Makefile.include
+++ b/src/include/Makefile.include
@@ -10,7 +10,7 @@
 #                         University of Stuttgart.  All rights reserved.
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
-# Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2007-2016 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2017      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
@@ -47,6 +47,6 @@ headers += \
 endif ! PMIX_EMBEDDED_MODE
 
 if WANT_INSTALL_HEADERS
-nodist_headers += \
+nobase_pmix_HEADERS += \
     include/pmix_config.h
 endif

--- a/src/mca/pif/Makefile.am
+++ b/src/mca/pif/Makefile.am
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -17,7 +18,7 @@ libmca_pif_la_SOURCES += $(headers)
 
 # Conditionally install the header files
 if WANT_INSTALL_HEADERS
-pmixdir = $(pmixincludedir)/pmix/mca/pif
+pmixdir = $(pmixincludedir)/$(subdir)
 nobase_pmix_HEADERS = $(headers)
 endif
 

--- a/src/mca/psec/Makefile.am
+++ b/src/mca/psec/Makefile.am
@@ -11,8 +11,8 @@
 # Copyright (c) 2004-2005 The Regents of the University of California.
 #                         All rights reserved.
 # Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
-# Copyright (c) 2013-2016 Intel, Inc. All rights reserved
-# Copyright (c) 2016 Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow

--- a/src/threads/Makefile.include
+++ b/src/threads/Makefile.include
@@ -13,7 +13,7 @@
 # Copyright (c) 2014 Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2015      Research Organization for Information Science
 #                         and Technology (RIST). All rights reserved.
-# Copyright (c) 2017      Intel, Inc. All rights reserved.
+# Copyright (c) 2017-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -30,7 +30,7 @@ headers += \
         threads/threads.h \
         threads/tsd.h \
         threads/wait_sync.h \
-	threads/thread_usage.h
+	    threads/thread_usage.h
 
 sources += \
         threads/mutex.c \

--- a/src/threads/thread_usage.h
+++ b/src/threads/thread_usage.h
@@ -26,7 +26,7 @@
 #if !defined(PMIX_THREAD_USAGE_H)
 #define PMIX_THREAD_USAGE_H
 
-#include "pmix_config.h"
+#include "src/include/pmix_config.h"
 
 #include "src/atomics/sys/atomic.h"
 #include "src/include/prefetch.h"


### PR DESCRIPTION
Ensure we get _all_ the headers exposed and in the correct place

Signed-off-by: Ralph Castain <rhc@pmix.org>