### PR TITLE
Complete implementation of network coord support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,6 +161,7 @@ test/simple/gwtest
 test/simple/simpjctrl
 test/simple/simpio
 test/simple/data-*
+test/simple/simpcoord
 
 # coverity
 cov-int

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -268,14 +268,19 @@ typedef uint32_t pmix_rank_t;
 #define PMIX_PARENT_ID                      "pmix.parent"           // (pmix_proc_t*) identifier of the process that called PMIx_Spawn
                                                                     //                to launch this proc's application
 #define PMIX_EXIT_CODE                      "pmix.exit.code"        // (int) exit code returned when proc terminated
-#define PMIX_NETWORK_COORDINATE             "pmix.net.coord"        // (pmix_coord_t*) Network coordinate of the specified process
-#define PMIX_NETWORK_COORD_SYSTEM           "pmix.net.coordsys"     // (pmix_coord_system_t) Network coordinate system being employed to
-                                                                    //                describe the specified network plane
+#define PMIX_NETWORK_COORDINATE             "pmix.net.coord"        // (pmix_coord_t*) Network coordinate of the specified process in
+                                                                    //       the given view type (e.g., logical vs physical)
+#define PMIX_NETWORK_VIEW                   "pmix.net.view"         // (pmix_coord_view_t) Requested view type (e.g., logical vs physical)
+#define PMIX_NETWORK_DIMS                   "pmix.net.dims"         // (uint32_t) Number of dimensions in the specified network plane/view
 #define PMIX_NETWORK_PLANE                  "pmix.net.plane"        // (char*) string ID of a network plane
 #define PMIX_NETWORK_SWITCH                 "pmix.net.switch"       // (char*) string ID of a network switch
 #define PMIX_NETWORK_NIC                    "pmix.net.nic"          // (char*) string ID of a NIC
 #define PMIX_NETWORK_ENDPT                  "pmix.net.endpt"        // (assigned) network endpt for process - type assigned by
                                                                     //            fabric provider
+#define PMIX_NETWORK_SHAPE                  "pmix.net.shape"        // (pmix_data_array_t*) number of interfaces (uint32_t) on each dimension of the
+                                                                    //        specified network plane in the requested view
+#define PMIX_NETWORK_SHAPE_STRING           "pmix.net.shapestr"     // (char*) network shape expressed as a string (e.g., "10x12x2")
+
 
 /* size info */
 #define PMIX_UNIV_SIZE                      "pmix.univ.size"        // (uint32_t) #procs in this nspace
@@ -1079,19 +1084,6 @@ typedef enum {
 } pmix_group_operation_t;
 
 
-/* define a structure for a proc's network coordinate */
-typedef struct pmix_coord {
-    int x;
-    int y;
-    int z;
-} pmix_coord_t;
-
-/* define coordinate system values */
-typedef uint8_t pmix_coord_system_t;
-#define PMIX_COORD_CARTESIAN    0x00
-#define PMIX_COORD_TOROID       0x01
-#define PMIX_COORD_CYLINDRICAL  0x02
-
 
 /* define some "hooks" external libraries can use to
  * intercept memory allocation/release operations */
@@ -1141,6 +1133,60 @@ static inline void* pmix_calloc(size_t n, size_t m)
 /* define a convenience macro for checking names */
 #define PMIX_CHECK_PROCID(a, b) \
     (PMIX_CHECK_NSPACE((a)->nspace, (b)->nspace) && ((a)->rank == (b)->rank || (PMIX_RANK_WILDCARD == (a)->rank || PMIX_RANK_WILDCARD == (b)->rank)))
+
+
+/****    PMIX COORD    ****/
+/* define coordinate system views */
+typedef uint8_t pmix_coord_view_t;
+#define PMIX_COORD_VIEW_UNDEF       0x00
+#define PMIX_COORD_LOGICAL_VIEW     0x01
+#define PMIX_COORD_PHYSICAL_VIEW    0x02
+
+/* define a structure for a proc's network coordinate */
+typedef struct pmix_coord {
+    pmix_coord_view_t view;
+    int *coord;
+    size_t dims;
+} pmix_coord_t;
+
+#define PMIX_COORD_CREATE(m, d, n)                                      \
+    do {                                                                \
+        (m) = (pmix_coord_t*)pmix_calloc((n), sizeof(pmix_coord_t));    \
+        if (NULL != (m)) {                                              \
+            (m)->view = PMIX_COORD_VIEW_UNDEF;                          \
+            (m)->dims = (d);                                            \
+            (m)->coord = (int*)pmix_calloc((m)->dims, sizeof(int));     \
+        }                                                               \
+    } while(0)
+
+#define PMIX_COORD_CONSTRUCT(m, d)          \
+    do {                                    \
+        (m)->view = PMIX_COORD_VIEW_UNDEF;  \
+        (m)->coord = NULL;                  \
+        (m)->dims = 0;                      \
+    } while(0)
+
+#define PMIX_COORD_DESTRUCT(m)              \
+    do {                                    \
+        (m)->view = PMIX_COORD_VIEW_UNDEF;  \
+        if (NULL != (m)->coord) {           \
+            pmix_free((m)->coord);          \
+            (m)->coord = NULL;              \
+            (m)->dims = 0;                  \
+        }                                   \
+    } while(0)
+
+#define PMIX_COORD_FREE(m, n)                       \
+    do {                                            \
+        size_t _nc_;                                \
+        if (NULL != (m)) {                          \
+            for (_nc_ = 0; _nc_ < (n); _nc_++) {    \
+                PMIX_COORD_DESTRUCT(&(m)[_nc_]);    \
+            }                                       \
+            free((m));                              \
+            (m) = NULL;                             \
+        }                                           \
+    } while(0)
 
 
 /****    PMIX BYTE OBJECT    ****/

