### PR TITLE
Implement support for class-based info arrays

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -76,6 +76,45 @@ Master (not on release branches yet)
  - Fix a bug when registering default event handlers
 
 
+3.1.0 -- 17 Jan 2019
+----------------------
+**** THIS RELEASE MARKS THE STARTING POINT FOR FULL COMPLIANCE
+**** WITH THE PMIX v3 STANDARD. ALL API BEHAVIORS AND ATTRIBUTE
+**** DEFINITIONS MEET THE v3 STANDARD SPECIFICATIONS.
+ - Add a new, faster dstore GDS component 'ds21'
+ - Performance optimizations for the dstore GDS components.
+ - Plug miscellaneous memory leaks
+ - Silence an unnecessary warning message when checking connection
+   to a non-supporting server
+ - Ensure lost-connection events get delivered to default event
+   handlers
+ - Correctly handle cache refresh for queries
+ - Protect against race conditions between host and internal library
+   when dealing with async requests
+ - Cleanup tool operations and add support for connections to
+   remote servers. Initial support for debugger direct/indirect
+   launch verified with PRRTE. Cleanup setting of tmpdir options.
+   Drop rendezvous files when acting as a launcher
+ - Automatically store the server URI for easy access by client
+ - Provide MCA parameter to control TCP connect retry/timeout
+ - Update event notification system to properly evict oldest events
+   when more space is needed
+ - Fix a number of error paths
+ - Update IOF cache code to properly drop oldest message. Provide
+   MCA parameter for setting cache size.
+ - Handle setsockopt(SO_RCVTIMEO) not being supported
+ - Ensure that epilogs get run even when connections unexpectedly
+   terminate. Properly split epilog strings to process multiple
+   paths
+ - Pass the tool's command line to the server so it can be returned
+   in queries
+ - Add support for C11 atomics
+ - Support collection and forwarding of fabric-specific envars
+ - Improve handling of hwloc configure option
+ - Fix PMIx_server_generate_regex to preserve node ordering
+ - Fix a bug when registering default event handlers
+
+
 3.0.2 -- 18 Sept 2018
 ----------------------
 - Ensure we cleanup any active sensors when a peer departs. Allow the

--- a/src/common/pmix_query.c
+++ b/src/common/pmix_query.c
@@ -146,6 +146,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     pmix_list_t results;
     pmix_kval_t *kv, *kvnxt;
     pmix_proc_t proc;
+    bool rank_given;
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
@@ -193,6 +194,7 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
     memset(proc.nspace, 0, PMIX_MAX_NSLEN+1);
     proc.rank = PMIX_RANK_INVALID;
     for (n=0; n < nqueries; n++) {
+        rank_given = false;
         /* check for requests to report supported attributes */
         if (0 == strcmp(queries[n].keys[0], PMIX_QUERY_ATTRIBUTE_SUPPORT)) {
             cd = PMIX_NEW(pmix_query_caddy_t);
@@ -216,37 +218,41 @@ PMIX_EXPORT pmix_status_t PMIx_Query_info_nb(pmix_query_t queries[], size_t nque
             } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_PROCID)) {
                 PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.proc->nspace);
                 proc.rank = queries[n].qualifiers[p].value.data.proc->rank;
+                rank_given = true;
             } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_NSPACE)) {
                 PMIX_LOAD_NSPACE(proc.nspace, queries[n].qualifiers[p].value.data.string);
             } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_RANK)) {
                 proc.rank = queries[n].qualifiers[p].value.data.rank;
-            } else if (PMIX_CHECK_KEY(&queries[n].qualifiers[p], PMIX_HOSTNAME)) {
-                if (0 != strcmp(queries[n].qualifiers[p].value.data.string, pmix_globals.hostname)) {
-                    /* asking about a different host, so ask for the info */
-                    PMIX_LIST_DESTRUCT(&results);
-                    goto query;
-                }
+                rank_given = true;
             }
         }
         /* we get here if a refresh isn't required - first try a local
          * "get" on the data to see if we already have it */
         PMIX_CONSTRUCT(&cb, pmix_cb_t);
         cb.copy = false;
