### PR TITLE
Do not use '==' in m4 test statements

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,7 @@ example, a bug might be fixed in the master, and then moved to
 multiple release branches.
 
 
-3.1.3 -- TBD
+3.1.3 -- 2 July 2019
 ----------------------
 - PR #1096: Restore PMIX_NUM_SLOTS for backward compatibility
 - PR #1106: Automatically generate PMIX_NUMERIC_VERSION
@@ -64,6 +64,7 @@ multiple release branches.
 - PR #1311: Work around memory bug in older gcc compilers
 - PR #1321: Provide memory op hooks in user-facing macros
 - PR #1329: Add -fPIC to static builds
+- PR #1340: Do not use '==' in m4 test statements
 
 
 3.1.2 -- 24 Jan 2019

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -191,7 +191,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                [Link the output PMIx library to this extra lib (used in embedded mode)]))
     AC_MSG_CHECKING([for extra lib])
     AS_IF([test ! -z "$with_pmix_extra_lib"],
-          [AS_IF([test "$with_pmix_extra_lib" == "yes" || test "$with_pmix_extra_lib" == "no"],
+          [AS_IF([test "$with_pmix_extra_lib" = "yes" || test "$with_pmix_extra_lib" = "no"],
                  [AC_MSG_RESULT([ERROR])
                   AC_MSG_WARN([Invalid value for --with-extra-pmix-lib:])
                   AC_MSG_WARN([    $with_pmix_extra_lib])
@@ -209,7 +209,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
                                [Link any embedded components/tools that require it to the provided libtool lib (used in embedded mode)]))
     AC_MSG_CHECKING([for extra ltlib])
     AS_IF([test ! -z "$with_pmix_extra_ltlib"],
-          [AS_IF([test "$with_pmix_extra_ltlib" == "yes" || test "$with_pmix_extra_ltlib" == "no"],
+          [AS_IF([test "$with_pmix_extra_ltlib" = "yes" || test "$with_pmix_extra_ltlib" = "no"],
                  [AC_MSG_RESULT([ERROR])
                   AC_MSG_WARN([Invalid value for --with-pmix-extra-ltlib:])
                   AC_MSG_WARN([    $with_pmix_extra_ltlib])
@@ -1184,7 +1184,7 @@ AC_MSG_CHECKING([if want to support dlopen of non-global namespaces])
 AC_ARG_ENABLE([nonglobal-dlopen],
               AC_HELP_STRING([--enable-nonglobal-dlopen],
                              [enable non-global dlopen (default: enabled)]))
-if test "$enable_nonglobal_dlopen" == "no"; then
+if test "$enable_nonglobal_dlopen" = "no"; then
     AC_MSG_RESULT([no])
     pmix_need_libpmix=0
 else

--- a/configure.ac
+++ b/configure.ac
@@ -171,7 +171,7 @@ LT_PREREQ([2.2.6])
 
 pmix_enable_shared="$enable_shared"
 pmix_enable_static="$enable_static"
-AS_IF([test ! -z "$enable_static" && test "$enable_static" == "yes"],
+AS_IF([test ! -z "$enable_static" && test "$enable_static" = "yes"],
       [CFLAGS="$CFLAGS -fPIC"])
 
 AM_ENABLE_SHARED

--- a/contrib/whitespace-purge.sh
+++ b/contrib/whitespace-purge.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (c) 2015      Intel, Inc. All rights reserved.
+# Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
 # Copyright (c) 2015      Los Alamos National Security, LLC. All rights
 #                         reserved
 # Copyright (c) 2015 Cisco Systems, Inc.
@@ -18,7 +18,7 @@ for file in $(git ls-files) ; do
     # skip sym links, pdfs, etc. If any other file types should be
     # skipped add the check here.
     type=$(file -b --mime-type -h $file)
-    if test ${type::4} == "text" ; then
+    if test ${type::4} = "text" ; then
         # Eliminate whitespace at the end of lines
         perl -pi -e 's/\s*$/\n/' $file
     fi

--- a/src/mca/pnet/opa/configure.m4
+++ b/src/mca/pnet/opa/configure.m4
@@ -12,7 +12,7 @@
 #                         All rights reserved.
 # Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
 # Copyright (c) 2013      Sandia National Laboratories.  All rights reserved.
-# Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+# Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
 # $COPYRIGHT$
 #
 # Additional copyrights may follow
@@ -46,7 +46,7 @@ AC_DEFUN([MCA_pmix_pnet_opa_CONFIG],[
     pmix_check_opamgt_dir=
 
     AC_MSG_CHECKING([if opamgt requested])
-    AS_IF([test "$with_opamgt" == "no"],
+    AS_IF([test "$with_opamgt" = "no"],
           [AC_MSG_RESULT([no])
            pmix_check_opamgt_happy=no],
           [AC_MSG_RESULT([yes])


### PR DESCRIPTION
Thanks to Stephane Goujet for the report

Signed-off-by: Ralph Castain <rhc@pmix.org>
(cherry picked from commit a6c1f8e6e7841c76ac7e16ded5cde4854db96bf1)