### PR TITLE
travis: test python bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ dist: xenial
 cache:
   apt: true
 
-language: c
+language: python
+python:
+  - "3.5"
 
 addons:
   apt:
@@ -40,6 +42,7 @@ script:
         # prepare
         # build
         - ./autogen.pl
+        - pip install -q cython
         - ./configure ${ENABLE_WERROR}
         - if [ $? -ne 0 ]; then cat config.log; fi
         - make all


### PR DESCRIPTION
 - use python 3.5
 - install cython
 - pass the --enable-python-bindings option to configure

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>