-        /* set the proc */
-        if (PMIX_RANK_INVALID == proc.rank &&
-            0 == strlen(proc.nspace)) {
-            /* use our id */
-            cb.proc = &pmix_globals.myid;
-        } else {
-            if (0 == strlen(proc.nspace)) {
-                /* use our nspace */
-                PMIX_LOAD_NSPACE(cb.proc->nspace, pmix_globals.myid.nspace);
-            }
-            if (PMIX_RANK_INVALID == proc.rank) {
-                /* user the wildcard rank */
-                proc.rank = PMIX_RANK_WILDCARD;
-            }
+        /* if they are querying about node or app values not directly
+         * associated with a proc (i.e., they didn't specify the proc),
+         * then we obtain those by leaving the proc info as undefined */
+        if (!rank_given) {
+            proc.rank = PMIX_RANK_UNDEF;
             cb.proc = &proc;
+        } else {
+            /* set the proc */
+            if (PMIX_RANK_INVALID == proc.rank &&
+                0 == strlen(proc.nspace)) {
+                /* use our id */
+                cb.proc = &pmix_globals.myid;
+            } else {
+                if (0 == strlen(proc.nspace)) {
+                    /* use our nspace */
+                    PMIX_LOAD_NSPACE(cb.proc->nspace, pmix_globals.myid.nspace);
+                }
+                if (PMIX_RANK_INVALID == proc.rank) {
+                    /* user the wildcard rank */
+                    proc.rank = PMIX_RANK_WILDCARD;
+                }
+                cb.proc = &proc;
+            }
         }
         for (p=0; NULL != queries[n].keys[p]; p++) {
             cb.key = queries[n].keys[p];

--- a/src/include/pmix_globals.c
+++ b/src/include/pmix_globals.c
@@ -308,6 +308,7 @@ static void cbcon(pmix_cb_t *p)
     PMIX_CONSTRUCT(&p->kvs, pmix_list_t);
     p->copy = false;
     p->timer_running = false;
+    p->level = PMIX_LEVEL_UNDEF;
 }
 static void cbdes(pmix_cb_t *p)
 {

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -133,6 +133,16 @@ typedef enum {
     PMIX_COLLECT_MAX
 } pmix_collect_t;
 
+/* define a set of flags indicating the level
+ * of information being stored/requested */
+typedef enum {
+    PMIX_LEVEL_UNDEF,
+    PMIX_LEVEL_SESSION,
+    PMIX_LEVEL_JOB,
+    PMIX_LEVEL_APP,
+    PMIX_LEVEL_NODE
+} pmix_level_t;
+
 /****    PEER STRUCTURES    ****/
 
 /* clients can only talk to their server, and servers are
@@ -406,6 +416,7 @@ typedef struct {
     pmix_list_t kvs;
     bool copy;
     bool timer_running;
+    pmix_level_t level;
 } pmix_cb_t;
 PMIX_CLASS_DECLARATION(pmix_cb_t);
 

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -943,8 +943,7 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     pmix_list_t cache, ncache;
     pmix_nodeinfo_t *nd;
 
-  //  pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-    pmix_output(0,
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:cache_job_info for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         nptr->nspace);

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -36,13 +36,14 @@
 #include "src/class/pmix_list.h"
 #include "src/client/pmix_client_ops.h"
 #include "src/server/pmix_server_ops.h"
-#include "src/util/argv.h"
 #include "src/mca/pcompress/base/base.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/hash.h"
 #include "src/util/output.h"
+#include "src/util/name_fns.h"
 #include "src/util/pmix_environ.h"
-#include "src/mca/preg/preg.h"
 
 #include "src/mca/gds/base/base.h"
 #include "gds_hash.h"
@@ -274,6 +275,9 @@ static pmix_status_t process_node_array(pmix_info_t *info,
     pmix_nodeinfo_t *nd = NULL, *ndptr;
     bool update;
 
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "PROCESSING NODE ARRAY");
+
     /* array of node-level info for a specific node */
     if (PMIX_DATA_ARRAY != info->value.type) {
         PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
@@ -387,6 +391,9 @@ static pmix_status_t process_app_array(pmix_info_t *info,
     pmix_kval_t *kp2, *k1, *knext;
     pmix_nodeinfo_t *nd;
     bool update;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "PROCESSING APP ARRAY");
 
     /* apps have to belong to a job */
     if (NULL == trk) {
@@ -519,6 +526,7 @@ static pmix_status_t process_job_array(pmix_info_t *info,
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "PROCESSING JOB ARRAY");
+
     /* array of job-level info */
     if (PMIX_DATA_ARRAY != info->value.type) {
         PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
@@ -1985,6 +1993,229 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
 }
 
 
+static pmix_status_t dohash(pmix_hash_table_t *ht,
+                            const char *key,
+                            pmix_rank_t rank,
+                            pmix_list_t *kvs)
+{
+    pmix_status_t rc;
+    pmix_value_t *val;
+    pmix_kval_t *kv, *k2;
+    pmix_info_t *info;
+    size_t n, ninfo;
+
+    rc = pmix_hash_fetch(ht, rank, key, &val);
+    if (PMIX_SUCCESS == rc) {
+    pmix_output(0, "%s: FOUND %s", PMIX_NAME_PRINT(&pmix_globals.myid), (NULL == key) ? "NULL" : key);
+        /* if the key was NULL, then all found keys will be
+         * returned as a pmix_data_array_t in the value */
+        if (NULL == key) {
+            if (NULL == val->data.darray ||
+                PMIX_INFO != val->data.darray->type ||
+                0 == val->data.darray->size) {
+                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
+                return PMIX_ERR_NOT_FOUND;
+            }
+            info = (pmix_info_t*)val->data.darray->array;
+            ninfo = val->data.darray->size;
+            for (n=0; n < ninfo; n++) {
+                /* see if we already have this on the list */
+                kv = NULL;
+                PMIX_LIST_FOREACH(k2, kvs, pmix_kval_t) {
+                    if (PMIX_CHECK_KEY(&info[n], k2->key)) {
+                        kv = k2;
+                        break;
+                    }
+                }
+                if (NULL != kv) {
+                    continue;
+                }
+                kv = PMIX_NEW(pmix_kval_t);
+                if (NULL == kv) {
+                    PMIX_VALUE_RELEASE(val);
+                    return PMIX_ERR_NOMEM;
+                }
+                kv->key = strdup(info[n].key);
+                pmix_output(0, "ARRAY ADDING %s", kv->key);
+                kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                if (NULL == kv->value) {
+                    PMIX_VALUE_RELEASE(val);
+                    PMIX_RELEASE(kv);
+                    return PMIX_ERR_NOMEM;
+                }
+                PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
+                                       kv->value, &info[n].value);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_ERROR_LOG(rc);
+                    PMIX_VALUE_RELEASE(val);
+                    PMIX_RELEASE(kv);
+                    return rc;
+                }
+                pmix_list_append(kvs, &kv->super);
+            }
+            PMIX_VALUE_RELEASE(val);
+        } else {
+            kv = PMIX_NEW(pmix_kval_t);
+            if (NULL == kv) {
+                PMIX_VALUE_RELEASE(val);
+                return PMIX_ERR_NOMEM;
+            }
+            kv->key = strdup(key);
+            pmix_output(0, "ADDING %s", kv->key);
+            kv->value = val;
+            pmix_list_append(kvs, &kv->super);
+        }
+    }
+    return rc;
+}
+
+static pmix_status_t fetch_nodeinfo(const char *key, pmix_list_t *tgt,
+                                    pmix_info_t *info, size_t ninfo,
+                                    pmix_list_t *kvs)
+{
+    size_t n;
+    pmix_status_t rc;
+    uint32_t nid;
+    char *hostname = NULL;
+    bool found = false;
+    pmix_nodeinfo_t *nd, *ndptr;
+    pmix_kval_t *kv, *kp2;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING NODE INFO");
+
+    /* scan for the nodeID or hostname to identify
+     * which node they are asking about */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_NODEID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, nid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            found = true;
+            break;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_HOSTNAME)) {
+            hostname = info[n].value.data.string;
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+    }
+
+    /* scan the list of nodes to find the matching entry */
+    nd = NULL;
+    PMIX_LIST_FOREACH(ndptr, tgt, pmix_nodeinfo_t) {
+        if (NULL != hostname && 0 == strcmp(nd->hostname, hostname)) {
+            nd = ndptr;
+            break;
+        }
+        if (NULL == hostname && nid == ndptr->nodeid) {
+            nd = ndptr;
+            break;
+        }
+    }
+    if (NULL == nd) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+    /* scan the info list of this node to generate the results */
+    rc = PMIX_ERR_NOT_FOUND;
+    PMIX_LIST_FOREACH(kv, &nd->info, pmix_kval_t) {
+        if (NULL == key || PMIX_CHECK_KEY(kv, key)) {
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(kv->key);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            PMIX_VALUE_XFER(rc, kp2->value, kv->value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                return rc;
+            }
+            pmix_list_append(kvs, &kp2->super);
+            rc = PMIX_SUCCESS;
+            if (NULL != key) {
+                break;
+            }
+        }
+    }
+
+    return rc;
+}
+
+static pmix_status_t fetch_appinfo(const char *key, pmix_list_t *tgt,
+                                   pmix_info_t *info, size_t ninfo,
+                                   pmix_list_t *kvs)
+{
+    size_t n;
+    pmix_status_t rc;
+    uint32_t appnum;
+    bool found = false;
+    pmix_apptrkr_t *app, *apptr;
+    pmix_kval_t *kv, *kp2;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "FETCHING APP INFO");
+
+    /* scan for the appnum to identify
+     * which app they are asking about */
+    for (n=0; n < ninfo; n++) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_APPNUM)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, appnum, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+            found = true;
+            break;
+        }
+    }
+    if (!found) {
+        return PMIX_ERR_DATA_VALUE_NOT_FOUND;
+    }
+
+    /* scan the list of apps to find the matching entry */
+    app = NULL;
+    PMIX_LIST_FOREACH(apptr, tgt, pmix_apptrkr_t) {
+        if (appnum == apptr->appnum) {
+            app = apptr;
+            break;
+        }
+    }
+    if (NULL == app) {
+        return PMIX_ERR_NOT_FOUND;
+    }
+
+    /* see if they wanted to know something about a node that
+     * is associated with this app */
+    rc = fetch_nodeinfo(key, &app->nodeinfo, info, ninfo, kvs);
+    if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
+        return rc;
+    }
+
+    /* scan the info list of this app to generate the results */
+    rc = PMIX_ERR_NOT_FOUND;
+    PMIX_LIST_FOREACH(kv, &app->appinfo, pmix_kval_t) {
+        if (NULL == key || PMIX_CHECK_KEY(kv, key)) {
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(kv->key);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            PMIX_VALUE_XFER(rc, kp2->value, kv->value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                return rc;
+            }
+            pmix_list_append(kvs, &kp2->super);
+            rc = PMIX_SUCCESS;
+            if (NULL != key) {
+                break;
+            }
+        }
+    }
+
+    return rc;
+}
+
 static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                                 pmix_scope_t scope, bool copy,
                                 const char *key,