--- a/src/mca/bfrops/base/bfrop_base_copy.c
+++ b/src/mca/bfrops/base/bfrop_base_copy.c
@@ -421,6 +421,7 @@ pmix_status_t pmix_bfrops_base_copy_darray(pmix_data_array_t **dest,
     pmix_query_t *pq, *sq;
     pmix_envar_t *pe, *se;
     pmix_regattr_t *pr, *sr;
+    pmix_coord_t *pc, *sc;
 
     if (PMIX_DATA_ARRAY != type) {
         return PMIX_ERR_BAD_PARAM;
@@ -844,7 +845,19 @@ pmix_status_t pmix_bfrops_base_copy_darray(pmix_data_array_t **dest,
                 free(p);
                 return PMIX_ERR_NOMEM;
             }
-            memcpy(p->array, src->array, src->size * sizeof(pmix_coord_t));
+            pc = (pmix_coord_t*)p->array;
+            sc = (pmix_coord_t*)src->array;
+            for (n=0; n < src->size; n++) {
+                pc[n].view = sc[n].view;
+                pc[n].dims = sc[n].dims;
+                if (0 < pc[n].dims) {
+                    pc[n].coord = (int*)malloc(pc[n].dims * sizeof(int));
+                    if (NULL == pc[n].coord) {
+                        return PMIX_ERR_NOMEM;
+                    }
+                    memcpy(pc[n].coord, sc[n].coord, pc[n].dims * sizeof(int));
+                }
+            }
             break;
         case PMIX_REGATTR:
             PMIX_REGATTR_CREATE(p->array, src->size);
@@ -924,11 +937,26 @@ pmix_status_t pmix_bfrops_base_copy_coord(pmix_coord_t **dest,
                                           pmix_coord_t *src,
                                           pmix_data_type_t type)
 {
+    pmix_coord_t *d;
+
     if (PMIX_COORD != type) {
         return PMIX_ERR_BAD_PARAM;
     }
-    *dest = (pmix_coord_t*)malloc(sizeof(pmix_coord_t));
-    memcpy(*dest, src, sizeof(pmix_coord_t));
+    d = (pmix_coord_t*)malloc(sizeof(pmix_coord_t));
+    if (NULL == d) {
+        return PMIX_ERR_NOMEM;
+    }
+    d->view = src->view;
+    d->dims = src->dims;
+    if (0 < d->dims) {
+        d->coord = (int*)malloc(d->dims * sizeof(int));
+        if (NULL == d->coord) {
+            free(d);
+            return PMIX_ERR_NOMEM;
+        }
+        memcpy(d->coord, src->coord, d->dims * sizeof(int));
+    }
+    *dest = d;
     return PMIX_SUCCESS;
 }
 

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -1248,18 +1248,18 @@ pmix_status_t pmix_bfrops_base_pack_coord(pmix_pointer_array_t *regtypes,
         return PMIX_ERR_BAD_PARAM;
     }
     for (i=0; i < num_vals; ++i) {
-        /* pack the x-coord */
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].x, 1, PMIX_INT, regtypes);
+        /* pack the view */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].view, 1, PMIX_UINT8, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        /* pack the y-coord */
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].y, 1, PMIX_INT, regtypes);
+        /* pack the number of dimensions */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].dims, 1, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        /* pack the z-coord */
-        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].z, 1, PMIX_INT, regtypes);
+        /* pack the array of coordinates */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].coord, ptr[i].dims, PMIX_INT, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }

--- a/src/mca/bfrops/base/bfrop_base_print.c
+++ b/src/mca/bfrops/base/bfrop_base_print.c
@@ -936,6 +936,7 @@ int pmix_bfrops_base_print_status(char **output, char *prefix,
     char *prefx;
     int rc;
     pmix_regattr_t *r;
+    char *tp;
 
     if (PMIX_VALUE != type) {
         return PMIX_ERR_BAD_PARAM;
@@ -1086,8 +1087,17 @@ int pmix_bfrops_base_print_status(char **output, char *prefix,
             break;
 
         case PMIX_COORD:
-            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_COORD\tx-axis: %d\ty-axis: %d\tz-axis: %d",
-                          prefx, src->data.coord->x, src->data.coord->y, src->data.coord->z);
+            if (PMIX_COORD_VIEW_UNDEF == src->data.coord->view) {
+                tp = "UNDEF";
+            } else if (PMIX_COORD_LOGICAL_VIEW == src->data.coord->view) {
+                tp = "LOGICAL";
+            } else if (PMIX_COORD_PHYSICAL_VIEW == src->data.coord->view) {
+                tp = "PHYSICAL";
+            } else {
+                tp = "UNRECOGNIZED";
+            }
+            rc = asprintf(output, "%sPMIX_VALUE: Data type: PMIX_COORD\tView: %s\tDims: %lu",
+                          prefx, tp, (unsigned long)src->data.coord->dims);
             break;
 
         case PMIX_REGATTR:
@@ -1842,6 +1852,7 @@ pmix_status_t pmix_bfrops_base_print_coord(char **output, char *prefix,
 {
     char *prefx;
     int ret;
+    char *tp;
 
     if (PMIX_COORD != type) {
         return PMIX_ERR_BAD_PARAM;
@@ -1855,8 +1866,17 @@ pmix_status_t pmix_bfrops_base_print_coord(char **output, char *prefix,
         prefx = prefix;
     }
 
-    ret = asprintf(output, "%sData type: PMIX_COORD\tx-axis: %d\ty-axis: %d\tz-axis: %d",
-                   prefx, src->x, src->y, src->z);
+    if (PMIX_COORD_VIEW_UNDEF == src->view) {
+        tp = "UNDEF";
+    } else if (PMIX_COORD_LOGICAL_VIEW == src->view) {
+        tp = "LOGICAL";
+    } else if (PMIX_COORD_PHYSICAL_VIEW == src->view) {
+        tp = "PHYSICAL";
+    } else {
+        tp = "UNRECOGNIZED";
+    }
+    ret = asprintf(output, "%sData type: PMIX_COORD\tView: %s\tDims: %lu",
+                   prefx, tp, (unsigned long)src->dims);
     if (prefx != prefix) {
         free(prefx);
     }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -1470,23 +1470,26 @@ pmix_status_t pmix_bfrops_base_unpack_coord(pmix_pointer_array_t *regtypes,
     n = *num_vals;
 
     for (i = 0; i < n; ++i) {
-        /* unpack the x-axis */
+        /* unpack the view */
         m=1;
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].x, &m, PMIX_INT, regtypes);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].view, &m, PMIX_UINT8, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        /* unpack the y-coord */
+        /* unpack the dims */
         m=1;
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].y, &m, PMIX_INT, regtypes);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].dims, &m, PMIX_SIZE, regtypes);
         if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        /* unpack the z-coord */
-        m=1;
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].z, &m, PMIX_INT, regtypes);
-        if (PMIX_SUCCESS != ret) {
-            return ret;
+        if (0 < ptr[i].dims) {
+            ptr[i].coord = (int*)malloc(ptr[i].dims * sizeof(int));
+            /* unpack the coords */
+            m=ptr[i].dims;
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].coord, &m, PMIX_INT, regtypes);
+            if (PMIX_SUCCESS != ret) {
+                return ret;
+            }
         }
     }
     return PMIX_SUCCESS;

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -616,9 +616,9 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                     }
                 }
                 pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                                    "[%s:%d] gds:hash:cache_job_info data for rank %u: key %s",
+                                    "[%s:%d] gds:hash:cache_job_info data for nspace %s rank %u: key %s",
                                     pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                                    rank, kp2->key);
+                                    trk->ns, rank, kp2->key);
                 /* store it in the hash_table */
                 if (PMIX_SUCCESS != (rc = pmix_hash_store(ht, rank, kp2))) {
                     PMIX_ERROR_LOG(rc);

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -623,6 +623,16 @@ static pmix_status_t process_maps(char *nspace, char *nregex, char *pregex)
         return rc;
     }
 
