### PR TITLE
Add PMIx_Get wrapper in Python bindings

### DIFF
--- a/bindings/python/client.py.in
+++ b/bindings/python/client.py.in
@@ -26,6 +26,11 @@ def main():
     info = []
     rc = foo.fence(procs, info)
     print("Fence result ", rc)
+    print("GET")
+    info = []
+    rc, get_val = foo.get(("testnspace", 0), "mykey", info)
+    print("Get result: ", rc)
+    print("Get value returned: ", get_val)
     # finalize
     info = []
     foo.finalize(info)


### PR DESCRIPTION
Allows PMIx_Get to be called through the
Python bindings interface.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>