@@ -1994,10 +2225,13 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     pmix_job_t *trk, *t;
     pmix_status_t rc;
     pmix_value_t *val;
-    pmix_kval_t *kv;
+    pmix_kval_t *kv, *kvptr;
     pmix_info_t *info;
     size_t n, ninfo;
     pmix_hash_table_t *ht;
+    pmix_session_t *sptr;
+    uint32_t sid;
+    pmix_rank_t rnk;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%u] pmix:gds:hash fetch %s for proc %s:%u on scope %s",
@@ -2067,6 +2301,55 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
         return PMIX_SUCCESS;
     }
 
+    /* if the nspace and rank are undefined, then they are asking
+     * for session-level information. */
+    if (0 == strlen(proc->nspace) && PMIX_RANK_UNDEF == proc->rank) {
+        /* they must have included something identifying the info
+         * class they are querying */
+        for (n=0; n < nqual; n++) {
+            if (PMIX_CHECK_KEY(&qualifiers[n], PMIX_SESSION_ID)) {
+                /* they want session-level info - see if we have
+                 * that session */
+                PMIX_VALUE_GET_NUMBER(rc, &qualifiers[n].value, sid, uint32_t);
+                if (PMIX_SUCCESS != rc) {
+                    /* didn't provide a correct value */
+                    PMIX_ERROR_LOG(rc);
+                    return rc;
+                }
+                PMIX_LIST_FOREACH(sptr, &mysessions, pmix_session_t) {
+                    if (sptr->session == sid) {
+                        /* see if they want info for a specific node */
+                        rc = fetch_nodeinfo(key, &sptr->nodeinfo, qualifiers, nqual, kvs);
+                        /* if they did, then we are done */
+                        if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
+                            return rc;
+                        }
+                        /* check the session info */
+                        PMIX_LIST_FOREACH(kvptr, &sptr->sessioninfo, pmix_kval_t) {
+                            if (NULL == key || PMIX_CHECK_KEY(kvptr, key)) {
+                                kv = PMIX_NEW(pmix_kval_t);
+                                kv->key = strdup(kvptr->key);
+                                kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                                PMIX_VALUE_XFER(rc, kv->value, kvptr->value);
+                                if (PMIX_SUCCESS != rc) {
+                                    PMIX_RELEASE(kv);
+                                    return rc;
+                                }
+                                pmix_list_append(kvs, &kv->super);
+                                if (NULL != key) {
+                                    /* we are done */
+                                    return PMIX_SUCCESS;
+                                }
+                            }
+                        }
+                    }
+                }
+                /* if we get here, then the session wasn't found */
+                return PMIX_ERR_NOT_FOUND;
+            }
+        }
+    }
+
     /* find the hash table for this nspace */
     trk = NULL;
     PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
