### PR TITLE
Fix legacy support for PMI-1

### DIFF
--- a/src/client/pmi1.c
+++ b/src/client/pmi1.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
@@ -83,7 +83,7 @@ PMIX_EXPORT int PMI_Init(int *spawned)
 
     /* getting internal key requires special rank value */
     memcpy(&proc, &myproc, sizeof(myproc));
-    proc.rank = PMIX_RANK_UNDEF;
+    proc.rank = PMIX_RANK_WILDCARD;
 
     /* set controlling parameters
      * PMIX_OPTIONAL - expect that these keys should be available on startup
@@ -392,8 +392,6 @@ PMIX_EXPORT int PMI_Get_appnum(int *appnum)
     pmix_value_t *val;
     pmix_info_t info[1];
     bool  val_optinal = 1;
-    pmix_proc_t proc = myproc;
-    proc.rank = PMIX_RANK_WILDCARD;
 
     PMI_CHECK();
 
@@ -412,11 +410,11 @@ PMIX_EXPORT int PMI_Get_appnum(int *appnum)
     PMIX_INFO_CONSTRUCT(&info[0]);
     PMIX_INFO_LOAD(&info[0], PMIX_OPTIONAL, &val_optinal, PMIX_BOOL);
 
-    rc = PMIx_Get(&proc, PMIX_APPNUM, info, 1, &val);
+    rc = PMIx_Get(&myproc, PMIX_APPNUM, info, 1, &val);
     if (PMIX_SUCCESS == rc) {
         rc = convert_int(appnum, val);
         PMIX_VALUE_RELEASE(val);
-    } else if( PMIX_ERR_NOT_FOUND == rc ){
+    } else {
         /* this is optional value, set to 0 */
         *appnum = 0;
         rc = PMIX_SUCCESS;
@@ -443,7 +441,7 @@ PMIX_EXPORT int PMI_Publish_name(const char service_name[], const char port[])
     }
 
     /* pass the service/port */
-           pmix_strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
+    pmix_strncpy(info.key, service_name, PMIX_MAX_KEYLEN);
     info.value.type = PMIX_STRING;
     info.value.data.string = (char*) port;
 
@@ -495,7 +493,7 @@ PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
     PMIX_PDATA_CONSTRUCT(&pdata);
 
     /* pass the service */
-           pmix_strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
+    pmix_strncpy(pdata.key, service_name, PMIX_MAX_KEYLEN);
 
     /* PMI-1 doesn't want the nspace back */
     if (PMIX_SUCCESS != (rc = PMIx_Lookup(&pdata, 1, NULL, 0))) {
@@ -512,7 +510,7 @@ PMIX_EXPORT int PMI_Lookup_name(const char service_name[], char port[])
      * potential we could overrun it. As this feature
      * isn't widely supported in PMI-1, try being
      * conservative */
-           pmix_strncpy(port, pdata.value.data.string, PMIX_MAX_KEYLEN);
+    pmix_strncpy(port, pdata.value.data.string, PMIX_MAX_KEYLEN);
     PMIX_PDATA_DESTRUCT(&pdata);
 
     return PMIX_SUCCESS;

--- a/src/client/pmix_client_fence.c
+++ b/src/client/pmix_client_fence.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2014-2019 Research Organization for Information Science
  *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2014      Artem Y. Polyakov <artpol84@gmail.com>.
@@ -72,7 +72,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: executing fence");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -105,7 +105,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence(const pmix_proc_t procs[], size_t nprocs,
     rc = cb->status;
     PMIX_RELEASE(cb);
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: fence released");
 
     return rc;
@@ -124,7 +124,7 @@ PMIX_EXPORT pmix_status_t PMIx_Fence_nb(const pmix_proc_t procs[], size_t nprocs
 
     PMIX_ACQUIRE_THREAD(&pmix_global_lock);
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: fence_nb called");
 
     if (pmix_globals.init_cntr <= 0) {
@@ -184,7 +184,7 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
     pmix_status_t ret;
     int32_t cnt;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "client:unpack fence called");
 
     /* unpack the status code */
@@ -195,7 +195,7 @@ static pmix_status_t unpack_return(pmix_buffer_t *data)
         PMIX_ERROR_LOG(rc);
         return rc;
     }
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "client:unpack fence received status %d", ret);
     return ret;
 }
