### PR TITLE
Minor cleanups in the Python bindings

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -41,7 +41,8 @@ cdef void setupapp_cbfunc(pmix_status_t status,
         active.cache_info(ilist)
         status = rc
     active.set(status)
-    cbfunc(PMIX_SUCCESS, cbdata)
+    if (NULL != cbfunc):
+        cbfunc(PMIX_SUCCESS, cbdata)
     return
 
 cdef class PMIxClient:

--- a/bindings/python/sched.py.in
+++ b/bindings/python/sched.py.in
@@ -56,13 +56,13 @@ def main():
     print("Node regex: ", regex)
     (rc, ppn) = foo.generate_ppn("0,1,2;3,4,5;6,7")
     print("PPN: ", ppn)
-    darray = (PMIX_INFO, [{'key':PMIX_ALLOC_NETWORK_ID, 
+    darray = (PMIX_INFO, [{'key':PMIX_ALLOC_NETWORK_ID,
                             'value':'SIMPSCHED.net', 'val_type':PMIX_STRING},
-                           {'key':PMIX_ALLOC_NETWORK_SEC_KEY, 'value':'T', 
+                           {'key':PMIX_ALLOC_NETWORK_SEC_KEY, 'value':'T',
                             'val_type':PMIX_BOOL},
-                           {'key':PMIX_SETUP_APP_ENVARS, 'value':'T', 
+                           {'key':PMIX_SETUP_APP_ENVARS, 'value':'T',
                             'val_type':PMIX_BOOL}])
-    kyvals = [{'key':PMIX_NODE_MAP, 'value':'regex', 'val_type':PMIX_STRING},
+    kyvals = [{'key':PMIX_NODE_MAP, 'value':regex, 'val_type':PMIX_STRING},
               {'key':PMIX_PROC_MAP, 'value':ppn, 'val_type':PMIX_STRING},
               {'key':PMIX_ALLOC_NETWORK, 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
 
@@ -77,9 +77,9 @@ def main():
     env = os.environ.copy()
 
     # register an nspace for the client app
-    kvals = [{'key':PMIX_NODE_MAP, 'value':'regex', 'val_type':PMIX_STRING},
-             {'key':PMIX_PROC_MAP, 'value':ppn, 'val_type':PMIX_STRING}, 
-             {'key':PMIX_UNIV_SIZE, 'value':1, 'val_type':PMIX_UINT32}, 
+    kvals = [{'key':PMIX_NODE_MAP, 'value':regex, 'val_type':PMIX_STRING},
+             {'key':PMIX_PROC_MAP, 'value':ppn, 'val_type':PMIX_STRING},
+             {'key':PMIX_UNIV_SIZE, 'value':1, 'val_type':PMIX_UINT32},
              {'key':PMIX_JOB_SIZE, 'value':1, 'val_type':PMIX_UINT32}]
     print("REGISTERING NSPACE")
     rc = foo.register_nspace("testnspace", 1, kvals)


### PR DESCRIPTION
Check for NULL callback function before executing it.

Correctly pass the node regex in sched.py example

Signed-off-by: Ralph Castain <rhc@pmix.org>