### PR TITLE
Silence Coverity warning

### DIFF
--- a/src/util/pmix_environ.c
+++ b/src/util/pmix_environ.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2006      Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2007-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
- * Copyright (c) 2014-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * Copyright (c) 2019      Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
@@ -32,10 +32,12 @@
 #include <string.h>
 
 #include "src/util/printf.h"
+#include "src/util/error.h"
 #include "src/util/argv.h"
 #include "src/util/pmix_environ.h"
 
 #define PMIX_DEFAULT_TMPDIR "/tmp"
+#define PMIX_MAX_ENVAR_LENGTH   100000
 
 /*
  * Merge two environ-like char arrays, ensuring that there are no
@@ -76,7 +78,7 @@ char **pmix_environ_merge(char **minor, char **major)
             pmix_setenv(minor[i], NULL, false, &ret);
         } else {
 
-            /* strdup minor[i] in case it's a constat string */
+            /* strdup minor[i] in case it's a constant string */
 
             name = strdup(minor[i]);
             value = name + (value - minor[i]);
@@ -101,9 +103,60 @@ char **pmix_environ_merge(char **minor, char **major)
     int i;
     char *newvalue, *compare;
     size_t len;
+    bool valid;
+
+    /* Check the bozo case */
+    if( NULL == env ) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    if (NULL != value) {
+        /* check the string for unacceptable length - i.e., ensure
+         * it is NULL-terminated */
+        valid = false;
+        for (i=0; i < PMIX_MAX_ENVAR_LENGTH; i++) {
+            if ('\0' == value[i]) {
+                valid = true;
+                break;
+            }
+        }
+        if (!valid) {
+            PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+            return PMIX_ERR_BAD_PARAM;
+        }
+    }
+
+    /* If this is the "environ" array, use putenv or setenv */
+    if (*env == environ) {
+        /* THIS IS POTENTIALLY A MEMORY LEAK!  But I am doing it
+           because so that we don't violate the law of least
+           astonishmet for PMIX developers (i.e., those that don't
+           check the return code of pmix_setenv() and notice that we
+           returned an error if you passed in the real environ) */
+#if defined (HAVE_SETENV)
+        if (NULL == value) {
+            /* this is actually an unsetenv request */
+            unsetenv(name);
+        } else {
+            setenv(name, value, overwrite);
+        }
+#else
+        /* Make the new value */
+        if (NULL == value) {
+            i = asprintf(&newvalue, "%s=", name);
+        } else {
+            i = asprintf(&newvalue, "%s=%s", name, value);
+        }
+        if (NULL == newvalue || 0 > i) {
+            return PMIX_ERR_OUT_OF_RESOURCE;
+        }
+        putenv(newvalue);
+        /* cannot free it as putenv doesn't copy the value */
+#endif
+        return PMIX_SUCCESS;
+    }
 
     /* Make the new value */
-
     if (NULL == value) {
         i = asprintf(&newvalue, "%s=", name);
     } else {
@@ -113,31 +166,10 @@ char **pmix_environ_merge(char **minor, char **major)
         return PMIX_ERR_OUT_OF_RESOURCE;
     }
 
-    /* Check the bozo case */
-
-    if( NULL == env ) {
-        return PMIX_ERR_BAD_PARAM;
-    } else if (NULL == *env) {
+    if (NULL == *env) {
         i = 0;
         pmix_argv_append(&i, env, newvalue);
         free(newvalue);
-        return PMIX_SUCCESS;
-    }
-
-    /* If this is the "environ" array, use putenv */
-    if( *env == environ ) {
-        /* THIS IS POTENTIALLY A MEMORY LEAK!  But I am doing it
-           because so that we don't violate the law of least
-           astonishmet for PMIX developers (i.e., those that don't
-           check the return code of pmix_setenv() and notice that we
-           returned an error if you passed in the real environ) */
-#if defined (HAVE_SETENV)
-        setenv(name, value, overwrite);
-        /* setenv copies the value, so we can free it here */
-        free(newvalue);
-#else
-        putenv(newvalue);
-#endif
         return PMIX_SUCCESS;
     }
 


### PR DESCRIPTION
Try an approach to resolving the "tainted value" warning by checking the
envar string for NULL-termination. Protect setenv against a NULL input.

Signed-off-by: Ralph Castain <rhc@pmix.org>