@@ -254,7 +254,7 @@ static void wait_cbfunc(struct pmix_peer_t *pr, pmix_ptl_hdr_t *hdr,
     pmix_cb_t *cb = (pmix_cb_t*)cbdata;
     pmix_status_t rc;
 
-    pmix_output_verbose(2, pmix_globals.debug_output,
+    pmix_output_verbose(2, pmix_client_globals.fence_output,
                         "pmix: fence_nb callback recvd");
 
     if (NULL == cb) {

--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -53,6 +53,7 @@
 #include "src/util/argv.h"
 #include "src/util/error.h"
 #include "src/util/hash.h"
+#include "src/util/name_fns.h"
 #include "src/util/output.h"
 #include "src/mca/gds/gds.h"
 #include "src/mca/ptl/ptl.h"
@@ -95,14 +96,15 @@ PMIX_EXPORT pmix_status_t PMIx_Get(const pmix_proc_t *proc,
     PMIX_RELEASE_THREAD(&pmix_global_lock);
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
-                        "pmix:client get for %s:%d key %s",
-                        (NULL == proc) ? "NULL" : proc->nspace,
-                        (NULL == proc) ? PMIX_RANK_UNDEF : proc->rank,
+                        "pmix:client get for %s key %s",
+                        (NULL == proc) ? "NULL" : PMIX_NAME_PRINT(proc),
                         (NULL == key) ? "NULL" : key);
 
     /* try to get data directly, without threadshift */
-    if (PMIX_SUCCESS == (rc = _getfn_fastpath(proc, key, info, ninfo, val))) {
-        goto done;
+    if (PMIX_RANK_UNDEF != proc->rank) {
+        if (PMIX_SUCCESS == (rc = _getfn_fastpath(proc, key, info, ninfo, val))) {
+            goto done;
+        }
     }
 
     /* create a callback object as we need to pass it to the
@@ -325,9 +327,14 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
     }
 
     if (PMIX_SUCCESS != ret) {
+        PMIX_ERROR_LOG(ret);
         goto done;
     }
-    PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_client_globals.myserver, buf);
+    if (PMIX_RANK_UNDEF == proc.rank) {
+        PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_globals.mypeer, buf);
+    } else {
+        PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_client_globals.myserver, buf);
+    }
     if (PMIX_SUCCESS != rc) {
         goto done;
     }
@@ -346,7 +353,11 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
             /* fetch the data from server peer module - since it is passing
              * it back to the user, we need a copy of it */
             cb->copy = true;
-            PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
+            if (PMIX_RANK_UNDEF == proc.rank) {
+                PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+            } else {
+                PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
+            }
             if (PMIX_SUCCESS == rc) {
                 if (1 != pmix_list_get_size(&cb->kvs)) {
                     rc = PMIX_ERR_INVALID_VAL;
@@ -552,14 +563,14 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     /* cb was passed to us from another thread - acquire it */
     PMIX_ACQUIRE_OBJECT(cb);
 
-    pmix_output_verbose(2, pmix_client_globals.get_output,
-                        "pmix: getnbfn value for proc %s:%u key %s",
-                        cb->pname.nspace, cb->pname.rank,
-                        (NULL == cb->key) ? "NULL" : cb->key);
-
     /* set the proc object identifier */
     pmix_strncpy(proc.nspace, cb->pname.nspace, PMIX_MAX_NSLEN);
     proc.rank = cb->pname.rank;
+
+    pmix_output_verbose(2, pmix_client_globals.get_output,
+                        "pmix: getnbfn value for proc %s key %s",
+                        PMIX_NAME_PRINT(&proc),
+                        (NULL == cb->key) ? "NULL" : cb->key);
 
     /* scan the incoming directives */
     if (NULL != cb->info) {
@@ -613,7 +624,13 @@ static void _getnbfn(int fd, short flags, void *cbdata)
         /* fetch the data from my server's module - since we are passing
          * it back to the user, we need a copy of it */
         cb->copy = true;
-        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
+        /* if the peer and server GDS component are the same, then no
+         * point in trying it again */
+        if (0 != strcmp(pmix_globals.mypeer->nptr->compat.gds->name, pmix_client_globals.myserver->nptr->compat.gds->name)) {
+            PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
+        } else {
+            rc = PMIX_ERR_TAKE_NEXT_OPTION;
+        }
         if (PMIX_SUCCESS != rc) {
             pmix_output_verbose(5, pmix_client_globals.get_output,
                                 "pmix:client job-level data NOT found");
@@ -662,7 +679,17 @@ static void _getnbfn(int fd, short flags, void *cbdata)
                             "pmix:client job-level data NOT found");
         rc = process_values(&val, cb);
         goto respond;
+    } else if (PMIX_RANK_UNDEF == proc.rank) {
+        /* the data would have to be stored on our own peer, so
+         * we need to go request it */
+        goto request;
     } else {
+        /* if the peer and server GDS component are the same, then no
+         * point in trying it again */
+        if (0 == strcmp(pmix_globals.mypeer->nptr->compat.gds->name, pmix_client_globals.myserver->nptr->compat.gds->name)) {
+            val = NULL;
+            goto request;
+        }
         cb->proc = &proc;
         cb->copy = true;
         PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
@@ -731,9 +758,9 @@ static void _getnbfn(int fd, short flags, void *cbdata)
     }
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
-                        "%s:%d REQUESTING DATA FROM SERVER FOR %s:%d KEY %s",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        cb->pname.nspace, cb->pname.rank, cb->key);
+                        "%s REQUESTING DATA FROM SERVER FOR %s KEY %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_NAME_PRINT(cb->proc), cb->key);
 
     /* track the callback object */
     pmix_list_append(&pmix_client_globals.pending_requests, &cb->super);

--- a/src/event/pmix_event_notification.c
+++ b/src/event/pmix_event_notification.c
@@ -886,7 +886,7 @@ static void _notify_client_event(int sd, short args, void *cbdata)
             } else {
                 /* look up the nspace for this proc */
                 nptr = NULL;
-                PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
+                PMIX_LIST_FOREACH(tmp, &pmix_globals.nspaces, pmix_namespace_t) {
                     if (PMIX_CHECK_NSPACE(tmp->nspace, cd->targets[n].nspace)) {
                         nptr = tmp;
                         break;

--- a/src/include/pmix_globals.h
+++ b/src/include/pmix_globals.h
@@ -513,6 +513,7 @@ typedef struct {
     bool xml_output;
     bool timestamp_output;
     size_t output_limit;
+    pmix_list_t nspaces;
 } pmix_globals_t;
 
 /* provide access to a function to cleanup epilogs */

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1523,6 +1523,7 @@ static pmix_status_t hash_store_job_info(const char *nspace,
     pmix_hash_table_t *ht;
     char **nodelist = NULL;
     pmix_info_t *info, *iptr;
+    pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%u] pmix:gds:hash store job info for nspace %s",
@@ -1542,6 +1543,24 @@ static pmix_status_t hash_store_job_info(const char *nspace,
         return rc;
     }
 
+    /* see if we already have this nspace */
+    nptr = NULL;
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (0 == strcmp(ns->nspace, nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        nptr = PMIX_NEW(pmix_namespace_t);
+        if (NULL == nptr) {
+            rc = PMIX_ERR_NOMEM;
+            return rc;
+        }
+        nptr->nspace = strdup(nspace);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+    }
+
     /* see if we already have a hash table for this nspace */
     ht = NULL;
     PMIX_LIST_FOREACH(htptr, &myjobs, pmix_job_t) {
@@ -1554,6 +1573,8 @@ static pmix_status_t hash_store_job_info(const char *nspace,
         /* nope - create one */
         htptr = PMIX_NEW(pmix_job_t);
         htptr->ns = strdup(nspace);
+        PMIX_RETAIN(nptr);
+        htptr->nptr = nptr;
         pmix_list_append(&myjobs, &htptr->super);
         ht = &htptr->internal;
     }
@@ -1566,7 +1587,7 @@ static pmix_status_t hash_store_job_info(const char *nspace,
         pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                             "[%s:%u] pmix:gds:hash store job info working key %s",
                             pmix_globals.myid.nspace, pmix_globals.myid.rank, kptr->key);
-        if (0 == strcmp(kptr->key, PMIX_PROC_BLOB)) {
+        if (PMIX_CHECK_KEY(kptr, PMIX_PROC_BLOB)) {
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
             PMIX_LOAD_BUFFER(pmix_client_globals.myserver, &buf2, bo->bytes, bo->size);
@@ -1617,7 +1638,7 @@ static pmix_status_t hash_store_job_info(const char *nspace,
             /* cleanup */
             PMIX_DESTRUCT(&buf2);  // releases the original kptr data
             PMIX_RELEASE(kp2);
-        } else if (0 == strcmp(kptr->key, PMIX_MAP_BLOB)) {
+        } else if (PMIX_CHECK_KEY(kptr, PMIX_MAP_BLOB)) {
             /* transfer the byte object for unpacking */
             bo = &(kptr->value->data.bo);
             PMIX_CONSTRUCT(&buf2, pmix_buffer_t);
@@ -1788,6 +1809,11 @@ static pmix_status_t hash_store_job_info(const char *nspace,
                 PMIX_RELEASE(kptr);
                 return rc;
             }
+            /* if this is the job size, then store it in
+             * the nptr tracker */
+            if (0 == nptr->nprocs && PMIX_CHECK_KEY(kptr, PMIX_JOB_SIZE)) {
+                nptr->nprocs = kptr->value->data.uint32;
+            }
         }
         PMIX_RELEASE(kptr);
         kptr = PMIX_NEW(pmix_kval_t);
@@ -1813,11 +1839,12 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
     pmix_job_t *trk, *t;
     pmix_status_t rc;
     pmix_kval_t *kp;
+    pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s:%d] gds:hash:hash_store for proc [%s:%d] key %s type %s scope %s",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
-                        proc->nspace, proc->rank, kv->key,
+                        "%s gds:hash:hash_store for proc %s key %s type %s scope %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        PMIX_NAME_PRINT(proc), kv->key,
                         PMIx_Data_type_string(kv->value->type), PMIx_Scope_string(scope));
 
     if (NULL == kv->key) {
@@ -1836,6 +1863,26 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
         /* create one */
         trk = PMIX_NEW(pmix_job_t);
         trk->ns = strdup(proc->nspace);
+        /* see if we already have this nspace */
+        nptr = NULL;
+        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
+            if (0 == strcmp(ns->nspace, proc->nspace)) {
+                nptr = ns;
+                break;
+            }
+        }
+        if (NULL == nptr) {
+            nptr = PMIX_NEW(pmix_namespace_t);
+            if (NULL == nptr) {
+                rc = PMIX_ERR_NOMEM;
+                PMIX_RELEASE(trk);
+                return rc;
+            }
+            nptr->nspace = strdup(proc->nspace);
+            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+        }
+        PMIX_RETAIN(nptr);
+        trk->nptr = nptr;
         pmix_list_append(&myjobs, &trk->super);
     }
 
@@ -1867,6 +1914,11 @@ static pmix_status_t hash_store(const pmix_proc_t *proc,
             }
             PMIX_RELEASE(kp);  // maintain accounting
         }
+    }
+
+    /* if the number of procs for the nspace object is new, then update it */
+    if (0 == trk->nptr->nprocs && PMIX_CHECK_KEY(kv, PMIX_JOB_SIZE)) {
+        trk->nptr->nprocs = kv->value->data.uint32;
     }
 
     /* store it in the corresponding hash table */
@@ -1941,6 +1993,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
     pmix_job_t *trk, *t;
     pmix_status_t rc = PMIX_SUCCESS;
     pmix_kval_t *kv;
+    pmix_namespace_t *ns, *nptr;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
                         "[%s:%d] gds:hash:store_modex for nspace %s",
@@ -1959,6 +2012,26 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
         /* create one */
         trk = PMIX_NEW(pmix_job_t);
         trk->ns = strdup(proc->nspace);
+        /* see if we already have this nspace */
+        nptr = NULL;
+        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
+            if (0 == strcmp(ns->nspace, proc->nspace)) {
+                nptr = ns;
+                break;
+            }
+        }
+        if (NULL == nptr) {
+            nptr = PMIX_NEW(pmix_namespace_t);
+            if (NULL == nptr) {
+                rc = PMIX_ERR_NOMEM;
+                PMIX_RELEASE(trk);
+                return rc;
+            }
+            nptr->nspace = strdup(proc->nspace);
+            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+        }
+        PMIX_RETAIN(nptr);
+        trk->nptr = nptr;
         pmix_list_append(&myjobs, &trk->super);
     }
 
@@ -1973,10 +2046,20 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
     rc = pmix_gds_base_modex_unpack_kval(key_fmt, pbkt, kmap, kv);
 
     while (PMIX_SUCCESS == rc) {
-        /* store this in the hash table */
-        if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc->rank, kv))) {
-            PMIX_ERROR_LOG(rc);
-            return rc;
+        if (PMIX_RANK_UNDEF == proc->rank) {
+            /* if the rank is undefined, then we store it on the
+             * remote table of rank=0 as we know that rank must
+             * always exist */
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, 0, kv))) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
+        } else {
+            /* store this in the hash table */
+            if (PMIX_SUCCESS != (rc = pmix_hash_store(&trk->remote, proc->rank, kv))) {
+                PMIX_ERROR_LOG(rc);
+                return rc;
+            }
         }
         PMIX_RELEASE(kv);  // maintain accounting as the hash increments the ref count
         /* continue along */