+    /* bozo check */
+    if (pmix_argv_count(nodes) != pmix_argv_count(procs)) {
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        pmix_argv_free(nodes);
+        pmix_argv_free(procs);
+        PMIX_RELEASE_THREAD(&pmix_pnet_globals.lock);
+        return rc;
+    }
+
     /* see if we already know about this job */
     job = NULL;
     if (0 < pmix_list_get_size(&pmix_pnet_globals.jobs)) {

--- a/src/mca/pnet/pnet.h
+++ b/src/mca/pnet/pnet.h
@@ -162,17 +162,6 @@ typedef pmix_status_t (*pmix_pnet_base_module_register_fabric_fn_t)(pmix_fabric_
 /* Deregister the fabric, giving the associated module a chance to cleanup */
 typedef pmix_status_t (*pmix_pnet_base_deregister_fabric_fn_t)(pmix_fabric_t *fabric);
 
-/* Get the number of vertices in the fabric */
-typedef pmix_status_t (*pmix_pnet_base_module_get_num_verts_fn_t)(pmix_fabric_t *fabric,
-                                                                  uint32_t *nverts);
-
-/* Get the cost of communicating from the src to the dest
- * index - i.e., return the [src,dest] location in the
- * communication cost array */
-typedef pmix_status_t (*pmix_pnet_base_module_get_cost_fn_t)(pmix_fabric_t *fabric,
-                                                             uint32_t src, uint32_t dest,
-                                                             uint16_t *cost);
-
 /* Get the identifier and nodename corresponding to the provided
  * index of the communication cost array - caller must provide
  * the address of an allocated pmix_value_t structure */
@@ -182,11 +171,9 @@ typedef pmix_status_t (*pmix_pnet_base_module_get_vertex_fn_t)(pmix_fabric_t *fa
                                                                char **nodename);
 
 /* Get the index in the communication cost array corresponding
- * to the provided identifier and the node upon which it resides */
+ * to the provided identifier(s) */
 typedef pmix_status_t (*pmix_pnet_base_module_get_index_fn_t)(pmix_fabric_t *fabric,
-                                                              pmix_value_t *identifier,
-                                                              uint32_t *i,
-                                                              char **nodename);
+                                                              pmix_value_t *vertex, uint32_t *i);
 /**
  * Base structure for a PNET module. Each component should malloc a
  * copy of the module structure for each fabric plane they support.
@@ -208,8 +195,6 @@ typedef struct {
     pmix_pnet_base_module_deliver_inventory_fn_t    deliver_inventory;
     pmix_pnet_base_module_register_fabric_fn_t      register_fabric;
     pmix_pnet_base_deregister_fabric_fn_t           deregister_fabric;
-    pmix_pnet_base_module_get_num_verts_fn_t        get_num_vertices;
-    pmix_pnet_base_module_get_cost_fn_t             get_cost;
     pmix_pnet_base_module_get_vertex_fn_t           get_vertex;
     pmix_pnet_base_module_get_index_fn_t            get_index;
 } pmix_pnet_module_t;

--- a/src/server/pmix_sched.c
+++ b/src/server/pmix_sched.c
@@ -63,6 +63,11 @@ PMIX_EXPORT pmix_status_t PMIx_server_register_fabric(pmix_fabric_t *fabric,
     pmix_pnet_base_active_module_t *active;
     pmix_status_t rc;
 
+    /* ensure our fields of the fabric object are initialized */
+    fabric->commcost = NULL;
+    fabric->nverts = 0;
+    fabric->module = NULL;
+
     PMIX_ACQUIRE_THREAD(&pmix_pnet_globals.lock);
 
     if (0 == pmix_list_get_size(&pmix_pnet_globals.actives)) {
@@ -108,50 +113,6 @@ PMIX_EXPORT pmix_status_t PMIx_server_deregister_fabric(pmix_fabric_t *fabric)
     return rc;
 }
 
-PMIX_EXPORT pmix_status_t PMIx_server_get_num_vertices(pmix_fabric_t *fabric,
-                                                       uint32_t *nverts)
-{
-    pmix_status_t ret;
-    pmix_pnet_fabric_t *ft;
-    pmix_pnet_module_t *module;
-
-    if (NULL == fabric || NULL == fabric->module) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    ft = (pmix_pnet_fabric_t*)fabric->module;
-    module = (pmix_pnet_module_t*)ft->module;
-
-    if (NULL == module->get_num_vertices) {
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-    ret = module->get_num_vertices(fabric, nverts);
-
-    return ret;
-}
-
-PMIX_EXPORT pmix_status_t PMIx_server_get_comm_cost(pmix_fabric_t *fabric,
-                                                    uint32_t src, uint32_t dest,
-                                                    uint16_t *cost)
-{
-    pmix_status_t ret;
-    pmix_pnet_fabric_t *ft;
-    pmix_pnet_module_t *module;
-
-    if (NULL == fabric || NULL == fabric->module) {
-        return PMIX_ERR_BAD_PARAM;
-    }
-    ft = (pmix_pnet_fabric_t*)fabric->module;
-    module = (pmix_pnet_module_t*)ft->module;
-
-    if (NULL == module->get_cost) {
-        return PMIX_ERR_NOT_SUPPORTED;
-    }
-
-    ret = module->get_cost(fabric, src, dest, cost);
-
-    return ret;
-}
-
 PMIX_EXPORT pmix_status_t PMIx_server_get_vertex_info(pmix_fabric_t *fabric,
                                                       uint32_t i, pmix_value_t *vertex,
                                                       char **nodename)
@@ -176,8 +137,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_get_vertex_info(pmix_fabric_t *fabric,
 }
 
 PMIX_EXPORT pmix_status_t PMIx_server_get_index(pmix_fabric_t *fabric,
-                                                pmix_value_t *vertex, uint32_t *i,
-                                                char **nodename)
+                                                pmix_value_t *vertex, uint32_t *i)
 {
     pmix_status_t ret;
     pmix_pnet_fabric_t *ft;
@@ -193,7 +153,7 @@ PMIX_EXPORT pmix_status_t PMIx_server_get_index(pmix_fabric_t *fabric,
         return PMIX_ERR_NOT_SUPPORTED;
     }
 
-    ret = module->get_index(fabric, vertex, i, nodename);
+    ret = module->get_index(fabric, vertex, i);
 
     return ret;
 }

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -25,7 +25,8 @@ headers = simptest.h
 
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simplegacy simptimeout \
-                  gwtest gwclient stability quietclient simpjctrl simpio simpsched
+                  gwtest gwclient stability quietclient simpjctrl simpio simpsched \
+		  simpcoord
 
 simptest_SOURCES = \
         simptest.c
@@ -133,4 +134,10 @@ simpsched_SOURCES = \
         simpsched.c
 simpsched_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simpsched_LDADD = \
+    $(top_builddir)/src/libpmix.la
+
+simpcoord_SOURCES = \
+        simpcoord.c
+simpcoord_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
+simpcoord_LDADD = \
     $(top_builddir)/src/libpmix.la

--- a/test/simple/simpclient.c
+++ b/test/simple/simpclient.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -129,13 +129,14 @@ int main(int argc, char **argv)
     pmix_value_t *val = &value;
     char *tmp;
     pmix_proc_t proc;
-    uint32_t nprocs, n;
+    uint32_t nprocs, n, *u32;
     int cnt, j;
     bool doabort = false;
     volatile bool active;
     pmix_info_t info, *iptr;
-    size_t ninfo;
+    size_t ninfo, m;
     pmix_status_t code;
+    pmix_coord_t *coords;
 
     if (1 < argc) {
         if (0 == strcmp("-abort", argv[1])) {
@@ -207,6 +208,61 @@ int main(int argc, char **argv)
     nprocs = val->data.uint32;
     PMIX_VALUE_RELEASE(val);
     pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
+
+    /* get our assigned network endpts */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NETWORK_ENDPT, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get network endpt failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    pmix_output(0, "Client %s:%d was assigned %lu endpts",
+                myproc.nspace, myproc.rank,
+                (unsigned long)val->data.darray->size);
+
+    u32 = (uint32_t*)val->data.darray->array;
+    ninfo = val->data.darray->size;
+    {
+        char **foo = NULL;
+        for (n=0; n < ninfo; n++) {
+            asprintf(&tmp, "%d", u32[n]);
+            pmix_argv_append_nosize(&foo, tmp);
+            free(tmp);
+        }
+        tmp = pmix_argv_join(foo, ',');
+        pmix_argv_free(foo);
+        pmix_output(0, "ASSIGNED ENDPTS: %s", tmp);
+        free(tmp);
+    }
+
+    /* get our assigned network coordinates */
+    if (PMIX_SUCCESS != (rc = PMIx_Get(&myproc, PMIX_NETWORK_COORDINATE, NULL, 0, &val))) {
+        pmix_output(0, "Client ns %s rank %d: PMIx_Get network endpt failed: %s",
+                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+        goto done;
+    }
+    pmix_output(0, "Client %s:%d was assigned %lu coordinates",
+                myproc.nspace, myproc.rank,
+                (unsigned long)val->data.darray->size);
+    coords = (pmix_coord_t*)val->data.darray->array;
+    ninfo = val->data.darray->size;
+    for (m=0; m < ninfo; m++) {
+        char **foo = NULL;
+        char *view;
+        for (n=0; n < coords[m].dims; n++) {
+            asprintf(&tmp, "%d", coords[m].coord[n]);
+            pmix_argv_append_nosize(&foo, tmp);
+            free(tmp);
+        }
+        tmp = pmix_argv_join(foo, ',');
+        pmix_argv_free(foo);
+        if (PMIX_COORD_LOGICAL_VIEW == coords[m].view) {
+            view = "LOGICAL";
+        } else {
+            view = "PHYSICAL";
+        }
+        pmix_output(0, "COORD[%d] VIEW %s: %s", (int)m, view, tmp);
+        free(tmp);
+    }
 
     /* put a few values */
     (void)asprintf(&tmp, "%s-%d-internal", myproc.nspace, myproc.rank);

--- a/test/simple/simptest.c
+++ b/test/simple/simptest.c
@@ -229,8 +229,6 @@ static void dlcbfunc(int sd, short flags, void *cbdata)
 {
     myxfer_t *x = (myxfer_t*)cbdata;
 
-    pmix_output(0, "INVENTORY READY FOR DELIVERY");
-
     PMIx_server_deliver_inventory(x->info, x->ninfo, NULL, 0, opcbfunc, (void*)x);
 }
 
@@ -243,8 +241,6 @@ static void infocbfunc(pmix_status_t status,
     mylock_t *lock = (mylock_t*)cbdata;
     myxfer_t *x;
     size_t n;
-
-    pmix_output(0, "INVENTORY RECEIVED");
 
     /* we don't have any place to send this, so for test
      * purposes only, let's push it back down for processing.
@@ -264,6 +260,32 @@ static void infocbfunc(pmix_status_t status,
     }
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
+}
+
+static void setup_cbfunc(pmix_status_t status,
+                         pmix_info_t info[], size_t ninfo,
+                         void *provided_cbdata,
+                         pmix_op_cbfunc_t cbfunc, void *cbdata)
+{
+    myxfer_t *x = (myxfer_t*)provided_cbdata;
+    size_t n;
+
+    /* transfer it to the caddy for return to the main thread */
+    if (0 < ninfo) {
+        PMIX_INFO_CREATE(x->info, ninfo);
+        x->ninfo = ninfo;
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&x->info[n], &info[n]);
+        }
+    }
+
+    /* let the library release the data and cleanup from
+     * the operation */
+    if (NULL != cbfunc) {
+        cbfunc(PMIX_SUCCESS, cbdata);
+    }
+
+    DEBUG_WAKEUP_THREAD(&x->lock);
 }
 
 /* this is an event notification function that we explicitly request
@@ -356,6 +378,10 @@ int main(int argc, char **argv)
         fprintf(stderr, "ERROR IN COMPUTING CONSTANTS: PMIX_SUCCESS = %d\n", PMIX_SUCCESS);
         exit(1);
     }
+
+    /* set a known network configuration for the pnet/test component */
+    putenv("PMIX_MCA_pnet_test_nverts=nodes:5;plane:d:3;plane:s:2;plane:d:5");
+    putenv("PMIX_MCA_pnet=test");
 
     /* see if we were passed the number of procs to run or
      * the executable to use */
@@ -465,7 +491,7 @@ int main(int argc, char **argv)
 
     PMIX_INFO_CREATE(info, ninfo);
     PMIX_INFO_LOAD(&info[0], PMIX_SERVER_TOOL_SUPPORT, NULL, PMIX_BOOL);
-    PMIX_INFO_LOAD(&info[1], PMIX_SERVER_GATEWAY, NULL, PMIX_BOOL);
+    PMIX_INFO_LOAD(&info[1], PMIX_SERVER_SCHEDULER, NULL, PMIX_BOOL);
 #if PMIX_HAVE_HWLOC
     if (hwloc) {
         if (NULL != hwloc_file) {
@@ -706,17 +732,63 @@ int main(int argc, char **argv)
 static void set_namespace(int nprocs, char *ranks, char *nspace,
                           pmix_op_cbfunc_t cbfunc, myxfer_t *x)
 {
-    char *regex, *ppn;
-    char hostname[PMIX_MAXHOSTNAMELEN];
+    char *regex, *ppn, *rks;
     int n, m, k;
     pmix_data_array_t *array;
-    pmix_info_t *info;
+    pmix_info_t *info, *iptr, *ip;
+    myxfer_t cd, lock;
+    pmix_status_t rc;
 
-    gethostname(hostname, sizeof(hostname));
     x->ninfo = 16 + nprocs;
 
     PMIX_INFO_CREATE(x->info, x->ninfo);
     n = 0;
+
+    PMIx_generate_regex("test000,test001,test002", &regex);
+    (void)strncpy(x->info[n].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
+    x->info[n].value.type = PMIX_STRING;
+    x->info[n].value.data.string = regex;
+    ++n;
+
+    /* if we have some empty nodes, then fill their spots */
+    PMIx_generate_ppn("0;1;2", &ppn);
+    (void)strncpy(x->info[n].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
+    x->info[n].value.type = PMIX_STRING;
+    x->info[n].value.data.string = ppn;
+    ++n;
+
+    /* we have the required info to run setup_app, so do that now */
+    PMIX_INFO_CREATE(iptr, 4);
+    PMIX_INFO_XFER(&iptr[0], &x->info[0]);
+    PMIX_INFO_XFER(&iptr[1], &x->info[1]);
+    PMIX_INFO_LOAD(&iptr[2], PMIX_SETUP_APP_ENVARS, NULL, PMIX_BOOL);
+    PMIX_LOAD_KEY(iptr[3].key, PMIX_ALLOC_NETWORK);
+    iptr[3].value.type = PMIX_DATA_ARRAY;
+    PMIX_DATA_ARRAY_CREATE(iptr[3].value.data.darray, 2, PMIX_INFO);
+    ip = (pmix_info_t*)iptr[3].value.data.darray->array;
+    asprintf(&rks, "%s.net", nspace);
+    PMIX_INFO_LOAD(&ip[0], PMIX_ALLOC_NETWORK_ID, rks, PMIX_STRING);
+    free(rks);
+    PMIX_INFO_LOAD(&ip[1], PMIX_ALLOC_NETWORK_SEC_KEY, NULL, PMIX_BOOL);
+    PMIX_CONSTRUCT(&cd, myxfer_t);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_application(nspace, iptr, 4,
+                                                             setup_cbfunc, &cd))) {
+        pmix_output(0, "[%s:%d] PMIx_server_setup_application failed: %s", __FILE__, __LINE__, PMIx_Error_string(rc));
+        DEBUG_DESTRUCT_LOCK(&cd.lock);
+    } else {
+        DEBUG_WAIT_THREAD(&cd.lock);
+    }
+
+    /* use the results to setup the local subsystems */
+    PMIX_CONSTRUCT(&lock, myxfer_t);
+    if (PMIX_SUCCESS != (rc = PMIx_server_setup_local_support(nspace, cd.info, cd.ninfo,
+                                                                  opcbfunc, &lock))) {
+        pmix_output(0, "[%s:%d] PMIx_server_setup_local_support failed: %s", __FILE__, __LINE__, PMIx_Error_string(rc));
+    } else {
+        DEBUG_WAIT_THREAD(&lock.lock);
+    }
+    PMIX_DESTRUCT(&lock);
+    PMIX_DESTRUCT(&cd);
 
     (void)strncpy(x->info[n].key, PMIX_UNIV_SIZE, PMIX_MAX_KEYLEN);
     x->info[n].value.type = PMIX_UINT32;
@@ -736,18 +808,6 @@ static void set_namespace(int nprocs, char *ranks, char *nspace,
     (void)strncpy(x->info[n].key, PMIX_LOCAL_PEERS, PMIX_MAX_KEYLEN);
     x->info[n].value.type = PMIX_STRING;
     x->info[n].value.data.string = strdup(ranks);
-    ++n;
-
-    PMIx_generate_regex(hostname, &regex);
-    (void)strncpy(x->info[n].key, PMIX_NODE_MAP, PMIX_MAX_KEYLEN);
-    x->info[n].value.type = PMIX_STRING;
-    x->info[n].value.data.string = regex;
-    ++n;
-
-    PMIx_generate_ppn(ranks, &ppn);
-    (void)strncpy(x->info[n].key, PMIX_PROC_MAP, PMIX_MAX_KEYLEN);
-    x->info[n].value.type = PMIX_STRING;
-    x->info[n].value.data.string = ppn;
     ++n;
 
     (void)strncpy(x->info[n].key, PMIX_JOB_SIZE, PMIX_MAX_KEYLEN);
@@ -860,8 +920,6 @@ static void errhandler_reg_callbk (pmix_status_t status,
 {
     mylock_t *lock = (mylock_t*)cbdata;
 
-    pmix_output(0, "SERVER: ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
-                status, (unsigned long)errhandler_ref);
     lock->status = status;
     DEBUG_WAKEUP_THREAD(lock);
 }
@@ -874,8 +932,6 @@ static pmix_status_t connected(const pmix_proc_t *proc, void *server_object,
 static pmix_status_t finalized(const pmix_proc_t *proc, void *server_object,
                      pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_output(0, "SERVER: FINALIZED %s:%d WAKEUP %d",
-                proc->nspace, proc->rank, wakeup);
     return PMIX_OPERATION_SUCCEEDED;
 }
 
@@ -951,7 +1007,6 @@ static pmix_status_t fencenb_fn(const pmix_proc_t procs[], size_t nprocs,
 {
     pmix_shift_caddy_t *scd;
 
-    pmix_output(0, "SERVER: FENCENB");
     scd = PMIX_NEW(pmix_shift_caddy_t);
     scd->status = PMIX_SUCCESS;
     scd->data = data;
@@ -968,8 +1023,6 @@ static pmix_status_t dmodex_fn(const pmix_proc_t *proc,
                      pmix_modex_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_shift_caddy_t *scd;
-
-    pmix_output(0, "SERVER: DMODEX");
 
     /* if this is a timeout test, then do nothing */
     if (istimeouttest) {
@@ -992,8 +1045,6 @@ static pmix_status_t publish_fn(const pmix_proc_t *proc,
 {
     pmix_locdat_t *p;
     size_t n;
-
-    pmix_output(0, "SERVER: PUBLISH");
 
     for (n=0; n < ninfo; n++) {
         p = PMIX_NEW(pmix_locdat_t);
@@ -1034,8 +1085,6 @@ static pmix_status_t lookup_fn(const pmix_proc_t *proc, char **keys,
     pmix_pdata_t *pd = NULL;
     pmix_status_t ret = PMIX_ERR_NOT_FOUND;
     lkobj_t *lk;
-
-    pmix_output(0, "SERVER: LOOKUP");
 
     PMIX_CONSTRUCT(&results, pmix_list_t);
 
@@ -1086,8 +1135,6 @@ static pmix_status_t unpublish_fn(const pmix_proc_t *proc, char **keys,
     pmix_locdat_t *p, *p2;
     size_t n;
 
-    pmix_output(0, "SERVER: UNPUBLISH");
-
     for (n=0; NULL != keys[n]; n++) {
         PMIX_LIST_FOREACH_SAFE(p, p2, &pubdata, pmix_locdat_t) {
             if (0 == strncmp(keys[n], p->pdata.key, PMIX_MAX_KEYLEN)) {
@@ -1118,8 +1165,6 @@ static pmix_status_t spawn_fn(const pmix_proc_t *proc,
     size_t n;
     pmix_proc_t *pptr;
     bool spawned;
-
-    pmix_output(0, "SERVER: SPAWN");
 
     /* check the job info for parent and spawned keys */
     for (n=0; n < ninfo; n++) {
@@ -1154,8 +1199,6 @@ static pmix_status_t connect_fn(const pmix_proc_t procs[], size_t nprocs,
                                 const pmix_info_t info[], size_t ninfo,
                                 pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_output(0, "SERVER: CONNECT");
-
     /* in practice, we would pass this request to the local
      * resource manager for handling */
 
@@ -1169,8 +1212,6 @@ static pmix_status_t disconnect_fn(const pmix_proc_t procs[], size_t nprocs,
                                    const pmix_info_t info[], size_t ninfo,
                                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_output(0, "SERVER: DISCONNECT");
-
     return PMIX_OPERATION_SUCCEEDED;
 }
 
@@ -1193,7 +1234,6 @@ static pmix_status_t notify_event(pmix_status_t code,
                                   pmix_info_t info[], size_t ninfo,
                                   pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
-    pmix_output(0, "SERVER: NOTIFY EVENT");
     return PMIX_OPERATION_SUCCEEDED;
 }
 
@@ -1222,8 +1262,6 @@ static pmix_status_t query_fn(pmix_proc_t *proct,
     pmix_info_t *info;
     query_data_t qd;
 
-    pmix_output(0, "SERVER: QUERY");
-
     if (NULL == cbfunc) {
         return PMIX_ERROR;
     }
@@ -1251,8 +1289,6 @@ static void tool_connect_fn(pmix_info_t *info, size_t ninfo,
 {
     pmix_proc_t proc;
 
-    pmix_output(0, "SERVER: TOOL CONNECT");
-
     /* just pass back an arbitrary nspace */
     (void)strncpy(proc.nspace, "TOOL", PMIX_MAX_NSLEN);
     proc.rank = 0;
@@ -1279,8 +1315,6 @@ static void log_fn(const pmix_proc_t *client,
                    pmix_op_cbfunc_t cbfunc, void *cbdata)
 {
     mylog_t *lg = (mylog_t *)malloc(sizeof(mylog_t));
-
-    pmix_output(0, "SERVER: LOG");
 
     lg->cbfunc = cbfunc;
     lg->cbdata = cbdata;


### PR DESCRIPTION
Provide a more flexible definition for pmix_coord_t that supports
arbitrary dimensionality and offers multiple points-of-view for the
fabric. Implement the pnet/test component to provide coordinates based
on an MCA parameter definition for planes, switches, and nodes. Update
the simple tests to exercise it and display the result.

Signed-off-by: Ralph Castain <rhc@pmix.org>