### PR TITLE
Fix if_linux_ipv6_open interface filter

### DIFF
--- a/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
+++ b/src/mca/pif/linux_ipv6/pif_linux_ipv6.c
@@ -104,8 +104,8 @@ static int if_linux_ipv6_open(void)
                                 addrbyte[8], addrbyte[9], addrbyte[10], addrbyte[11],
                                 addrbyte[12], addrbyte[13], addrbyte[14], addrbyte[15], scope);
 
-            /* we don't want any other scope less than link-local */
-            if (scope < 0x20) {
+            /* Only interested in global (0x00) scope */
+            if (scope != 0x00) {
                 pmix_output_verbose(1, pmix_pif_base_framework.framework_output,
                                     "skipping interface %2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x:%2x%2x scope %x\n",
                                     addrbyte[0], addrbyte[1], addrbyte[2], addrbyte[3],


### PR DESCRIPTION
`if_linux_ipv6_open` should add interfaces with global scope to use them to reach any network host.

This ports the fix from https://github.com/open-mpi/ompi/pull/4930