@@ -2077,6 +2360,24 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     }
     if (NULL == trk) {
         return PMIX_ERR_INVALID_NAMESPACE;
+    }
+
+    /* if the rank isn't specified, check to see if they
+     * are looking for app-level or node-level info for
+     * this job */
+    if (PMIX_RANK_UNDEF == proc->rank) {
+        /* see if they want info for a specific node */
+        rc = fetch_nodeinfo(key, &trk->nodeinfo, qualifiers, nqual, kvs);
+        /* if they did, then we are done */
+        if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
+            return rc;
+        }
+        /* see if they want info for a specific app */
+        rc = fetch_appinfo(key, &trk->apps, qualifiers, nqual, kvs);
+        /* if they did, then we are done */
+        if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
+            return rc;
+        }
     }
 
     /* fetch from the corresponding hash table - note that
@@ -2098,59 +2399,55 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     }
 
   doover:
-    rc = pmix_hash_fetch(ht, proc->rank, key, &val);
-    if (PMIX_SUCCESS == rc) {
-        /* if the key was NULL, then all found keys will be
-         * returned as a pmix_data_array_t in the value */
-        if (NULL == key) {
-            if (NULL == val->data.darray ||
-                PMIX_INFO != val->data.darray->type ||
-                0 == val->data.darray->size) {
-                PMIX_ERROR_LOG(PMIX_ERR_NOT_FOUND);
-                return PMIX_ERR_NOT_FOUND;
+    /* if rank=PMIX_RANK_UNDEF, then we need to search all
+     * known ranks for this nspace as any one of them could
+     * be the source */
+    if (PMIX_RANK_UNDEF == proc->rank) {
+        for (rnk=0; rnk < trk->nptr->nprocs; rnk++) {
+            rc = dohash(ht, key, rnk, kvs);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
             }
-            info = (pmix_info_t*)val->data.darray->array;
-            ninfo = val->data.darray->size;
-            for (n=0; n < ninfo; n++) {
+            if (NULL != key) {
+                return rc;
+            }
+        }
+        /* also need to check any info that came in via
+         * a job-level info array */
+        PMIX_LIST_FOREACH(kvptr, &trk->jobinfo, pmix_kval_t) {
+            if (NULL == key || PMIX_CHECK_KEY(kvptr, key)) {
                 kv = PMIX_NEW(pmix_kval_t);
-                if (NULL == kv) {
-                    PMIX_VALUE_RELEASE(val);
-                    return PMIX_ERR_NOMEM;
-                }
-                kv->key = strdup(info[n].key);
+                kv->key = strdup(kvptr->key);
                 kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
-                if (NULL == kv->value) {
-                    PMIX_VALUE_RELEASE(val);
-                    PMIX_RELEASE(kv);
-                    return PMIX_ERR_NOMEM;
-                }
-                PMIX_BFROPS_VALUE_XFER(rc, pmix_globals.mypeer,
-                                       kv->value, &info[n].value);
+                PMIX_VALUE_XFER(rc, kv->value, kvptr->value);
                 if (PMIX_SUCCESS != rc) {
-                    PMIX_ERROR_LOG(rc);
-                    PMIX_VALUE_RELEASE(val);
                     PMIX_RELEASE(kv);
                     return rc;
                 }
                 pmix_list_append(kvs, &kv->super);
+                if (NULL != key) {
+                    break;
+                }
             }
-            PMIX_VALUE_RELEASE(val);
-            if (PMIX_GLOBAL == scope && ht == &trk->local) {
+        }
+        if (0 == pmix_list_get_size(kvs)) {
+            rc = PMIX_ERR_NOT_FOUND;
+        }
+    } else {
+        rc = dohash(ht, key, proc->rank, kvs);
+    }
+    if (PMIX_SUCCESS == rc) {
+        if (PMIX_GLOBAL == scope) {
+            if (ht == &trk->local) {
                 /* need to do this again for the remote data */
                 ht = &trk->remote;
                 goto doover;
+            } else if (ht == &trk->internal) {
+                /* check local */
+                ht = &trk->local;
+                goto doover;
             }
-            return PMIX_SUCCESS;
         }
-        /* just return the value */
-        kv = PMIX_NEW(pmix_kval_t);
-        if (NULL == kv) {
-            PMIX_VALUE_RELEASE(val);
-            return PMIX_ERR_NOMEM;
-        }
-        kv->key = strdup(key);
-        kv->value = val;
-        pmix_list_append(kvs, &kv->super);
     } else {
         if (PMIX_GLOBAL == scope ||
             PMIX_SCOPE_UNDEF == scope) {

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -116,6 +116,24 @@ pmix_gds_base_module_t pmix_hash_module = {
     .accept_kvs_resp = accept_kvs_resp
 };
 
+/* Define a bitmask to track what information may not have
+ * been provided but is computable from other info */
+#define PMIX_HASH_PROC_DATA     0x00000001
+#define PMIX_HASH_JOB_SIZE      0x00000002
+#define PMIX_HASH_MAX_PROCS     0x00000004
+#define PMIX_HASH_NUM_NODES     0x00000008
+#define PMIX_HASH_PROC_MAP      0x00000010
+#define PMIX_HASH_NODE_MAP      0x00000020
+
+/**********************************************/
+/* struct definitions */
+typedef struct {
+    pmix_list_item_t super;
+    uint32_t session;
+    pmix_list_t sessioninfo;
+    pmix_list_t nodeinfo;
+} pmix_session_t;
+
 typedef struct {
     pmix_list_item_t super;
     char *ns;
@@ -124,12 +142,42 @@ typedef struct {
     pmix_hash_table_t remote;
     pmix_hash_table_t local;
     bool gdata_added;
-} pmix_hash_trkr_t;
+    pmix_list_t jobinfo;
+    pmix_list_t apps;
+    pmix_list_t nodeinfo;
+    pmix_session_t *session;
+} pmix_job_t;
 
-static void htcon(pmix_hash_trkr_t *p)
+typedef struct {
+    pmix_list_item_t super;
+    uint32_t appnum;
+    pmix_list_t appinfo;
+    pmix_list_t nodeinfo;
+    pmix_job_t *job;
+} pmix_apptrkr_t;
+
+/**********************************************/
+/* class instantiations */
+static void scon(pmix_session_t *s)
+{
+    s->session = UINT32_MAX;
+    PMIX_CONSTRUCT(&s->sessioninfo, pmix_list_t);
+    PMIX_CONSTRUCT(&s->nodeinfo, pmix_list_t);
+}
+static void sdes(pmix_session_t *s)
+{
+    PMIX_LIST_DESTRUCT(&s->sessioninfo);
+    PMIX_LIST_DESTRUCT(&s->nodeinfo);
+}
+static PMIX_CLASS_INSTANCE(pmix_session_t,
+                           pmix_list_item_t,
+                           scon, sdes);
+
+static void htcon(pmix_job_t *p)
 {
     p->ns = NULL;
     p->nptr = NULL;
+    PMIX_CONSTRUCT(&p->jobinfo, pmix_list_t);
     PMIX_CONSTRUCT(&p->internal, pmix_hash_table_t);
     pmix_hash_table_init(&p->internal, 256);
     PMIX_CONSTRUCT(&p->remote, pmix_hash_table_t);
@@ -137,8 +185,11 @@ static void htcon(pmix_hash_trkr_t *p)
     PMIX_CONSTRUCT(&p->local, pmix_hash_table_t);
     pmix_hash_table_init(&p->local, 256);
     p->gdata_added = false;
+    PMIX_CONSTRUCT(&p->apps, pmix_list_t);
+    PMIX_CONSTRUCT(&p->nodeinfo, pmix_list_t);
+    p->session = NULL;
 }
-static void htdes(pmix_hash_trkr_t *p)
+static void htdes(pmix_job_t *p)
 {
     if (NULL != p->ns) {
         free(p->ns);
@@ -146,25 +197,245 @@ static void htdes(pmix_hash_trkr_t *p)
     if (NULL != p->nptr) {
         PMIX_RELEASE(p->nptr);
     }
+    PMIX_LIST_DESTRUCT(&p->jobinfo);
     pmix_hash_remove_data(&p->internal, PMIX_RANK_WILDCARD, NULL);
     PMIX_DESTRUCT(&p->internal);
     pmix_hash_remove_data(&p->remote, PMIX_RANK_WILDCARD, NULL);
     PMIX_DESTRUCT(&p->remote);
     pmix_hash_remove_data(&p->local, PMIX_RANK_WILDCARD, NULL);
     PMIX_DESTRUCT(&p->local);
+    PMIX_LIST_DESTRUCT(&p->apps);
+    PMIX_LIST_DESTRUCT(&p->nodeinfo);
+    if (NULL != p->session) {
+        PMIX_RELEASE(p->session);
+    }
 }
-static PMIX_CLASS_INSTANCE(pmix_hash_trkr_t,
+static PMIX_CLASS_INSTANCE(pmix_job_t,
                            pmix_list_item_t,
                            htcon, htdes);
 
-static pmix_list_t myhashes;
+static void apcon(pmix_apptrkr_t *p)
+{
+    p->appnum = UINT32_MAX;
+    PMIX_CONSTRUCT(&p->appinfo, pmix_list_t);
+    PMIX_CONSTRUCT(&p->nodeinfo, pmix_list_t);
+    p->job = NULL;
+}
+static void apdes(pmix_apptrkr_t *p)
+{
+    PMIX_LIST_DESTRUCT(&p->appinfo);
+    PMIX_LIST_DESTRUCT(&p->nodeinfo);
+    if (NULL != p->job) {
+        PMIX_RELEASE(p->job);
+    }
+}
+static PMIX_CLASS_INSTANCE(pmix_apptrkr_t,
+                           pmix_list_item_t,
+                           apcon, apdes);
+
+/**********************************************/
+
+/* process a node array */
+static pmix_status_t process_node_array(pmix_info_t *info,
+                                        pmix_list_t *tgt)
+{
+    return PMIX_SUCCESS;
+}
+
+/* process an app array */
+static pmix_status_t process_app_array(pmix_info_t *info,
+                                       pmix_job_t *trk)
+{
+    pmix_list_t cache, ncache;
+    size_t size, j;
+    pmix_info_t *iptr;
+    pmix_status_t rc = PMIX_SUCCESS;
+    uint32_t appnum;
+    pmix_apptrkr_t *app, *apptr;
+    pmix_kval_t *kp2;
+
+    /* apps have to belong to a job */
+    if (NULL == trk) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+
+    /* array of app-level info */
+    if (PMIX_DATA_ARRAY != info->value.type) {
+        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+        return PMIX_ERR_TYPE_MISMATCH;
+    }
+
+    /* setup arrays and lists */
+    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    PMIX_CONSTRUCT(&ncache, pmix_list_t);
+    size = info->value.data.darray->size;
+    iptr = (pmix_info_t*)info->value.data.darray->array;
+
+    for (j=0; j < size; j++) {
+        if (PMIX_CHECK_KEY(&iptr[j], PMIX_APPNUM)) {
+            PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, appnum, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+            /* see if we already have this app on the
+             * provided list */
+            app = NULL;
+            PMIX_LIST_FOREACH(apptr, &trk->apps, pmix_apptrkr_t) {
+                if (apptr->appnum == appnum) {
+                    app = apptr;
+                    break;
+                }
+            }
+            if (NULL == app) {
+                /* wasn't found, so create one */
+                app = PMIX_NEW(pmix_apptrkr_t);
+                app->appnum = appnum;
+                pmix_list_append(&trk->apps, &app->super);
+            }
+        } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_INFO_ARRAY)) {
+            if (PMIX_SUCCESS != (rc = process_node_array(&iptr[j], &ncache))) {
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+        } else {
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(iptr[j].key);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                goto release;
+            }
+            pmix_list_append(&cache, &kp2->super);
+        }
+    }
+    if (NULL == app) {
+        /* this is not allowed to happen - they are required
+         * to provide us with an app number per the standard */
+        rc = PMIX_ERR_BAD_PARAM;
+        PMIX_ERROR_LOG(rc);
+        goto release;
+    }
+    /* point the app at its job */
+    if (NULL == app->job) {
+        PMIX_RETAIN(trk);
+        app->job = trk;
+    }
+    /* transfer the app-level data across */
+    kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+    while (NULL != kp2) {
+        pmix_list_append(&app->appinfo, &kp2->super);
+        kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+    }
+    /* transfer the associated node-level data across */
+    kp2 = (pmix_kval_t*)pmix_list_remove_first(&ncache);
+    while (NULL != kp2) {
+        pmix_list_append(&app->nodeinfo, &kp2->super);
+        kp2 = (pmix_kval_t*)pmix_list_remove_first(&ncache);
+    }
+
+  release:
+    PMIX_LIST_DESTRUCT(&cache);
+    PMIX_LIST_DESTRUCT(&ncache);
+
+    return rc;
+}
+
+/* process a job array */
+static pmix_status_t process_job_array(pmix_info_t *info,
+                                       pmix_job_t *trk,
+                                       uint32_t *flags,
+                                       char ***procs,
+                                       char ***nodes)
+{
+    pmix_list_t cache;
+    size_t j, size;
+    pmix_info_t *iptr;
+    pmix_kval_t *kp2;
+    pmix_status_t rc;
+
+    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+                        "PROCESSING JOB ARRAY");
+    /* array of job-level info */
+    if (PMIX_DATA_ARRAY != info->value.type) {
+        PMIX_ERROR_LOG(PMIX_ERR_TYPE_MISMATCH);
+        return PMIX_ERR_TYPE_MISMATCH;
+    }
+    size = info->value.data.darray->size;
+    iptr = (pmix_info_t*)info->value.data.darray->array;
+    PMIX_CONSTRUCT(&cache, pmix_list_t);
+    for (j=0; j < size; j++) {
+        if (PMIX_CHECK_KEY(&iptr[j], PMIX_APP_INFO_ARRAY)) {
+            if (PMIX_SUCCESS != (rc = process_app_array(&iptr[j], trk))) {
+                return rc;
+            }
+        } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_PROC_MAP)) {
+            /* not allowed to get this more than once */
+            if (*flags & PMIX_HASH_PROC_MAP) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            /* parse the regex to get the argv array containing proc ranks on each node */
+            if (PMIX_SUCCESS != (rc = pmix_preg.parse_procs(iptr[j].value.data.string, procs))) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+            /* mark that we got the map */
+            *flags |= PMIX_HASH_PROC_MAP;
+        } else if (PMIX_CHECK_KEY(&iptr[j], PMIX_NODE_MAP)) {
+            /* not allowed to get this more than once */
+            if (*flags & PMIX_HASH_NODE_MAP) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            /* store the node map itself since that is
+             * what v3 uses */
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(PMIX_NODE_MAP);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            kp2->value->type = PMIX_STRING;
+            kp2->value->data.string = strdup(iptr[j].value.data.string);
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->internal, PMIX_RANK_WILDCARD, kp2))) {
+                PMIX_ERROR_LOG(rc);
+                PMIX_RELEASE(kp2);
+                return rc;
+            }
+            PMIX_RELEASE(kp2);  // maintain acctg
+
+            /* parse the regex to get the argv array of node names */
+            if (PMIX_SUCCESS != (rc = pmix_preg.parse_nodes(iptr[j].value.data.string, nodes))) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+            /* mark that we got the map */
+            *flags |= PMIX_HASH_NODE_MAP;
+        } else {
+            kp2 = PMIX_NEW(pmix_kval_t);
+            kp2->key = strdup(iptr[j].key);
+            kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_RELEASE(kp2);
+                PMIX_LIST_DESTRUCT(&cache);
+                return rc;
+            }
+            pmix_list_append(&trk->jobinfo, &kp2->super);
+        }
+    }
+    return PMIX_SUCCESS;
+}
+
+static pmix_list_t mysessions, myjobs;
 
 static pmix_status_t hash_init(pmix_info_t info[], size_t ninfo)
 {
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "gds: hash init");
 
