### PR TITLE
util/environ: use setenv() if available

### DIFF
--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -664,7 +664,7 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     # -lrt might be needed for clock_gettime
     PMIX_SEARCH_LIBS_CORE([clock_gettime], [rt])
 
-    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty])
+    AC_CHECK_FUNCS([asprintf snprintf vasprintf vsnprintf strsignal socketpair strncpy_s usleep statfs statvfs getpeereid getpeerucred strnlen posix_fallocate tcgetpgrp setpgid ptsname openpty setenv])
 
     # On some hosts, htonl is a define, so the AC_CHECK_FUNC will get
     # confused.  On others, it's in the standard library, but stubbed with

--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -14,6 +14,8 @@
  *                         reserved.
  * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -129,7 +131,13 @@ char **pmix_environ_merge(char **minor, char **major)
            astonishmet for PMIX developers (i.e., those that don't
            check the return code of pmix_setenv() and notice that we
            returned an error if you passed in the real environ) */
+#if defined (HAVE_SETENV)
+        setenv(name, value, overwrite);
+        /* setenv copies the value, so we can free it here */
+        free(newvalue);
+#else
         putenv(newvalue);
+#endif
         return PMIX_SUCCESS;
     }
 


### PR DESCRIPTION
setenv() is more friendly than putenv() with respect to
valgrind that does not report a memory leak with the former.

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>