### PR TITLE
Cleanup handling of data requests for different nspaces

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -505,8 +505,11 @@ static pmix_status_t _getfn_fastpath(const pmix_proc_t *proc, const pmix_key_t k
     /* scan the incoming directives */
     if (NULL != info) {
         for (n=0; n < ninfo; n++) {
-            if (0 == strncmp(info[n].key, PMIX_DATA_SCOPE, PMIX_MAX_KEYLEN)) {
+            if (PMIX_CHECK_KEY(&info[n], PMIX_DATA_SCOPE)) {
                 cb->scope = info[n].value.data.scope;
+            } else if (PMIX_CHECK_KEY(&info[n], PMIX_OPTIONAL) ||
+                       PMIX_CHECK_KEY(&info[n], PMIX_IMMEDIATE)) {
+                continue;
             } else {
                 /* we cannot handle any other directives via this path */
                 PMIX_RELEASE(cb);
@@ -520,16 +523,16 @@ static pmix_status_t _getfn_fastpath(const pmix_proc_t *proc, const pmix_key_t k
     cb->info = (pmix_info_t*)info;
     cb->ninfo = ninfo;
 
-    PMIX_GDS_FETCH_IS_TSAFE(rc, pmix_globals.mypeer);
+    PMIX_GDS_FETCH_IS_TSAFE(rc, pmix_client_globals.myserver);
     if (PMIX_SUCCESS == rc) {
-        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
+        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
         if (PMIX_SUCCESS == rc) {
             goto done;
         }
     }
-    PMIX_GDS_FETCH_IS_TSAFE(rc, pmix_client_globals.myserver);
+    PMIX_GDS_FETCH_IS_TSAFE(rc, pmix_globals.mypeer);
     if (PMIX_SUCCESS == rc) {
-        PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);
+        PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
         if (PMIX_SUCCESS == rc) {
             goto done;
         }

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -1369,6 +1369,7 @@ static pmix_status_t register_info(pmix_peer_t *peer,
         PMIX_BFROPS_PACK(rc, peer, reply, kvptr, 1, PMIX_KVAL);
     }
 
+    /* get the proc-level data for each proc in the job */
     for (rank=0; rank < ns->nprocs; rank++) {
         val = NULL;
         rc = pmix_hash_fetch(ht, rank, NULL, &val);
@@ -2087,6 +2088,7 @@ static pmix_status_t dohash(pmix_hash_table_t *ht,
     pmix_kval_t *kv, *k2;
     pmix_info_t *info;
     size_t n, ninfo;
+    bool found;
 
     rc = pmix_hash_fetch(ht, rank, key, &val);
     if (PMIX_SUCCESS == rc) {
@@ -2110,14 +2112,14 @@ static pmix_status_t dohash(pmix_hash_table_t *ht,
                     continue;
                 }
                 /* see if we already have this on the list */
-                kv = NULL;
+                found = false;
                 PMIX_LIST_FOREACH(k2, kvs, pmix_kval_t) {
                     if (PMIX_CHECK_KEY(&info[n], k2->key)) {
-                        kv = k2;
+                        found = true;
                         break;
                     }
                 }
-                if (NULL != kv) {
+                if (found) {
                     continue;
                 }
                 kv = PMIX_NEW(pmix_kval_t);
@@ -2322,7 +2324,7 @@ static pmix_status_t hash_fetch(const pmix_proc_t *proc,
     pmix_rank_t rnk;
 
     pmix_output_verbose(2, pmix_gds_base_framework.framework_output,
-                        "[%s] pmix:gds:hash fetch %s for proc %s on scope %s",
+                        "%s pmix:gds:hash fetch %s for proc %s on scope %s",
                         PMIX_NAME_PRINT(&pmix_globals.myid),
                         (NULL == key) ? "NULL" : key,
                         PMIX_NAME_PRINT(proc), PMIx_Scope_string(scope));


### PR DESCRIPTION
If data is being requested for a different nspace, then correctly direct
it to the right place.

Signed-off-by: Ralph Castain <rhc@pmix.org>