-    PMIX_CONSTRUCT(&myhashes, pmix_list_t);
+    PMIX_CONSTRUCT(&mysessions, pmix_list_t);
+    PMIX_CONSTRUCT(&myjobs, pmix_list_t);
     return PMIX_SUCCESS;
 }
 
@@ -173,7 +444,8 @@ static void hash_finalize(void)
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "gds: hash finalize");
 
-    PMIX_LIST_DESTRUCT(&myhashes);
+    PMIX_LIST_DESTRUCT(&mysessions);
+    PMIX_LIST_DESTRUCT(&myjobs);
 }
 
 static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo,
@@ -201,13 +473,6 @@ static pmix_status_t hash_assign_module(pmix_info_t *info, size_t ninfo,
     }
     return PMIX_SUCCESS;
 }
-
-/* Define a bitmask to track what information may not have
- * been provided but is computable from other info */
-#define PMIX_HASH_PROC_DATA     0x00000001
-#define PMIX_HASH_JOB_SIZE      0x00000002
-#define PMIX_HASH_MAX_PROCS     0x00000004
-#define PMIX_HASH_NUM_NODES     0x00000008
 
 static pmix_status_t store_map(pmix_hash_table_t *ht,
                                char **nodes, char **ppn,
@@ -497,25 +762,29 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                                   pmix_info_t info[], size_t ninfo)
 {
     pmix_namespace_t *nptr = (pmix_namespace_t*)ns;
-    pmix_hash_trkr_t *trk, *t;
+    pmix_job_t *trk, *t;
+    pmix_session_t *s = NULL, *sptr;
     pmix_hash_table_t *ht;
     pmix_kval_t *kp2, *kvptr;
     pmix_info_t *iptr;
     char **nodes=NULL, **procs=NULL;
     uint8_t *tmp;
+    uint32_t sid=UINT32_MAX;
     pmix_rank_t rank;
     pmix_status_t rc=PMIX_SUCCESS;
     size_t n, j, size, len;
     uint32_t flags = 0;
+    pmix_list_t cache;
 
-    pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+  //  pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
+    pmix_output(0,
                         "[%s:%d] gds:hash:cache_job_info for nspace %s",
                         pmix_globals.myid.nspace, pmix_globals.myid.rank,
                         nptr->nspace);
 
     /* find the hash table for this nspace */
     trk = NULL;
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(nptr->nspace, t->ns)) {
             trk = t;
             break;
@@ -523,14 +792,14 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     }
     if (NULL == trk) {
         /* create a tracker as we will likely need it */
-        trk = PMIX_NEW(pmix_hash_trkr_t);
+        trk = PMIX_NEW(pmix_job_t);
         if (NULL == trk) {
             return PMIX_ERR_NOMEM;
         }
         PMIX_RETAIN(nptr);
         trk->nptr = nptr;
         trk->ns = strdup(nptr->nspace);
-        pmix_list_append(&myhashes, &trk->super);
+        pmix_list_append(&myjobs, &trk->super);
     }
 
     /* if there isn't any data, then be content with just
@@ -542,7 +811,121 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
     /* cache the job info on the internal hash table for this nspace */
     ht = &trk->internal;
     for (n=0; n < ninfo; n++) {
-        if (0 == strcmp(info[n].key, PMIX_NODE_MAP)) {
+        if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_ID)) {
+            PMIX_VALUE_GET_NUMBER(rc, &info[n].value, sid, uint32_t);
+            if (PMIX_SUCCESS != rc) {
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+            /* see if we have this session */
+            s = NULL;
+            PMIX_LIST_FOREACH(sptr, &mysessions, pmix_session_t) {
+                if (sptr->session == sid) {
+                    s = sptr;
+                    break;
+                }
+            }
+            if (NULL == s) {
+                s = PMIX_NEW(pmix_session_t);
+                s->session = sid;
+                pmix_list_append(&mysessions, &s->super);
+            }
+            /* point the job at it */
+            if (NULL == trk->session) {
+                PMIX_RETAIN(s);
+                trk->session = s;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_SESSION_INFO_ARRAY)) {
+            /* array of session-level info */
+            if (PMIX_DATA_ARRAY != info[n].value.type) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                rc = PMIX_ERR_TYPE_MISMATCH;
+                goto release;
+            }
+            size = info[n].value.data.darray->size;
+            iptr = (pmix_info_t*)info[n].value.data.darray->array;
+            PMIX_CONSTRUCT(&cache, pmix_list_t);
+            for (j=0; j < size; j++) {
+                if (PMIX_CHECK_KEY(&iptr[j], PMIX_SESSION_ID)) {
+                    PMIX_VALUE_GET_NUMBER(rc, &iptr[j].value, sid, uint32_t);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_LIST_DESTRUCT(&cache);
+                        return rc;
+                    }
+                    /* setup a session object */
+                    if (NULL != s) {
+                        /* does this match the one we were previously given? */
+                        if (sid != s->session) {
+                            /* no - see if we already have this session */
+                            PMIX_LIST_FOREACH(sptr, &mysessions, pmix_session_t) {
+                                if (sptr->session == sid) {
+                                    s = sptr;
+                                    break;
+                                }
+                            }
+                            if (sid != s->session) {
+                                /* wasn't found, so create one */
+                                s = PMIX_NEW(pmix_session_t);
+                                s->session = sid;
+                                pmix_list_append(&mysessions, &s->super);
+                            }
+                        }
+                    } else {
+                        s = PMIX_NEW(pmix_session_t);
+                        s->session = sid;
+                        pmix_list_append(&mysessions, &s->super);
+                    }
+                } else {
+                    kp2 = PMIX_NEW(pmix_kval_t);
+                    kp2->key = strdup(iptr[j].key);
+                    kp2->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+                    PMIX_VALUE_XFER(rc, kp2->value, &iptr[j].value);
+                    if (PMIX_SUCCESS != rc) {
+                        PMIX_ERROR_LOG(rc);
+                        PMIX_RELEASE(kp2);
+                        PMIX_LIST_DESTRUCT(&cache);
+                        goto release;
+                    }
+                    pmix_list_append(&cache, &kp2->super);
+                }
+            }
+            if (NULL == s) {
+                /* this is not allowed to happen - they are required
+                 * to provide us with a session ID per the standard */
+                PMIX_LIST_DESTRUCT(&cache);
+                rc = PMIX_ERR_BAD_PARAM;
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+            /* point the job at it */
+            if (NULL == trk->session) {
+                PMIX_RETAIN(s);
+                trk->session = s;
+            }
+            /* transfer the data across */
+            kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+            while (NULL != kp2) {
+                pmix_list_append(&s->sessioninfo, &kp2->super);
+                kp2 = (pmix_kval_t*)pmix_list_remove_first(&cache);
+            }
+            PMIX_LIST_DESTRUCT(&cache);
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_JOB_INFO_ARRAY)) {
+            if (PMIX_SUCCESS != (rc = process_job_array(&info[n], trk, &flags, &procs, &nodes))) {
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_APP_INFO_ARRAY)) {
+            if (PMIX_SUCCESS != (rc = process_app_array(&info[n], trk))) {
+                PMIX_ERROR_LOG(rc);
+                goto release;
+            }
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_NODE_MAP)) {
+            /* not allowed to get this more than once */
+            if (flags & PMIX_HASH_NODE_MAP) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
             /* store the node map itself since that is
              * what v3 uses */
             kp2 = PMIX_NEW(pmix_kval_t);
@@ -562,12 +945,21 @@ pmix_status_t hash_cache_job_info(struct pmix_namespace_t *ns,
                 PMIX_ERROR_LOG(rc);
                 goto release;
             }
-        } else if (0 == strcmp(info[n].key, PMIX_PROC_MAP)) {
+            /* mark that we got the map */
+            flags |= PMIX_HASH_NODE_MAP;
+        } else if (PMIX_CHECK_KEY(&info[n], PMIX_PROC_MAP)) {
+            /* not allowed to get this more than once */
+            if (flags & PMIX_HASH_PROC_MAP) {
+                PMIX_ERROR_LOG(PMIX_ERR_BAD_PARAM);
+                return PMIX_ERR_BAD_PARAM;
+            }
             /* parse the regex to get the argv array containing proc ranks on each node */
             if (PMIX_SUCCESS != (rc = pmix_preg.parse_procs(info[n].value.data.string, &procs))) {
                 PMIX_ERROR_LOG(rc);
                 goto release;
             }
+            /* mark that we got the map */
+            flags |= PMIX_HASH_PROC_MAP;
         } else if (0 == strcmp(info[n].key, PMIX_PROC_DATA)) {
             flags |= PMIX_HASH_PROC_DATA;
             /* an array of data pertaining to a specific proc */
@@ -728,18 +1120,18 @@ static pmix_status_t register_info(pmix_peer_t *peer,
                                    pmix_namespace_t *ns,
                                    pmix_buffer_t *reply)
 {
-    pmix_hash_trkr_t *trk, *t;
+    pmix_job_t *trk, *t;
     pmix_hash_table_t *ht;
     pmix_value_t *val, blob;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_info_t *info;
     size_t ninfo, n;
-    pmix_kval_t kv;
+    pmix_kval_t kv, *kvptr;
     pmix_buffer_t buf;
     pmix_rank_t rank;
 
     trk = NULL;
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(ns->nspace, t->ns)) {
             trk = t;
             break;
@@ -776,6 +1168,11 @@ static pmix_status_t register_info(pmix_peer_t *peer,
     }
     if (NULL != val) {
         PMIX_VALUE_RELEASE(val);
+    }
+
+    /* add all values in the jobinfo list */
+    PMIX_LIST_FOREACH(kvptr, &trk->jobinfo, pmix_kval_t) {
+        PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
     }
 
     for (rank=0; rank < ns->nprocs; rank++) {
@@ -825,7 +1222,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     pmix_namespace_t *ns = peer->nptr;
     char *msg;
     pmix_status_t rc;
-    pmix_hash_trkr_t *trk, *t2;
+    pmix_job_t *trk, *t2;
 
     if (!PMIX_PROC_IS_SERVER(pmix_globals.mypeer) &&
         !PMIX_PROC_IS_LAUNCHER(pmix_globals.mypeer)) {
@@ -865,7 +1262,7 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
     /* setup a tracker for this nspace as we will likely
      * need it again */
     trk = NULL;
-    PMIX_LIST_FOREACH(t2, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t2, &myjobs, pmix_job_t) {
         if (ns == t2->nptr) {
             trk = t2;
             if (NULL == trk->ns) {
@@ -878,11 +1275,11 @@ static pmix_status_t hash_register_job_info(struct pmix_peer_t *pr,
         }
     }
     if (NULL == trk) {
-        trk = PMIX_NEW(pmix_hash_trkr_t);
+        trk = PMIX_NEW(pmix_job_t);
         trk->ns = strdup(ns->nspace);
         PMIX_RETAIN(ns);
         trk->nptr = ns;
-        pmix_list_append(&myhashes, &trk->super);
+        pmix_list_append(&myjobs, &trk->super);
     }
 
     /* the job info for the specified nspace has
@@ -928,7 +1325,7 @@ static pmix_status_t hash_store_job_info(const char *nspace,
     pmix_byte_object_t *bo;
     pmix_buffer_t buf2;
     int rank;
-    pmix_hash_trkr_t *htptr;
+    pmix_job_t *htptr;
     pmix_hash_table_t *ht;
     char **nodelist = NULL;
     pmix_info_t *info, *iptr;
@@ -953,7 +1350,7 @@ static pmix_status_t hash_store_job_info(const char *nspace,
 
     /* see if we already have a hash table for this nspace */
     ht = NULL;
-    PMIX_LIST_FOREACH(htptr, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(htptr, &myjobs, pmix_job_t) {
         if (0 == strcmp(htptr->ns, nspace)) {
             ht = &htptr->internal;
             break;
@@ -961,9 +1358,9 @@ static pmix_status_t hash_store_job_info(const char *nspace,
     }
     if (NULL == ht) {
         /* nope - create one */
-        htptr = PMIX_NEW(pmix_hash_trkr_t);
+        htptr = PMIX_NEW(pmix_job_t);
         htptr->ns = strdup(nspace);
-        pmix_list_append(&myhashes, &htptr->super);
+        pmix_list_append(&myjobs, &htptr->super);
         ht = &htptr->internal;
     }
 
@@ -1219,7 +1616,7 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
                                 pmix_scope_t scope,
                                 pmix_kval_t *kv)
 {
-    pmix_hash_trkr_t *trk, *t;
+    pmix_job_t *trk, *t;
     pmix_status_t rc;
     pmix_kval_t *kp;
 
@@ -1235,7 +1632,7 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
 
     /* find the hash table for this nspace */
     trk = NULL;
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(proc->nspace, t->ns)) {
             trk = t;
             break;
@@ -1243,9 +1640,9 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
     }
     if (NULL == trk) {
         /* create one */
-        trk = PMIX_NEW(pmix_hash_trkr_t);
+        trk = PMIX_NEW(pmix_job_t);
         trk->ns = strdup(proc->nspace);
-        pmix_list_append(&myhashes, &trk->super);
+        pmix_list_append(&myjobs, &trk->super);
     }
 
     /* see if the proc is me */
@@ -1347,7 +1744,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
                                        char **kmap,
                                        pmix_buffer_t *pbkt)
 {
-    pmix_hash_trkr_t *trk, *t;
+    pmix_job_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_kval_t *kv;
 
@@ -1358,7 +1755,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
 
     /* find the hash table for this nspace */
     trk = NULL;
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(proc->nspace, t->ns)) {
             trk = t;
             break;
@@ -1366,9 +1763,9 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
     }
     if (NULL == trk) {
         /* create one */
-        trk = PMIX_NEW(pmix_hash_trkr_t);
+        trk = PMIX_NEW(pmix_job_t);
         trk->ns = strdup(proc->nspace);
-        pmix_list_append(&myhashes, &trk->super);
+        pmix_list_append(&myjobs, &trk->super);
     }
 
     /* this is data returned via the PMIx_Fence call when
@@ -1408,7 +1805,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                                 pmix_info_t qualifiers[], size_t nqual,
                                 pmix_list_t *kvs)
 {
-    pmix_hash_trkr_t *trk, *t;
+    pmix_job_t *trk, *t;
     pmix_status_t rc;
     pmix_value_t *val;
     pmix_kval_t *kv;
@@ -1429,7 +1826,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
         /* see if we have a tracker for this nspace - we will
          * if we already cached the job info for it */
         trk = NULL;
-        PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+        PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
             if (0 == strcmp(proc->nspace, t->ns)) {
                 trk = t;
                 break;
@@ -1486,7 +1883,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
 
     /* find the hash table for this nspace */
     trk = NULL;
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(proc->nspace, t->ns)) {
             trk = t;
             break;
@@ -1602,13 +1999,13 @@ static pmix_status_t nspace_add(const char *nspace,
 
 static pmix_status_t nspace_del(const char *nspace)
 {
-    pmix_hash_trkr_t *t;
+    pmix_job_t *t;
 
     /* find the hash table for this nspace */
-    PMIX_LIST_FOREACH(t, &myhashes, pmix_hash_trkr_t) {
+    PMIX_LIST_FOREACH(t, &myjobs, pmix_job_t) {
         if (0 == strcmp(nspace, t->ns)) {
             /* release it */
-            pmix_list_remove_item(&myhashes, &t->super);
+            pmix_list_remove_item(&myjobs, &t->super);
             PMIX_RELEASE(t);
             break;
         }

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -918,10 +918,15 @@ pmix_status_t pmix_server_fence(pmix_server_caddy_t *cd,
         /* see if we are to collect data or enforce a timeout - we don't internally care
          * about any other directives */
         for (n=0; n < ninfo; n++) {
-            if (0 == strcmp(info[n].key, PMIX_COLLECT_DATA)) {
-                collect_data = true;
-            } else if (0 == strncmp(info[n].key, PMIX_TIMEOUT, PMIX_MAX_KEYLEN)) {
-                tv.tv_sec = info[n].value.data.uint32;
+            if (PMIX_CHECK_KEY(&info[n], PMIX_COLLECT_DATA)) {
+                collect_data = PMIX_INFO_TRUE(&info[n]);
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_TIMEOUT)) {
+                PMIX_VALUE_GET_NUMBER(rc, &info[n].value, tv.tv_sec, uint32_t);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_PROC_FREE(procs, nprocs);
+                    PMIX_INFO_FREE(info, ninfo);
+                    return rc;
+                }
             }
         }
     }
@@ -3087,7 +3092,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
 
     cnt = 0;  // track how many infos are cleanup related
     for (n=0; n < cd->ninfo; n++) {
-        if (0 == strncmp(cd->info[n].key, PMIX_REGISTER_CLEANUP, PMIX_MAX_KEYLEN)) {
+        if (PMIX_CHECK_KEY(&cd->info[n], PMIX_REGISTER_CLEANUP)) {
             ++cnt;
             if (PMIX_STRING != cd->info[n].value.type ||
                 NULL == cd->info[n].value.data.string) {
@@ -3103,7 +3108,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
             }
             cf->path = strdup(cd->info[n].value.data.string);
             pmix_list_append(&cachefiles, &cf->super);
-        } else if (0 == strncmp(cd->info[n].key, PMIX_REGISTER_CLEANUP_DIR, PMIX_MAX_KEYLEN)) {
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_REGISTER_CLEANUP_DIR)) {
             ++cnt;
             if (PMIX_STRING != cd->info[n].value.type ||
                 NULL == cd->info[n].value.data.string) {
@@ -3119,10 +3124,10 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
             }
             cdir->path = strdup(cd->info[n].value.data.string);
             pmix_list_append(&cachedirs, &cdir->super);
-        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_RECURSIVE, PMIX_MAX_KEYLEN)) {
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_RECURSIVE)) {
             recurse = PMIX_INFO_TRUE(&cd->info[n]);
             ++cnt;
-        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_IGNORE, PMIX_MAX_KEYLEN)) {
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_IGNORE)) {
             if (PMIX_STRING != cd->info[n].value.type ||
                 NULL == cd->info[n].value.data.string) {
                 /* return an error */
@@ -3138,7 +3143,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
             cf->path = strdup(cd->info[n].value.data.string);
             pmix_list_append(&ignorefiles, &cf->super);
             ++cnt;
-        } else if (0 == strncmp(cd->info[n].key, PMIX_CLEANUP_LEAVE_TOPDIR, PMIX_MAX_KEYLEN)) {
+        } else if (PMIX_CHECK_KEY(&cd->info[n], PMIX_CLEANUP_LEAVE_TOPDIR)) {
             leave_topdir = PMIX_INFO_TRUE(&cd->info[n]);
             ++cnt;
         }
@@ -3556,8 +3561,7 @@ pmix_status_t pmix_server_iofreg(pmix_peer_t *peer,
                 continue;
             }
             /* do we already have this source for this peer? */
-            if (0 == strncmp(cd->procs[n].nspace, req->pname.nspace, PMIX_MAX_NSLEN) &&
-                (PMIX_RANK_WILDCARD == req->pname.rank || cd->procs[n].rank == req->pname.rank)) {
+            if (PMIX_CHECK_PROCID(&cd->procs[n], &req->pname)) {
                 match = true;
                 if ((req->channels & cd->channels) != cd->channels) {
                     /* this is a channel update */


### PR DESCRIPTION
The updated PMIx v3.1 Standard defines new attributes for passing arrays
of data for the various levels (job, app, node). This was done in order
to simplify the data being passed to register_nspace, and to support
passing of data that used the same attribute key for each level - e.g.,
the PMIX_NODE_SIZE for multiple nodes. This PR implements at least the
job and app arrays - the node array support remains TBD.

Signed-off-by: Ralph Castain <rhc@pmix.org>