@@ -1996,6 +2079,7 @@ static pmix_status_t _hash_store_modex(pmix_gds_base_ctx_t ctx,
 static pmix_status_t dohash(pmix_hash_table_t *ht,
                             const char *key,
                             pmix_rank_t rank,
+                            bool skip_genvals,
                             pmix_list_t *kvs)
 {
     pmix_status_t rc;
@@ -2019,6 +2103,12 @@ static pmix_status_t dohash(pmix_hash_table_t *ht,
             info = (pmix_info_t*)val->data.darray->array;
             ninfo = val->data.darray->size;
             for (n=0; n < ninfo; n++) {
+                /* if the rank is UNDEF, then we don't want
+                 * anything that starts with "pmix" */
+                if (skip_genvals &&
+                    0 == strncmp(info[n].key, "pmix", 4)) {
+                    continue;
+                }
                 /* see if we already have this on the list */
                 kv = NULL;
                 PMIX_LIST_FOREACH(k2, kvs, pmix_kval_t) {
@@ -2232,10 +2322,10 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     pmix_rank_t rnk;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s:%u] pmix:gds:hash fetch %s for proc %s:%u on scope %s",
-                        pmix_globals.myid.nspace, pmix_globals.myid.rank,
+                        "[%s] pmix:gds:hash fetch %s for proc %s on scope %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
                         (NULL == key) ? "NULL" : key,
-                        proc->nspace, proc->rank, PMIx_Scope_string(scope));
+                        PMIX_NAME_PRINT(proc), PMIx_Scope_string(scope));
 
     /* if the rank is wildcard and the key is NULL, then
      * they are asking for a complete copy of the job-level
@@ -2374,7 +2464,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
         rc = fetch_appinfo(key, &trk->apps, qualifiers, nqual, kvs);
         /* if they did, then we are done */
         if (PMIX_ERR_DATA_VALUE_NOT_FOUND != rc) {
-            return rc;
+           return rc;
         }
     }
 
@@ -2402,16 +2492,15 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
      * be the source */
     if (PMIX_RANK_UNDEF == proc->rank) {
         for (rnk=0; rnk < trk->nptr->nprocs; rnk++) {
-            rc = dohash(ht, key, rnk, kvs);
-            if (PMIX_SUCCESS != rc) {
+            rc = dohash(ht, key, rnk, true, kvs);
+            if (PMIX_ERR_NOMEM == rc) {
                 return rc;
             }
-            if (NULL != key) {
+            if (PMIX_SUCCESS == rc && NULL != key) {
                 return rc;
             }
         }
-        /* also need to check any info that came in via
-         * a job-level info array */
+        /* also need to check any job-level info */
         PMIX_LIST_FOREACH(kvptr, &trk->jobinfo, pmix_kval_t) {
             if (NULL == key || PMIX_CHECK_KEY(kvptr, key)) {
                 kv = PMIX_NEW(pmix_kval_t);
@@ -2428,11 +2517,13 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                 }
             }
         }
-        if (0 == pmix_list_get_size(kvs)) {
-            rc = PMIX_ERR_NOT_FOUND;
+        if (NULL == key) {
+            /* and need to add all job info just in case that was
+             * passed via a different GDS component */
+            dohash(&trk->internal, NULL, PMIX_RANK_WILDCARD, false, kvs);
         }
     } else {
-        rc = dohash(ht, key, proc->rank, kvs);
+        rc = dohash(ht, key, proc->rank, false, kvs);
     }
     if (PMIX_SUCCESS == rc) {
         if (PMIX_GLOBAL == scope) {
@@ -2459,6 +2550,9 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
                 goto doover;
             }
         }
+    }
+    if (0 == pmix_list_get_size(kvs)) {
+        rc = PMIX_ERR_NOT_FOUND;
     }
 
     return rc;
@@ -2550,6 +2644,12 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
             PMIX_ERROR_LOG(rc);
             return rc;
         }
+        /* if the rank is UNDEF, then we store this on our own
+         * rank tables */
+        if (PMIX_RANK_UNDEF == proct.rank) {
+            proct.rank = pmix_globals.myid.rank;
+        }
+
         cnt = 1;
         kv = PMIX_NEW(pmix_kval_t);
         PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
@@ -2559,7 +2659,6 @@ static pmix_status_t accept_kvs_resp(pmix_buffer_t *buf)
              * the kval contains shmem connection info, then the
              * component will know what to do about it (or else
              * we selected the wrong component for this peer!) */
-
             PMIX_GDS_STORE_KV(rc, pmix_globals.mypeer, &proct, PMIX_INTERNAL, kv);
             if (PMIX_SUCCESS != rc) {
                 PMIX_ERROR_LOG(rc);

--- a/src/mca/pfexec/base/pfexec_base_default_fns.c
+++ b/src/mca/pfexec/base/pfexec_base_default_fns.c
@@ -155,7 +155,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
 
     /* ensure our nspace is on the server global list */
     nptr = NULL;
-    PMIX_LIST_FOREACH(n2, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(n2, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(n2->nspace, pmix_globals.myid.nspace)) {
             nptr = n2;
             break;
@@ -165,7 +165,7 @@ void pmix_pfexec_base_spawn_proc(int sd, short args, void *cbdata)
         /* add it */
         nptr = PMIX_NEW(pmix_namespace_t);
         nptr->nspace = strdup(pmix_globals.myid.nspace);
-        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
     /* mark all children as "registered" so collectives don't falter */
     nptr->all_registered = true;

--- a/src/mca/pnet/base/pnet_base_fns.c
+++ b/src/mca/pnet/base/pnet_base_fns.c
@@ -60,7 +60,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
         nptr = NULL;
         /* find this nspace - note that it may not have
          * been registered yet */
-        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
+        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
             if (0 == strcmp(ns->nspace, nspace)) {
                 nptr = ns;
                 break;
@@ -73,7 +73,7 @@ pmix_status_t pmix_pnet_base_allocate(char *nspace,
                 return PMIX_ERR_NOMEM;
             }
             nptr->nspace = strdup(nspace);
-            pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+            pmix_list_append(&pmix_globals.nspaces, &nptr->super);
         }
 
         if (NULL != info) {
@@ -144,7 +144,7 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
 
     /* find this proc's nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, nspace)) {
             nptr = ns;
             break;
@@ -157,7 +157,7 @@ pmix_status_t pmix_pnet_base_setup_local_network(char *nspace,
             return PMIX_ERR_NOMEM;
         }
         nptr->nspace = strdup(nspace);
-        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
 
     PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
@@ -189,7 +189,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
 
     /* find this proc's nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, proc->nspace)) {
             nptr = ns;
             break;
@@ -202,7 +202,7 @@ pmix_status_t pmix_pnet_base_setup_fork(const pmix_proc_t *proc, char ***env)
             return PMIX_ERR_NOMEM;
         }
         nptr->nspace = strdup(proc->nspace);
-        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
     }
 
     PMIX_LIST_FOREACH(active, &pmix_pnet_globals.actives, pmix_pnet_base_active_module_t) {
@@ -280,7 +280,7 @@ void pmix_pnet_base_deregister_nspace(char *nspace)
 
     /* find this nspace object */
     nptr = NULL;
-    PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(ns->nspace, nspace)) {
             nptr = ns;
             break;

--- a/src/mca/ptl/tcp/ptl_tcp_component.c
+++ b/src/mca/ptl/tcp/ptl_tcp_component.c
@@ -1416,7 +1416,7 @@ static void connection_handler(int sd, short args, void *cbdata)
              * of local clients. So let's start by searching for
              * the nspace object */
             nptr = NULL;
-            PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
+            PMIX_LIST_FOREACH(tmp, &pmix_globals.nspaces, pmix_namespace_t) {
                 if (0 == strcmp(tmp->nspace, nspace)) {
                     nptr = tmp;
                     break;
@@ -1566,7 +1566,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;
@@ -1870,7 +1870,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     if (5 != pnd->flag && 8 != pnd->flag) {
         PMIX_RETAIN(nptr);
         nptr->nspace = strdup(cd->proc.nspace);
-        pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
         info = PMIX_NEW(pmix_rank_info_t);
         info->pname.nspace = strdup(nptr->nspace);
         info->pname.rank = cd->proc.rank;
@@ -1898,7 +1898,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     peer->nptr->compat.psec = pmix_psec_base_assign_module(pnd->psec);
     if (NULL == peer->nptr->compat.psec) {
         PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         CLOSE_THE_SOCKET(pnd->sd);
         goto done;
@@ -1913,7 +1913,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     PMIX_INFO_DESTRUCT(&ginfo);
     if (NULL == peer->nptr->compat.gds) {
         PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         CLOSE_THE_SOCKET(pnd->sd);
         goto done;
@@ -1932,7 +1932,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
     req = PMIX_NEW(pmix_iof_req_t);
     if (NULL == req) {
         PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         CLOSE_THE_SOCKET(pnd->sd);
         goto done;
@@ -1968,7 +1968,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
                             "validation of tool credentials failed: %s",
                             PMIx_Error_string(rc));
         PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         CLOSE_THE_SOCKET(pnd->sd);
         goto done;
@@ -1981,7 +1981,7 @@ static void process_cbfunc(int sd, short args, void *cbdata)
         PMIX_RELEASE(pnd);
         PMIX_RELEASE(cd);
         PMIX_RELEASE(peer);
-        pmix_list_remove_item(&pmix_server_globals.nspaces, &nptr->super);
+        pmix_list_remove_item(&pmix_globals.nspaces, &nptr->super);
         PMIX_RELEASE(nptr);  // will release the info object
         /* probably cannot send an error reply if we are out of memory */
         return;

--- a/src/mca/ptl/usock/ptl_usock_component.c
+++ b/src/mca/ptl/usock/ptl_usock_component.c
@@ -552,7 +552,7 @@ static void connection_handler(int sd, short args, void *cbdata)
 
     /* see if we know this nspace */
     nptr = NULL;
-    PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
+    PMIX_LIST_FOREACH(tmp, &pmix_globals.nspaces, pmix_namespace_t) {
         if (0 == strcmp(tmp->nspace, nspace)) {
             nptr = tmp;
             break;

--- a/src/runtime/pmix_finalize.c
+++ b/src/runtime/pmix_finalize.c
@@ -125,6 +125,7 @@ void pmix_rte_finalize(void)
     PMIX_LIST_DESTRUCT(&pmix_globals.iof_requests);
     PMIX_LIST_DESTRUCT(&pmix_globals.stdin_targets);
     free(pmix_globals.hostname);
+    PMIX_LIST_DESTRUCT(&pmix_globals.nspaces);
 
     /* now safe to release the event base */
     if (!pmix_globals.external_evbase) {

--- a/src/runtime/pmix_init.c
+++ b/src/runtime/pmix_init.c
@@ -178,6 +178,8 @@ int pmix_rte_init(pmix_proc_type_t type,
     ret = pmix_hotel_init(&pmix_globals.notifications, pmix_globals.max_events,
                           pmix_globals.evbase, pmix_globals.event_eviction_time,
                           _notification_eviction_cbfunc);
+    PMIX_CONSTRUCT(&pmix_globals.nspaces, pmix_list_t);
+
     if (PMIX_SUCCESS != ret) {
         error = "notification hotel init";
         goto return_error;

--- a/src/server/pmix_server_ops.c
+++ b/src/server/pmix_server_ops.c
@@ -442,7 +442,7 @@ static pmix_server_trkr_t* new_tracker(char *id, pmix_proc_t *procs,
         }
         /* is this nspace known to us? */
         nptr = NULL;
-        PMIX_LIST_FOREACH(ns, &pmix_server_globals.nspaces, pmix_namespace_t) {
+        PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
             if (0 == strcmp(procs[i].nspace, ns->nspace)) {
                 nptr = ns;
                 break;
@@ -3025,7 +3025,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
         for (n=0; n < cd->ntargets; n++) {
             /* find the nspace of this proc */
             nptr = NULL;
-            PMIX_LIST_FOREACH(tmp, &pmix_server_globals.nspaces, pmix_namespace_t) {
+            PMIX_LIST_FOREACH(tmp, &pmix_globals.nspaces, pmix_namespace_t) {
                 if (0 == strcmp(tmp->nspace, cd->targets[n].nspace)) {
                     nptr = tmp;
                     break;
@@ -3038,7 +3038,7 @@ pmix_status_t pmix_server_job_ctrl(pmix_peer_t *peer,
                     goto exit;
                 }
                 nptr->nspace = strdup(cd->targets[n].nspace);
-                pmix_list_append(&pmix_server_globals.nspaces, &nptr->super);
+                pmix_list_append(&pmix_globals.nspaces, &nptr->super);
             }
             /* if the rank is wildcard, then we use the epilog for the nspace */
             if (PMIX_RANK_WILDCARD == cd->targets[n].rank) {

--- a/src/tool/pmix_tool.c
+++ b/src/tool/pmix_tool.c
@@ -1254,7 +1254,6 @@ PMIX_EXPORT pmix_status_t PMIx_tool_finalize(void)
         PMIX_LIST_DESTRUCT(&pmix_server_globals.local_reqs);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.gdata);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.events);
-        PMIX_LIST_DESTRUCT(&pmix_server_globals.nspaces);
         PMIX_LIST_DESTRUCT(&pmix_server_globals.iof);
     }
 

--- a/src/util/name_fns.c
+++ b/src/util/name_fns.c
@@ -12,7 +12,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -98,6 +98,7 @@ char* pmix_util_print_name_args(const pmix_proc_t *name)
 {
     pmix_print_args_buffers_t *ptr;
     char *rank;
+    int index;
 
     /* get the next buffer */
     ptr = get_print_name_buffer();
@@ -105,29 +106,36 @@ char* pmix_util_print_name_args(const pmix_proc_t *name)
         PMIX_ERROR_LOG(PMIX_ERR_OUT_OF_RESOURCE);
         return pmix_print_args_null;
     }
-    /* cycle around the ring */
-    if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {
-        ptr->cntr = 0;
-    }
 
     /* protect against NULL names */
     if (NULL == name) {
-        snprintf(ptr->buffers[ptr->cntr++], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "[NO-NAME]");
-        return ptr->buffers[ptr->cntr-1];
+        index = ptr->cntr;
+        snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "[NO-NAME]");
+        ptr->cntr++;
+        if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {
+            ptr->cntr = 0;
+        }
+        return ptr->buffers[index];
     }
 
     rank = pmix_util_print_rank(name->rank);
 
-    snprintf(ptr->buffers[ptr->cntr++],
+    index = ptr->cntr;
+    snprintf(ptr->buffers[index],
              PMIX_PRINT_NAME_ARGS_MAX_SIZE,
-             "[%s,%s]", name->nspace, rank);
+             "[%s:%s]", name->nspace, rank);
+    ptr->cntr++;
+    if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {
+        ptr->cntr = 0;
+    }
 
-    return ptr->buffers[ptr->cntr-1];
+    return ptr->buffers[index];
 }
 
 char* pmix_util_print_rank(const pmix_rank_t vpid)
 {
     pmix_print_args_buffers_t *ptr;
+    int index;
 
     ptr = get_print_name_buffer();
 
@@ -136,19 +144,19 @@ char* pmix_util_print_rank(const pmix_rank_t vpid)
         return pmix_print_args_null;
     }
 
-    /* cycle around the ring */
-    if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {
-        ptr->cntr = 0;
-    }
-
+    index = ptr->cntr;
     if (PMIX_RANK_UNDEF == vpid) {
-        snprintf(ptr->buffers[ptr->cntr++], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "UNDEF");
+        snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "UNDEF");
     } else if (PMIX_RANK_WILDCARD == vpid) {
-        snprintf(ptr->buffers[ptr->cntr++], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "WILDCARD");
+        snprintf(ptr->buffers[index], PMIX_PRINT_NAME_ARGS_MAX_SIZE, "WILDCARD");
     } else {
-        snprintf(ptr->buffers[ptr->cntr++],
+        snprintf(ptr->buffers[index],
                  PMIX_PRINT_NAME_ARGS_MAX_SIZE,
                  "%ld", (long)vpid);
     }
-    return ptr->buffers[ptr->cntr-1];
+    ptr->cntr++;
+    if (PMIX_PRINT_NAME_ARG_NUM_BUFS == ptr->cntr) {
+        ptr->cntr = 0;
+    }
+    return ptr->buffers[index];
 }

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -86,7 +86,7 @@ simplegacy_SOURCES = \
         simplegacy.c
 simplegacy_LDFLAGS = $(PMIX_PKG_CONFIG_LDFLAGS)
 simplegacy_LDADD = \
-    $(top_builddir)/src/libpmix.la
+    $(top_builddir)/src/libpmi.la
 
 simptimeout_SOURCES = \
         simptimeout.c

--- a/test/simple/simplegacy.c
+++ b/test/simple/simplegacy.c
@@ -13,7 +13,7 @@
  *                         All rights reserved.
  * Copyright (c) 2009-2012 Cisco Systems, Inc.  All rights reserved.
  * Copyright (c) 2011      Oak Ridge National Labs.  All rights reserved.
- * Copyright (c) 2013-2017 Intel, Inc. All rights reserved.
+ * Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Mellanox Technologies, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
@@ -24,230 +24,90 @@
  */
 
 #include <src/include/pmix_config.h>
-#include <pmix.h>
+#include <pmi.h>
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <time.h>
 
-#include "src/class/pmix_object.h"
-#include "src/util/output.h"
-#include "src/util/printf.h"
-
 #define MAXCNT 3
-
-static volatile bool completed = false;
-static pmix_proc_t myproc;
-
-static void notification_fn(size_t evhdlr_registration_id,
-                            pmix_status_t status,
-                            const pmix_proc_t *source,
-                            pmix_info_t info[], size_t ninfo,
-                            pmix_info_t results[], size_t nresults,
-                            pmix_event_notification_cbfunc_fn_t cbfunc,
-                            void *cbdata)
-{
-    pmix_output(0, "Client %s:%d NOTIFIED with status %s", myproc.nspace, myproc.rank, PMIx_Error_string(status));
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
-    }
-    completed = true;
-}
-
-static void errhandler_reg_callbk(pmix_status_t status,
-                                  size_t errhandler_ref,
-                                  void *cbdata)
-{
-    volatile bool *active = (volatile bool*)cbdata;
-
-    pmix_output(0, "Client: ERRHANDLER REGISTRATION CALLBACK CALLED WITH STATUS %d, ref=%lu",
-                status, (unsigned long)errhandler_ref);
-    *active = false;
-}
-
-/* this is an event notification function that we explicitly request
- * be called when the PMIX_MODEL_DECLARED notification is issued.
- * We could catch it in the general event notification function and test
- * the status to see if the status matched, but it often is simpler
- * to declare a use-specific notification callback point. In this case,
- * we are asking to know whenever a model is declared as a means
- * of testing server self-notification */
-static void model_callback(size_t evhdlr_registration_id,
-                           pmix_status_t status,
-                           const pmix_proc_t *source,
-                           pmix_info_t info[], size_t ninfo,
-                           pmix_info_t results[], size_t nresults,
-                           pmix_event_notification_cbfunc_fn_t cbfunc,
-                           void *cbdata)
-{
-    size_t n;
-
-    /* just let us know it was received */
-    fprintf(stderr, "%s:%d Model event handler called with status %d(%s)\n",
-            myproc.nspace, myproc.rank, status, PMIx_Error_string(status));
-    for (n=0; n < ninfo; n++) {
-        if (PMIX_STRING == info[n].value.type) {
-            fprintf(stderr, "%s:%d\t%s:\t%s\n",
-                    myproc.nspace, myproc.rank,
-                    info[n].key, info[n].value.data.string);
-        }
-    }
-
-    /* we must NOT tell the event handler state machine that we
-     * are the last step as that will prevent it from notifying
-     * anyone else that might be listening for declarations */
-    if (NULL != cbfunc) {
-        cbfunc(PMIX_SUCCESS, NULL, 0, NULL, NULL, cbdata);
-    }
-}
-
-/* event handler registration is done asynchronously */
-static void model_registration_callback(pmix_status_t status,
-                                        size_t evhandler_ref,
-                                        void *cbdata)
-{
-    volatile int *active = (volatile int*)cbdata;
-
-    fprintf(stderr, "simpclient EVENT HANDLER REGISTRATION RETURN STATUS %d, ref=%lu\n",
-               status, (unsigned long)evhandler_ref);
-    *active = false;
-}
 
 int main(int argc, char **argv)
 {
-    int rc;
-    pmix_value_t value;
-    pmix_value_t *val = &value;
+    int rc, j, n;
     char *tmp;
-    pmix_proc_t proc;
-    uint32_t nprocs, n;
-    int cnt, j;
-    volatile bool active;
-    pmix_info_t info, *iptr;
-    size_t ninfo;
-    pmix_status_t code;
+    int spawned;
+    int rank;
+    int nprocs;
+    char value[1024];
 
-    /* init us and declare we are a test programming model */
-    PMIX_INFO_CREATE(iptr, 2);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_PROGRAMMING_MODEL, "TEST", PMIX_STRING);
-    PMIX_INFO_LOAD(&iptr[1], PMIX_MODEL_LIBRARY_NAME, "PMIX", PMIX_STRING);
-    if (PMIX_SUCCESS != (rc = PMIx_Init(&myproc, iptr, 2))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Init failed: %s",
-                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fprintf(stderr, "Client calling init\n");
+    if (PMI_SUCCESS != (rc = PMI_Init(&spawned))) {
+        fprintf(stderr, "Client PMI_Init failed: %d\n", rc);
         exit(rc);
     }
-    PMIX_INFO_FREE(iptr, 2);
-    pmix_output(0, "Client ns %s rank %d: Running", myproc.nspace, myproc.rank);
+    fprintf(stderr, "Client Running\n");
 
     /* test something */
-    (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-    proc.rank = PMIX_RANK_WILDCARD;
-    if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &val))) {
-        pmix_output(0, "Client ns %s rank %d: PMIx_Get failed: %s",
-                    myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    if (PMI_SUCCESS != (rc = PMI_Get_rank(&rank))) {
+        fprintf(stderr, "Client PMI_Get_rank failed: %d\n", rc);
         exit(rc);
     }
-    nprocs = val->data .uint32;
-    PMIX_VALUE_RELEASE(val);
-    pmix_output(0, "Client %s:%d universe size %d", myproc.nspace, myproc.rank, nprocs);
-
-    /* register a handler specifically for when models declare */
-    active = true;
-    ninfo = 1;
-    PMIX_INFO_CREATE(iptr, ninfo);
-    PMIX_INFO_LOAD(&iptr[0], PMIX_EVENT_HDLR_NAME, "SIMPCLIENT-MODEL", PMIX_STRING);
-    code = PMIX_MODEL_DECLARED;
-    PMIx_Register_event_handler(&code, 1, iptr, ninfo,
-                                model_callback, model_registration_callback, (void*)&active);
-    while (active) {
-        usleep(10);
+    if (PMI_SUCCESS != (rc = PMI_Get_universe_size(&nprocs))) {
+        fprintf(stderr, "Client %d: PMI_Get_universe_size failed: %d\n", rank, rc);
+        exit(rc);
     }
-    PMIX_INFO_FREE(iptr, ninfo);
+    fprintf(stderr, "Client %d job size %d\n", rank, nprocs);
 
-    /* register our errhandler */
-    active = true;
-    PMIx_Register_event_handler(NULL, 0, NULL, 0,
-                                notification_fn, errhandler_reg_callbk, (void*)&active);
-    while (active) {
-        usleep(10);
+    for (j=0; j < 10; j++) {
+        (void)asprintf(&tmp, "%d-gasnet-0-%d", rank, j);
+        if (PMI_SUCCESS != (rc = PMI_KVS_Put("foobar", tmp, "myvalue"))) {
+            fprintf(stderr, "Client %d: j %d PMI_KVS_Put failed: %d\n",
+                    rank, j, rc);
+            goto done;
+        }
+        free(tmp);
     }
 
-    memset(&info, 0, sizeof(pmix_info_t));
-    (void)strncpy(info.key, PMIX_COLLECT_DATA, PMIX_MAX_KEYLEN);
-    info.value.type = PMIX_UNDEF;
-    info.value.data.flag = 1;
+    if (PMIX_SUCCESS != (rc = PMI_KVS_Commit("foobar"))) {
+            fprintf(stderr, "Client %d: PMI_KVS_Commit failed: %d\n", rank, rc);
+            goto done;
+    }
 
-    for (cnt=0; cnt < MAXCNT; cnt++) {
-        pmix_output(0, "EXECUTING LOOP %d", cnt);
-        for (j=0; j < 10; j++) {
-            (void)asprintf(&tmp, "%s-%d-gasnet-%d-%d", myproc.nspace, myproc.rank, cnt, j);
-            value.type = PMIX_UINT64;
-            value.data.uint64 = 1234;
-            if (PMIX_SUCCESS != (rc = PMIx_Put(PMIX_GLOBAL, tmp, &value))) {
-                pmix_output(0, "Client ns %s rank %d: PMIx_Put failed: %s",
-                            myproc.nspace, myproc.rank, PMIx_Error_string(rc));
-                goto done;
+    fprintf(stderr, "Client rank %d: CALLING PMI_Barrier\n", rank);
+
+    /* call fence to ensure the data is received */
+    if (PMI_SUCCESS != (rc = PMI_Barrier())) {
+            fprintf(stderr, "Client %d: PMI_Barrier failed: %d\n", rank, rc);
+        goto done;
+    }
+
+    /* check the returned data */
+    for (j=0; j < 10; j++) {
+        for (n=0; n < nprocs; n++) {
+            (void)asprintf(&tmp, "%d-gasnet-0-%d", n, j);
+            fprintf(stderr, "Client %d: Calling get\n", rank);
+            if (PMI_SUCCESS != (rc = PMI_KVS_Get("foobar", tmp, value, 1024))) {
+             fprintf(stderr, "Client %d: PMI_Get failed: %d\n", rank, rc);
+                continue;
+            }
+            if (0 == strcmp(value, "myvalue")) {
+                fprintf(stderr, "Client %d: PMI_Get returned correct value\n", rank);
+            } else {
+                fprintf(stderr, "Client %d: PMI_Get returned incorrect value\n", rank);
             }
             free(tmp);
-        }
-
-        if (PMIX_SUCCESS != (rc = PMIx_Commit())) {
-            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Commit failed: %s",
-                        myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
-            goto done;
-        }
-
-        /* call fence to ensure the data is received */
-        if (PMIX_SUCCESS != (rc = PMIx_Fence(NULL, 0, &info, 1))) {
-            pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Fence failed: %s",
-                        myproc.nspace, myproc.rank, cnt, PMIx_Error_string(rc));
-            goto done;
-        }
-
-        /* check the returned data */
-        (void)strncpy(proc.nspace, myproc.nspace, PMIX_MAX_NSLEN);
-        proc.rank = PMIX_RANK_UNDEF;
-        for (j=0; j < 10; j++) {
-            for (n=0; n < nprocs; n++) {
-                (void)asprintf(&tmp, "%s-%d-gasnet-%d-%d", myproc.nspace, n, cnt, j);
-                if (PMIX_SUCCESS != (rc = PMIx_Get(&proc, tmp, NULL, 0, &val))) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s failed: %s",
-                                myproc.nspace, myproc.rank, j, tmp, PMIx_Error_string(rc));
-                    continue;
-                }
-                if (NULL == val) {
-                    pmix_output(0, "Client ns %s rank %d: NULL value returned",
-                                myproc.nspace, myproc.rank);
-                    break;
-                }
-                if (PMIX_UINT64 != val->type) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong type: %d", myproc.nspace, myproc.rank, j, tmp, val->type);
-                    PMIX_VALUE_RELEASE(val);
-                    free(tmp);
-                    continue;
-                }
-                if (1234 != val->data.uint64) {
-                    pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned wrong value: %d", myproc.nspace, myproc.rank, j, tmp, (int)val->data.uint64);
-                    PMIX_VALUE_RELEASE(val);
-                    free(tmp);
-                    continue;
-                }
-                pmix_output(0, "Client ns %s rank %d cnt %d: PMIx_Get %s returned correct", myproc.nspace, myproc.rank, j, tmp);
-                PMIX_VALUE_RELEASE(val);
-                free(tmp);
-            }
         }
     }
 
   done:
     /* finalize us */
-    pmix_output(0, "Client ns %s rank %d: Finalizing", myproc.nspace, myproc.rank);
-    if (PMIX_SUCCESS != (rc = PMIx_Finalize(NULL, 0))) {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize failed: %s\n",
-                myproc.nspace, myproc.rank, PMIx_Error_string(rc));
+    fprintf(stderr, "Client rank %d: Finalizing\n", rank);
+    if (PMI_SUCCESS != (rc = PMI_Finalize())) {
+        fprintf(stderr, "Client rank %d: finalize failed %d\n", rank, rc);
     } else {
-        fprintf(stderr, "Client ns %s rank %d:PMIx_Finalize successfully completed\n", myproc.nspace, myproc.rank);
+        fprintf(stderr, "Client %d:PMI_Finalize successfully completed\n", rank);
     }
     fflush(stderr);
     return(rc);


### PR DESCRIPTION
Legacy interfaces cannot pass the proc whose data they are requesting.
Instead, legacy apps publish keys that have the proc's rank embedded in
them, thus making them globally unique. When requesting the data, the
requestor can only pass PMIX_RANK_UNDEF to PMIx_Get since it has no
other information.

In that scenario, we have to search data from all ranks (since it will
have been stored by rank when it was published) to find the unique key.
Since the datastore components cannot handle PMIX_RANK_UNDEF, we must
also ensure that all data operations involving PMIX_RANK_UNDEF flow
thru the GDS hash component

Also, fix the pmi_client test program - any keys "put" by a process must
be globally unique

Signed-off-by: Ralph Castain <rhc@pmix.org>