### PR TITLE
Extend the Python binding support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ test/simple/simpjctrl
 test/simple/simpio
 test/simple/data-*
 test/simple/simpcoord
+test/python/run_sched.sh
+test/python/run_server.sh
 
 # coverity
 cov-int

--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,6 @@ bindings/python/*.so
 bindings/python/build/
 bindings/python/pmix_constants.pxd
 bindings/python/pmix_constants.pxi
-bindings/python/client.py
-bindings/python/server.py
 
 examples/alloc
 examples/client
@@ -103,14 +101,6 @@ src/tools/ptop/ptop
 
 src/util/show_help_lex.c
 src/util/keyval/keyval_lex.c
-
-bindings/python/src/_pypmix.so
-bindings/python/src/libpypmix.so
-bindings/python/src/pypmix.py
-bindings/python/src/pypmix_wrap.c
-bindings/python/client.py
-bindings/python/server.py
-bindings/python/sched.py
 
 test/pmi2_client
 test/pmi_client

--- a/bindings/python/Makefile.am
+++ b/bindings/python/Makefile.am
@@ -21,7 +21,7 @@
 # $HEADER$
 #
 
-helpers = setup.py pmix.pyx
+helpers = setup.py pmix.pyx pmix.pxi construct.py
 
 if WANT_PYTHON_BINDINGS
 

--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -1,4 +1,4 @@
-@PMIX_PYTHON_PATH@
+#!/usr/bin/env python3
 
 from pmix import *
 

--- a/bindings/python/construct.py
+++ b/bindings/python/construct.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python3
 
 import os, os.path, sys, shutil, signal
 from optparse import OptionParser, OptionGroup

--- a/bindings/python/server.py
+++ b/bindings/python/server.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+from pmix import *
+import signal, time
+import os
+import select
+import subprocess
+
+global killer
+
+class GracefulKiller:
+  kill_now = False
+  def __init__(self):
+    signal.signal(signal.SIGINT, self.exit_gracefully)
+    signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+  def exit_gracefully(self,signum, frame):
+    self.kill_now = True
+
+def clientconnected(proc:tuple is not None):
+    print("CLIENT CONNECTED", proc)
+    return PMIX_SUCCESS
+
+def clientfinalized(proc:tuple is not None):
+    print("CLIENT FINALIZED", proc)
+    return PMIX_SUCCESS
+
+def clientfence(args:dict is not None):
+    print("SERVER FENCE", args)
+    return PMIX_SUCCESS
+
+def main():
+    try:
+        foo = PMIxServer()
+    except:
+        print("FAILED TO CREATE SERVER")
+        exit(1)
+    print("Testing server version ", foo.get_version())
+    args = [{'key':'FOOBAR', 'value':'VAR', 'val_type':PMIX_STRING},
+            {'key':'BLAST', 'value':7, 'val_type':PMIX_INT32}]
+    map = {'clientconnected': clientconnected,
+           'clientfinalized': clientfinalized,
+           'fencenb': clientfence}
+    my_result = foo.init(args, map)
+    print("Testing PMIx_Initialized")
+    rc = foo.initialized()
+    print("Initialized: ", rc)
+    vers = foo.get_version()
+    print("Version: ", vers)
+
+    # get our environment as a base
+    env = os.environ.copy()
+    # register an nspace for the client app
+    darray = (PMIX_SIZE, [1, 2, 3, 4, 5])
+    kvals = [{'key':'testkey', 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
+    print("REGISTERING NSPACE")
+    rc = foo.register_nspace("testnspace", 1, kvals)
+    print("RegNspace ", rc)
+
+    # register a client
+    uid = os.getuid()
+    gid = os.getgid()
+    rc = foo.register_client(("testnspace", 0), uid, gid)
+    print("RegClient ", rc)
+    # setup the fork
+    rc = foo.setup_fork(("testnspace", 0), env)
+    print("SetupFrk", rc)
+
+    # setup the client argv
+    args = ["./client.py"]
+    # open a subprocess with stdout and stderr
+    # as distinct pipes so we can capture their
+    # output as the process runs
+    p = subprocess.Popen(args, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # define storage to catch the output
+    stdout = []
+    stderr = []
+    # loop until the pipes close
+    while True:
+        reads = [p.stdout.fileno(), p.stderr.fileno()]
+        ret = select.select(reads, [], [])
+
+        stdout_done = True
+        stderr_done = True
+
+        for fd in ret[0]:
+            # if the data
+            if fd == p.stdout.fileno():
+                read = p.stdout.readline()
+                if read:
+                    read = read.decode('utf-8').rstrip()
+                    print('stdout: ' + read)
+                    stdout_done = False
+            elif fd == p.stderr.fileno():
+                read = p.stderr.readline()
+                if read:
+                    read = read.decode('utf-8').rstrip()
+                    print('stderr: ' + read)
+                    stderr_done = False
+
+        if stdout_done and stderr_done:
+            break
+
+    print("FINALIZING")
+    foo.finalize()
+
+if __name__ == '__main__':
+    global killer
+    killer = GracefulKiller()
+    main()

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -910,11 +910,6 @@ AC_DEFUN([PMIX_SETUP_CORE],[
         pmix_config_prefix[src/tools/pps/Makefile]
         pmix_config_prefix[src/tools/pattrs/Makefile]
         )
-    if test "$WANT_PYTHON_BINDINGS" = "1"; then
-        AC_CONFIG_FILES(pmix_config_prefix[bindings/python/server.py], [chmod +x bindings/python/server.py])
-        AC_CONFIG_FILES(pmix_config_prefix[bindings/python/client.py], [chmod +x bindings/python/client.py])
-        AC_CONFIG_FILES(pmix_config_prefix[bindings/python/sched.py],  [chmod +x bindings/python/sched.py])
-    fi
 
     # publish any embedded flags so external wrappers can use them
     AC_SUBST(PMIX_EMBEDDED_LIBS)
@@ -1213,9 +1208,8 @@ AM_CONDITIONAL([WANT_PYTHON_BINDINGS], [test $WANT_PYTHON_BINDINGS -eq 1])
 
 if test "$WANT_PYTHON_BINDINGS" = "1"; then
     AM_PATH_PYTHON([3.4])
-    AC_SUBST([PMIX_PYTHON_PATH], [#!"$PYTHON"], "Full Python executable path")
-    pyvers=`python --version`
-    python_version=${pyvers#"Python"}
+    pyvers=`python3 --version`
+    python_version=${pyvers#"Python "}
     major=$(echo $python_version | cut -d. -f1)
     minor=$(echo $python_version | cut -d. -f2)
     if test "$major" -lt "3"; then

--- a/config/pmix.m4
+++ b/config/pmix.m4
@@ -885,6 +885,10 @@ AC_DEFUN([PMIX_SETUP_CORE],[
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests13.pl], [chmod +x test/run_tests13.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests14.pl], [chmod +x test/run_tests14.pl])
     AC_CONFIG_FILES(pmix_config_prefix[test/run_tests15.pl], [chmod +x test/run_tests15.pl])
+    if test "$WANT_PYTHON_BINDINGS" = "1"; then
+        AC_CONFIG_FILES(pmix_config_prefix[test/python/run_server.sh], [chmod +x test/python/run_server.sh])
+        AC_CONFIG_FILES(pmix_config_prefix[test/python/run_sched.sh], [chmod +x test/python/run_sched.sh])
+    fi
 
     ############################################################################
     # final output
@@ -1242,6 +1246,9 @@ if test "$WANT_PYTHON_BINDINGS" = "1"; then
         AC_MSG_WARN([require that the Cython package be installed])
         AC_MSG_ERROR([Cannot continue])
     fi
+
+    pmix_pythondir=`eval echo $pythondir`
+    AC_SUBST([PMIX_PYTHON_EGG_PATH], [$pmix_pythondir], [Path to installed Python egg])
 fi
 
 # see if they want to disable non-RTLD_GLOBAL dlopen

--- a/configure.ac
+++ b/configure.ac
@@ -287,7 +287,8 @@ AC_SUBST([libmca_common_dstore_so_version])
 AC_CONFIG_FILES(pmix_config_prefix[contrib/Makefile]
                 pmix_config_prefix[examples/Makefile]
                 pmix_config_prefix[test/Makefile]
-                pmix_config_prefix[test/simple/Makefile])
+                pmix_config_prefix[test/simple/Makefile]
+                pmix_config_prefix[test/python/Makefile])
 
 pmix_show_title "Configuration complete"
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -25,6 +25,11 @@ if !WANT_HIDDEN
 # these tests use internal symbols
 # use --disable-visibility
 SUBDIRS = simple
+
+if WANT_PYTHON_BINDINGS
+SUBDIRS += python
+endif
+
 endif
 
 headers = test_common.h cli_stages.h server_callbacks.h utils.h test_fence.h \

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2019      Intel, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+noinst_SCRIPTS = \
+    server.py \
+    sched.py \
+    client.py
+
+#########################
+# Support for "make check"
+
+TESTS = \
+    server.py \
+    sched.py

--- a/test/python/Makefile.am
+++ b/test/python/Makefile.am
@@ -8,6 +8,8 @@
 #
 
 noinst_SCRIPTS = \
+	run_server.sh.in \
+	run_sched.sh.in \
     server.py \
     sched.py \
     client.py
@@ -15,6 +17,10 @@ noinst_SCRIPTS = \
 #########################
 # Support for "make check"
 
+if WANT_PYTHON_BINDINGS
+
 TESTS = \
-    server.py \
-    sched.py
+    run_server.sh \
+    run_sched.sh
+
+endif

--- a/test/python/client.py
+++ b/test/python/client.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+from pmix import *
+
+def main():
+    foo = PMIxClient()
+    print("Testing PMIx ", foo.get_version())
+    info = [{'key':PMIX_PROGRAMMING_MODEL, 'value':'TEST', 'val_type':PMIX_STRING},
+            {'key':PMIX_MODEL_LIBRARY_NAME, 'value':'PMIX', 'val_type':PMIX_STRING}]
+    my_result = foo.init(info)
+    print("Init result ", my_result)
+    if 0 != my_result:
+        print("FAILED TO INIT")
+        exit(1)
+    # try putting something
+    print("PUT")
+    rc = foo.put(PMIX_GLOBAL, "mykey", (1, PMIX_INT32))
+    print("Put result ", rc);
+    # commit it
+    print("COMMIT")
+    rc = foo.commit()
+    print ("Commit result ", rc)
+    # execute fence
+    print("FENCE")
+    procs = []
+    info = []
+    rc = foo.fence(procs, info)
+    print("Fence result ", rc)
+    print("GET")
+    info = []
+    rc, get_val = foo.get(("testnspace", 0), "mykey", info)
+    print("Get result: ", rc)
+    print("Get value returned: ", get_val)
+    # finalize
+    info = []
+    foo.finalize(info)
+    print("Client finalize complete")
+if __name__ == '__main__':
+    main()

--- a/test/python/run_sched.sh.in
+++ b/test/python/run_sched.sh.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
+
+./sched.py

--- a/test/python/run_server.sh.in
+++ b/test/python/run_server.sh.in
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PYTHONPATH=@PMIX_PYTHON_EGG_PATH@
+
+./server.py

--- a/test/python/sched.py
+++ b/test/python/sched.py
@@ -1,4 +1,4 @@
-@PMIX_PYTHON_PATH@
+#!/usr/bin/env python3
 
 from pmix import *
 import signal, time

--- a/test/python/server.py
+++ b/test/python/server.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+from pmix import *
+import signal, time
+import os
+import select
+import subprocess
+
+global killer
+
+class GracefulKiller:
+  kill_now = False
+  def __init__(self):
+    signal.signal(signal.SIGINT, self.exit_gracefully)
+    signal.signal(signal.SIGTERM, self.exit_gracefully)
+
+  def exit_gracefully(self,signum, frame):
+    self.kill_now = True
+
+def clientconnected(proc:tuple is not None):
+    print("CLIENT CONNECTED", proc)
+    return PMIX_SUCCESS
+
+def clientfinalized(proc:tuple is not None):
+    print("CLIENT FINALIZED", proc)
+    return PMIX_SUCCESS
+
+def clientfence(args:dict is not None):
+    print("SERVER FENCE", args)
+    return PMIX_SUCCESS
+
+def main():
+    try:
+        foo = PMIxServer()
+    except:
+        print("FAILED TO CREATE SERVER")
+        exit(1)
+    print("Testing server version ", foo.get_version())
+    args = [{'key':'FOOBAR', 'value':'VAR', 'val_type':PMIX_STRING},
+            {'key':'BLAST', 'value':7, 'val_type':PMIX_INT32}]
+    map = {'clientconnected': clientconnected,
+           'clientfinalized': clientfinalized,
+           'fencenb': clientfence}
+    my_result = foo.init(args, map)
+    print("Testing PMIx_Initialized")
+    rc = foo.initialized()
+    print("Initialized: ", rc)
+    vers = foo.get_version()
+    print("Version: ", vers)
+
+    # get our environment as a base
+    env = os.environ.copy()
+    # register an nspace for the client app
+    darray = (PMIX_SIZE, [1, 2, 3, 4, 5])
+    kvals = [{'key':'testkey', 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
+    print("REGISTERING NSPACE")
+    rc = foo.register_nspace("testnspace", 1, kvals)
+    print("RegNspace ", rc)
+
+    # register a client
+    uid = os.getuid()
+    gid = os.getgid()
+    rc = foo.register_client(("testnspace", 0), uid, gid)
+    print("RegClient ", rc)
+    # setup the fork
+    rc = foo.setup_fork(("testnspace", 0), env)
+    print("SetupFrk", rc)
+
+    # setup the client argv
+    args = ["./client.py"]
+    # open a subprocess with stdout and stderr
+    # as distinct pipes so we can capture their
+    # output as the process runs
+    p = subprocess.Popen(args, env=env,
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    # define storage to catch the output
+    stdout = []
+    stderr = []
+    # loop until the pipes close
+    while True:
+        reads = [p.stdout.fileno(), p.stderr.fileno()]
+        ret = select.select(reads, [], [])
+
+        stdout_done = True
+        stderr_done = True
+
+        for fd in ret[0]:
+            # if the data
+            if fd == p.stdout.fileno():
+                read = p.stdout.readline()
+                if read:
+                    read = read.decode('utf-8').rstrip()
+                    print('stdout: ' + read)
+                    stdout_done = False
+            elif fd == p.stderr.fileno():
+                read = p.stderr.readline()
+                if read:
+                    read = read.decode('utf-8').rstrip()
+                    print('stderr: ' + read)
+                    stderr_done = False
+
+        if stdout_done and stderr_done:
+            break
+
+    print("FINALIZING")
+    foo.finalize()
+
+if __name__ == '__main__':
+    global killer
+    killer = GracefulKiller()
+    main()

--- a/test/simple/Makefile.am
+++ b/test/simple/Makefile.am
@@ -26,7 +26,7 @@ headers = simptest.h
 noinst_PROGRAMS = simptest simpclient simppub simpdyn simpft simpdmodex \
                   test_pmix simptool simpdie simplegacy simptimeout \
                   gwtest gwclient stability quietclient simpjctrl simpio simpsched \
-		  simpcoord
+		          simpcoord
 
 simptest_SOURCES = \
         simptest.c


### PR DESCRIPTION
Force use of Python 3. Add the simple binding tests to "make check" when
Python bindings are built.

Signed-off-by: Ralph Castain <rhc@pmix.org>