### PR TITLE
v3.2/bfrops: redefinition regtypes for internal usage

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -4,7 +4,7 @@
  * Copyright (c) 2016-2018 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
- * Copyright (c) 2016-2018 Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -2570,7 +2570,8 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
         } else if (PMIX_APP == m->type) {
             pmix_app_t *_a = (pmix_app_t*)m->array;
             PMIX_APP_FREE(_a, m->size);
-        } else if (PMIX_BYTE_OBJECT == m->type) {
+        } else if (PMIX_BYTE_OBJECT == m->type ||
+                   PMIX_COMPRESSED_STRING == m->type) {
             pmix_byte_object_t *_b = (pmix_byte_object_t*)m->array;
             PMIX_BYTE_OBJECT_FREE(_b, m->size);
         } else if (PMIX_STRING == m->type) {
@@ -2608,7 +2609,8 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
                 PMIX_QUERY_CREATE((m)->array, (n));                 \
             } else if (PMIX_APP == (t)) {                           \
                 PMIX_APP_CREATE((m)->array, (n));                   \
-            } else if (PMIX_BYTE_OBJECT == (t)) {                   \
+            } else if (PMIX_BYTE_OBJECT == (t) ||                   \
+                       PMIX_COMPRESSED_STRING == (t)) {             \
                 PMIX_BYTE_OBJECT_CREATE((m)->array, (n));           \
             } else if (PMIX_ALLOC_DIRECTIVE == (t) ||               \
                        PMIX_PROC_STATE == (t) ||                    \
@@ -2617,10 +2619,9 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
                        PMIX_DATA_RANGE == (t) ||                    \
                        PMIX_BYTE == (t) ||                          \
                        PMIX_INT8 == (t) ||                          \
-                       PMIX_UINT8 == (t)) {                         \
+                       PMIX_UINT8 == (t) ||                         \
+                       PMIX_POINTER == (t)) {                       \
                 (m)->array = pmix_calloc((n), sizeof(int8_t));      \
-            } else if (PMIX_POINTER == (t)) {                       \
-		(m)->array = pmix_calloc((n), sizeof(void*));       \
             } else if (PMIX_STRING == (t)) {                        \
                 (m)->array = pmix_calloc((n), sizeof(char*));            \
             } else if (PMIX_SIZE == (t)) {                          \
@@ -2651,7 +2652,9 @@ static inline void pmix_darray_destruct(pmix_data_array_t *m)
             } else if (PMIX_TIMEVAL == (t)) {                       \
                 (m)->array = pmix_calloc((n), sizeof(struct timeval));   \
             } else if (PMIX_TIME == (t)) {                          \
-                (m)->array = pmix_calloc((n), sizeof(time_t));           \
+                (m)->array = pmix_calloc((n), sizeof(time_t));      \
+            } else if (PMIX_BOOL == (t)) {                          \
+                (m)->array = pmix_calloc((n), sizeof(bool));        \
             }                                                       \
         } else {                                                    \
             (m)->array = NULL;                                      \

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -12,8 +12,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2019      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -227,8 +227,10 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
         int32_t i;                                                          \
         tmptype *tmpbuf = (tmptype*)calloc(*num_vals, sizeof(tmptype));     \
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmpbuf, num_vals, tmpbfroptype, reg_types);        \
-        for (i = 0 ; i < *num_vals ; ++i) {                                 \
-            ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);            \
+        if (PMIX_ERR_UNKNOWN_DATA_TYPE != ret) {                            \
+            for (i = 0 ; i < *num_vals ; ++i) {                             \
+                ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);        \
+            }                                                               \
         }                                                                   \
         free(tmpbuf);                                                       \
     } while (0)

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -14,6 +14,8 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -159,46 +161,72 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
 #endif
 
 /* Unpack generic size macros */
-#define PMIX_BFROP_UNPACK_SIZE_MISMATCH(unpack_type, remote_type, ret)                     \
+#define PMIX_BFROP_UNPACK_SIZE_MISMATCH(reg_types, unpack_type, remote_type, ret)                     \
     do {                                                                        \
         switch(remote_type) {                                                   \
             case PMIX_UINT8:                                                    \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, uint8_t, remote_type);  \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, uint8_t, remote_type);  \
                 break;                                                          \
             case PMIX_INT8:                                                     \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, int8_t, remote_type);   \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, int8_t, remote_type);   \
                 break;                                                          \
             case PMIX_UINT16:                                                   \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, uint16_t, remote_type); \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, uint16_t, remote_type); \
                 break;                                                          \
             case PMIX_INT16:                                                    \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, int16_t, remote_type);  \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, int16_t, remote_type);  \
                 break;                                                          \
             case PMIX_UINT32:                                                   \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, uint32_t, remote_type); \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, uint32_t, remote_type); \
                 break;                                                          \
             case PMIX_INT32:                                                    \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, int32_t, remote_type);  \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, int32_t, remote_type);  \
                 break;                                                          \
             case PMIX_UINT64:                                                   \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, uint64_t, remote_type); \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, uint64_t, remote_type); \
                 break;                                                          \
             case PMIX_INT64:                                                    \
-                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, int64_t, remote_type);  \
+                PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, int64_t, remote_type);  \
                 break;                                                          \
             default:                                                            \
                 ret = PMIX_ERR_NOT_FOUND;                                       \
         }                                                                       \
     } while (0)
 
+#define PMIX_BFROPS_PACK_TYPE(r, b, s, n, t, arr)                           \
+    do {                                                                    \
+        pmix_bfrop_type_info_t *__info;                                     \
+        /* Lookup the pack function for this type and call it */            \
+        __info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item((arr),\
+                                                                      (t)); \
+        if (NULL == __info) {                                               \
+            (r) = PMIX_ERR_UNKNOWN_DATA_TYPE;                               \
+        } else {                                                            \
+            (r) = __info->odti_pack_fn(arr, b, s, n, t);                 \
+        }                                                                   \
+    } while(0)
+
+#define PMIX_BFROPS_UNPACK_TYPE(r, b, d, n, t, arr)                         \
+    do {                                                                    \
+        pmix_bfrop_type_info_t *__info;                                     \
+        /* Lookup the unpack function for this type and call it */          \
+        __info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item((arr),\
+                                                                      (t)); \
+        if (NULL == __info) {                                               \
+            (r) = PMIX_ERR_UNKNOWN_DATA_TYPE;                               \
+        } else {                                                            \
+            (r) = __info->odti_unpack_fn(arr, b, d, n, t);                  \
+        }                                                                   \
+    } while(0)
+
 /* NOTE: do not need to deal with endianness here, as the unpacking of
    the underling sender-side type will do that for us.  Repeat: the
    data in tmpbuf[] is already in host byte order. */
-#define PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(unpack_type, tmptype, tmpbfroptype)      \
+#define PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, tmptype, tmpbfroptype)    \
     do {                                                                    \
         int32_t i;                                                          \
         tmptype *tmpbuf = (tmptype*)malloc(sizeof(tmptype) * (*num_vals));  \
-        ret = unpack_gentype(buffer, tmpbuf, num_vals, tmpbfroptype);       \
+        ret = unpack_gentype(reg_types, buffer, tmpbuf, num_vals, tmpbfroptype);       \
         for (i = 0 ; i < *num_vals ; ++i) {                                 \
             ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);            \
         }                                                                   \
@@ -211,6 +239,16 @@ typedef struct pmix_info_array {
     pmix_info_t *array;
 } pmix_info_array_t;
 
+typedef pmix_status_t (*pmix_bfrop_internal_pack_fn_t)(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer,
+                                                       const void *src,
+                                                       int32_t num_values,
+                                                       pmix_data_type_t type);
+
+typedef pmix_status_t (*pmix_bfrop_internal_unpack_fn_t)(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
+                                                         int32_t *max_num_values,
+                                                         pmix_data_type_t type);
 
 /**
  * Internal struct used for holding registered bfrop functions
@@ -222,9 +260,9 @@ typedef struct pmix_info_array {
     /** Debugging string name */
     char *odti_name;
     /** Pack function */
-    pmix_bfrop_pack_fn_t odti_pack_fn;
+    pmix_bfrop_internal_pack_fn_t odti_pack_fn;
     /** Unpack function */
-    pmix_bfrop_unpack_fn_t odti_unpack_fn;
+    pmix_bfrop_internal_unpack_fn_t odti_unpack_fn;
     /** copy function */
     pmix_bfrop_copy_fn_t odti_copy_fn;
     /** prpmix_status_t function */
@@ -240,8 +278,8 @@ PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_bfrop_type_info_t);
     _info = PMIX_NEW(pmix_bfrop_type_info_t);                       \
     _info->odti_name = strdup((n));                                 \
     _info->odti_type = (t);                                         \
-    _info->odti_pack_fn = (pmix_bfrop_pack_fn_t)(p);                \
-    _info->odti_unpack_fn = (pmix_bfrop_unpack_fn_t)(u);            \
+    _info->odti_pack_fn = (pmix_bfrop_internal_pack_fn_t)(p);           \
+    _info->odti_unpack_fn = (pmix_bfrop_internal_unpack_fn_t)(u);       \
     _info->odti_copy_fn = (pmix_bfrop_copy_fn_t)(c) ;               \
     _info->odti_print_fn = (pmix_bfrop_print_fn_t)(pr) ;            \
     pmix_pointer_array_set_item((arr), (t), _info);                 \
@@ -306,88 +344,128 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_buffer(pmix_pointer_array_t *reg
                                                        const void *src, int32_t num_vals,
                                                        pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_bool(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_bool(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_sizet(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_byte(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_byte(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_string(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_string(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pid(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pid(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int16(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int16(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int32(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int32(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int64(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_int64(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_string(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_string(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_float(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_float(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_double(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_double(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_timeval(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_timeval(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, const void *src,
                                                         int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_time(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_time(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_status(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_status(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_buf(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_buf(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_bo(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_bo(pmix_pointer_array_t *regtypes,
+                                                   pmix_buffer_t *buffer, const void *src,
                                                    int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_proc(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_proc(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_value(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_value(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_info(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_info(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pdata(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pdata(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_app(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_app(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_kval(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_kval(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_array(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_array(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_modex(pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_persist(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_persist(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, const void *src,
                                                         int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_datatype(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_datatype(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, const void *src,
                                                          int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_ptr(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_ptr(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_scope(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_scope(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_range(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_range(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_cmd(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_cmd(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_info_directives(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_info_directives(pmix_pointer_array_t *regtypes,
+                                                                pmix_buffer_t *buffer, const void *src,
                                                                 int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pstate(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pstate(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_darray(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, const void *src,
                                                        int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_rank(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_rank(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, const void *src,
                                                      int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_query(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_query(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_val(pmix_buffer_t *buffer,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_val(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer,
                                                     pmix_value_t *p);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                                pmix_buffer_t *buffer, const void *src,
                                                                 int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
+                                                            pmix_buffer_t *buffer, const void *src,
                                                             int32_t num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_envar(pmix_buffer_t *buffer, const void *src,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_pack_envar(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, const void *src,
                                                       int32_t num_vals, pmix_data_type_t type);
 
 /*
@@ -398,90 +476,131 @@ PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes
                                                   void *dst, int32_t *num_vals,
                                                   pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_bool(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_bool(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_byte(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_byte(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_string(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_string(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pid(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pid(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int16(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int16(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int32(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int32(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                                           pmix_buffer_t *buffer, void *dest,
                                                            int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int64(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_int64(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_float(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_float(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_double(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_double(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                                          pmix_buffer_t *buffer, void *dest,
                                                           int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_time(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_time(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_status(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_status(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_val(pmix_buffer_t *buffer,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer,
                                                       pmix_value_t *val);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_value(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_value(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_info(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_info(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_buf(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_buf(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_proc(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_proc(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_kval(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_kval(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_modex(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_modex(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_persist(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_persist(pmix_pointer_array_t *regtypes,
+                                                          pmix_buffer_t *buffer, void *dest,
                                                           int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_bo(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_bo(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, void *dest,
                                                      int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_ptr(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_scope(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_scope(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_range(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_range(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_cmd(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_info_directives(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_info_directives(pmix_pointer_array_t *regtypes,
+                                                                  pmix_buffer_t *buffer, void *dest,
                                                                   int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                                           pmix_buffer_t *buffer, void *dest,
                                                            int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pstate(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pstate(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes,
+                                                         pmix_buffer_t *buffer, void *dest,
                                                          int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_rank(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_rank(pmix_pointer_array_t *regtypes,
+                                                       pmix_buffer_t *buffer, void *dest,
                                                        int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_query(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                                  pmix_buffer_t *buffer, void *dest,
                                                                   int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
+                                                              pmix_buffer_t *buffer, void *dest,
                                                               int32_t *num_vals, pmix_data_type_t type);
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_envar(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_envar(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
 /**** DEPRECATED ****/
-PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_buffer_t *buffer, void *dest,
+PMIX_EXPORT pmix_status_t pmix_bfrops_base_unpack_array(pmix_pointer_array_t *regtypes,
+                                                        pmix_buffer_t *buffer, void *dest,
                                                         int32_t *num_vals, pmix_data_type_t type);
 
 /*
@@ -655,9 +774,11 @@ PMIX_EXPORT char* pmix_bfrop_buffer_extend(pmix_buffer_t *bptr, size_t bytes_to_
 
 PMIX_EXPORT bool pmix_bfrop_too_small(pmix_buffer_t *buffer, size_t bytes_reqd);
 
-PMIX_EXPORT pmix_status_t pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
+PMIX_EXPORT pmix_status_t pmix_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                                     pmix_buffer_t *buffer, pmix_data_type_t type);
 
-PMIX_EXPORT pmix_status_t pmix_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type);
+PMIX_EXPORT pmix_status_t pmix_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                                   pmix_buffer_t *buffer, pmix_data_type_t *type);
 
 PMIX_EXPORT pmix_status_t pmix_bfrops_base_copy_payload(pmix_buffer_t *dest,
                                                         pmix_buffer_t *src);

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -226,7 +226,7 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
     do {                                                                    \
         int32_t i;                                                          \
         tmptype *tmpbuf = (tmptype*)malloc(sizeof(tmptype) * (*num_vals));  \
-        ret = unpack_gentype(reg_types, buffer, tmpbuf, num_vals, tmpbfroptype);       \
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmpbuf, num_vals, tmpbfroptype, reg_types);        \
         for (i = 0 ; i < *num_vals ; ++i) {                                 \
             ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);            \
         }                                                                   \

--- a/src/mca/bfrops/base/base.h
+++ b/src/mca/bfrops/base/base.h
@@ -225,7 +225,7 @@ PMIX_EXPORT extern pmix_bfrops_globals_t pmix_bfrops_globals;
 #define PMIX_BFROP_UNPACK_SIZE_MISMATCH_FOUND(reg_types, unpack_type, tmptype, tmpbfroptype)    \
     do {                                                                    \
         int32_t i;                                                          \
-        tmptype *tmpbuf = (tmptype*)malloc(sizeof(tmptype) * (*num_vals));  \
+        tmptype *tmpbuf = (tmptype*)calloc(*num_vals, sizeof(tmptype));     \
         PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmpbuf, num_vals, tmpbfroptype, reg_types);        \
         for (i = 0 ; i < *num_vals ; ++i) {                                 \
             ((unpack_type*) dest)[i] = (unpack_type)(tmpbuf[i]);            \

--- a/src/mca/bfrops/base/bfrop_base_fns.c
+++ b/src/mca/bfrops/base/bfrop_base_fns.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -727,39 +729,23 @@ bool pmix_bfrop_too_small(pmix_buffer_t *buffer, size_t bytes_reqd)
     return false;
 }
 
-pmix_status_t pmix_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
+pmix_status_t pmix_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, pmix_data_type_t type)
 {
-    uint16_t tmp;
-    char *dst;
+    pmix_status_t ret;
 
-    /* check to see if buffer needs extending */
-     if (NULL == (dst = pmix_bfrop_buffer_extend(buffer, sizeof(tmp)))) {
-        return PMIX_ERR_OUT_OF_RESOURCE;
-    }
-    tmp = pmix_htons(type);
-    memcpy(dst, &tmp, sizeof(tmp));
-    buffer->pack_ptr += sizeof(tmp);
-    buffer->bytes_used += sizeof(tmp);
-
-    return PMIX_SUCCESS;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, &type, 1, PMIX_UINT16, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
+pmix_status_t pmix_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, pmix_data_type_t *type)
 {
-    uint16_t tmp;
+    pmix_status_t ret;
+    int32_t m = 1;
 
-    /* check to see if there's enough data in buffer */
-    if (pmix_bfrop_too_small(buffer, sizeof(tmp))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
-    /* unpack the data */
-    memcpy(&tmp, buffer->unpack_ptr, sizeof(tmp));
-    tmp = pmix_ntohs(tmp);
-    memcpy(type, &tmp, sizeof(tmp));
-    buffer->unpack_ptr += sizeof(tmp);
-
-    return PMIX_SUCCESS;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, type, &m, PMIX_UINT16, regtypes);
+    return ret;
 }
 
 const char* pmix_bfrops_base_data_type_string(pmix_pointer_array_t *regtypes,

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -85,29 +85,6 @@ pmix_status_t pmix_bfrops_base_pack_buffer(pmix_pointer_array_t *regtypes,
     return rc;
 }
 
-static pmix_status_t pack_gentype(pmix_pointer_array_t *regtypes,
-                                  pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
-{
-    pmix_status_t ret;
-
-    switch(type) {
-        case PMIX_INT8:
-        case PMIX_UINT8:
-        case PMIX_INT16:
-        case PMIX_UINT16:
-        case PMIX_INT32:
-        case PMIX_UINT32:
-        case PMIX_INT64:
-        case PMIX_UINT64:
-            PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, type, regtypes);
-            return ret;
-
-        default:
-        return PMIX_ERR_UNKNOWN_DATA_TYPE;
-    }
-}
-
 /* PACK FUNCTIONS FOR GENERIC SYSTEM TYPES */
 
 /*
@@ -161,7 +138,8 @@ pmix_status_t pmix_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
     }
 
     /* Turn around and pack the real type */
-    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_INT);
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, BFROP_TYPE_INT, regtypes);
+    return ret;
 }
 
 /*
@@ -179,7 +157,8 @@ pmix_status_t pmix_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
         return ret;
     }
 
-    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_SIZE_T);
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, BFROP_TYPE_SIZE_T, regtypes);
+    return ret;
 }
 
 /*
@@ -198,9 +177,9 @@ pmix_status_t pmix_bfrops_base_pack_pid(pmix_pointer_array_t *regtypes,
     }
 
     /* Turn around and pack the real type */
-    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_PID_T);
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, BFROP_TYPE_PID_T, regtypes);
+    return ret;
 }
-
 
 /*
  * BYTE, CHAR, INT8

--- a/src/mca/bfrops/base/bfrop_base_pack.c
+++ b/src/mca/bfrops/base/bfrop_base_pack.c
@@ -10,6 +10,8 @@
  * Copyright (c) 2004-2005 The Regents of the University of California.
  *                         All rights reserved.
  * Copyright (c) 2015-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -49,14 +51,14 @@ pmix_status_t pmix_bfrops_base_pack(pmix_pointer_array_t *regtypes,
 
      /* Pack the number of values */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix_bfrop_store_data_type(buffer, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop_store_data_type(regtypes, buffer, PMIX_INT32))) {
             return rc;
         }
     }
-    if (PMIX_SUCCESS != (rc = pmix_bfrops_base_pack_int32(buffer, &num_vals, 1, PMIX_INT32))) {
+    PMIX_BFROPS_PACK_TYPE(rc, buffer, &num_vals, 1, PMIX_INT32, regtypes);
+    if (PMIX_SUCCESS != rc) {
         return rc;
     }
-
     /* Pack the value(s) */
     return pmix_bfrops_base_pack_buffer(regtypes, buffer, src, num_vals, type);
 }
@@ -68,7 +70,6 @@ pmix_status_t pmix_bfrops_base_pack_buffer(pmix_pointer_array_t *regtypes,
                                            pmix_data_type_t type)
 {
     pmix_status_t rc;
-    pmix_bfrop_type_info_t *info;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_pack_buffer( %p, %p, %lu, %d )\n",
@@ -76,43 +77,31 @@ pmix_status_t pmix_bfrops_base_pack_buffer(pmix_pointer_array_t *regtypes,
 
     /* Pack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix_bfrop_store_data_type(buffer, type))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop_store_data_type(regtypes, buffer, type))) {
             return rc;
         }
     }
-
-    /* Lookup the pack function for this type and call it */
-    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(regtypes, type))) {
-        PMIX_ERROR_LOG(PMIX_ERR_UNKNOWN_DATA_TYPE);
-        return PMIX_ERR_UNKNOWN_DATA_TYPE;
-    }
-
-    return info->odti_pack_fn(buffer, src, num_vals, type);
+    PMIX_BFROPS_PACK_TYPE(rc, buffer, src, num_vals, type, regtypes);
+    return rc;
 }
 
-static pmix_status_t pack_gentype(pmix_buffer_t *buffer, const void *src,
+static pmix_status_t pack_gentype(pmix_pointer_array_t *regtypes,
+                                  pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type)
 {
+    pmix_status_t ret;
+
     switch(type) {
         case PMIX_INT8:
         case PMIX_UINT8:
-        return pmix_bfrops_base_pack_byte(buffer, src, num_vals, type);
-        break;
-
         case PMIX_INT16:
         case PMIX_UINT16:
-        return pmix_bfrops_base_pack_int16(buffer, src, num_vals, type);
-        break;
-
         case PMIX_INT32:
         case PMIX_UINT32:
-        return pmix_bfrops_base_pack_int32(buffer, src, num_vals, type);
-        break;
-
         case PMIX_INT64:
         case PMIX_UINT64:
-        return pmix_bfrops_base_pack_int64(buffer, src, num_vals, type);
-        break;
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, type, regtypes);
+            return ret;
 
         default:
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
@@ -124,7 +113,8 @@ static pmix_status_t pack_gentype(pmix_buffer_t *buffer, const void *src,
 /*
  * BOOL
  */
- pmix_status_t pmix_bfrops_base_pack_bool(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix_bfrops_base_pack_bool(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
  {
     uint8_t *dst;
@@ -158,61 +148,65 @@ static pmix_status_t pack_gentype(pmix_buffer_t *buffer, const void *src,
 /*
  * INT
  */
-pmix_status_t pmix_bfrops_base_pack_int(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_int(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them */
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, BFROP_TYPE_INT))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pack_gentype(buffer, src, num_vals, BFROP_TYPE_INT);
+    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_INT);
 }
 
 /*
  * SIZE_T
  */
-pmix_status_t pmix_bfrops_base_pack_sizet(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_sizet(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     int ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, BFROP_TYPE_SIZE_T))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
         return ret;
     }
 
-    return pack_gentype(buffer, src, num_vals, BFROP_TYPE_SIZE_T);
+    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_SIZE_T);
 }
 
 /*
  * PID_T
  */
-pmix_status_t pmix_bfrops_base_pack_pid(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_pid(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
     int ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, BFROP_TYPE_PID_T))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_PID_T))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pack_gentype(buffer, src, num_vals, BFROP_TYPE_PID_T);
+    return pack_gentype(regtypes, buffer, src, num_vals, BFROP_TYPE_PID_T);
 }
 
 
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix_bfrops_base_pack_byte(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_byte(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
     char *dst;
@@ -238,7 +232,8 @@ pmix_status_t pmix_bfrops_base_pack_byte(pmix_buffer_t *buffer, const void *src,
 /*
  * INT16
  */
-pmix_status_t pmix_bfrops_base_pack_int16(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_int16(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -267,7 +262,8 @@ pmix_status_t pmix_bfrops_base_pack_int16(pmix_buffer_t *buffer, const void *src
 /*
  * INT32
  */
-pmix_status_t pmix_bfrops_base_pack_int32(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_int32(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -295,7 +291,8 @@ pmix_status_t pmix_bfrops_base_pack_int32(pmix_buffer_t *buffer, const void *src
 /*
  * INT64
  */
-pmix_status_t pmix_bfrops_base_pack_int64(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_int64(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -326,7 +323,8 @@ pmix_status_t pmix_bfrops_base_pack_int64(pmix_buffer_t *buffer, const void *src
 /*
  * STRING
  */
-pmix_status_t pmix_bfrops_base_pack_string(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_string(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
                                            int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -336,24 +334,28 @@ pmix_status_t pmix_bfrops_base_pack_string(pmix_buffer_t *buffer, const void *sr
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) {  /* got zero-length string/NULL pointer - store NULL */
             len = 0;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &len, 1, PMIX_INT32, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         } else {
             len = (int32_t)strlen(ssrc[i]) + 1;  // retain the NULL terminator
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &len, 1, PMIX_INT32, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, ssrc[i], len, PMIX_BYTE))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, ssrc[i], len, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
     }
-return ret;
+    return ret;
 }
 
 /* FLOAT */
-pmix_status_t pmix_bfrops_base_pack_float(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_float(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -366,18 +368,19 @@ pmix_status_t pmix_bfrops_base_pack_float(pmix_buffer_t *buffer, const void *src
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &convert, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             free(convert);
             return ret;
         }
         free(convert);
     }
-
     return PMIX_SUCCESS;
 }
 
 /* DOUBLE */
-pmix_status_t pmix_bfrops_base_pack_double(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_double(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
                                            int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -390,18 +393,19 @@ pmix_status_t pmix_bfrops_base_pack_double(pmix_buffer_t *buffer, const void *sr
         if (0 > ret) {
             return PMIX_ERR_OUT_OF_RESOURCE;
         }
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &convert, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             free(convert);
             return ret;
         }
         free(convert);
     }
-
     return PMIX_SUCCESS;
 }
 
 /* TIMEVAL */
-pmix_status_t pmix_bfrops_base_pack_timeval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_timeval(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, const void *src,
                                             int32_t num_vals, pmix_data_type_t type)
 {
     int64_t tmp[2];
@@ -412,16 +416,17 @@ pmix_status_t pmix_bfrops_base_pack_timeval(pmix_buffer_t *buffer, const void *s
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t)ssrc[i].tv_sec;
         tmp[1] = (int64_t)ssrc[i].tv_usec;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, tmp, 2, PMIX_INT64))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, tmp, 2, PMIX_INT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
-
     return PMIX_SUCCESS;
 }
 
 /* TIME */
-pmix_status_t pmix_bfrops_base_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_time(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -434,16 +439,17 @@ pmix_status_t pmix_bfrops_base_pack_time(pmix_buffer_t *buffer, const void *src,
      */
      for (i = 0; i < num_vals; ++i) {
         ui64 = (uint64_t)ssrc[i];
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, &ui64, 1, PMIX_UINT64))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ui64, 1, PMIX_UINT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
-
     return PMIX_SUCCESS;
 }
 
 /* STATUS */
-pmix_status_t pmix_bfrops_base_pack_status(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_status(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
                                            int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
@@ -453,16 +459,17 @@ pmix_status_t pmix_bfrops_base_pack_status(pmix_buffer_t *buffer, const void *sr
 
     for (i = 0; i < num_vals; ++i) {
         status = (int32_t)ssrc[i];
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &status, 1, PMIX_INT32))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &status, 1, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
     }
-
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_buf(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_buf(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
@@ -473,16 +480,22 @@ pmix_status_t pmix_bfrops_base_pack_buf(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the type of buffer */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, &ptr[i].type, 1, PMIX_BYTE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].type, 1,
+                              PMIX_BYTE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the number of bytes */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].bytes_used, 1, PMIX_SIZE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].bytes_used, 1,
+                              PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the bytes */
         if (0 < ptr[i].bytes_used) {
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, ptr[i].base_ptr, ptr[i].bytes_used, PMIX_BYTE))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].base_ptr,
+                                  ptr[i].bytes_used, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -490,7 +503,8 @@ pmix_status_t pmix_bfrops_base_pack_buf(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_bo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_bo(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                        int32_t num_vals, pmix_data_type_t type)
 {
     int ret;
@@ -499,11 +513,14 @@ pmix_status_t pmix_bfrops_base_pack_bo(pmix_buffer_t *buffer, const void *src,
 
     bo = (pmix_byte_object_t*)src;
     for (i=0; i < num_vals; i++) {
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &bo[i].size, 1, PMIX_SIZE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &bo[i].size, 1, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < bo[i].size) {
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, bo[i].bytes, bo[i].size,
+                                  PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -511,7 +528,8 @@ pmix_status_t pmix_bfrops_base_pack_bo(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_proc(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_proc(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *proc;
@@ -522,10 +540,13 @@ pmix_status_t pmix_bfrops_base_pack_proc(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         char *ptr = proc[i].nspace;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &ptr, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_rank(buffer, &proc[i].rank, 1, PMIX_PROC_RANK))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &proc[i].rank, 1,
+                              PMIX_PROC_RANK, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
@@ -534,7 +555,8 @@ pmix_status_t pmix_bfrops_base_pack_proc(pmix_buffer_t *buffer, const void *src,
 
 
 /* PMIX_VALUE */
-pmix_status_t pmix_bfrops_base_pack_value(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_value(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
@@ -545,20 +567,20 @@ pmix_status_t pmix_bfrops_base_pack_value(pmix_buffer_t *buffer, const void *src
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, ptr[i].type))) {
             return ret;
         }
         /* now pack the right field */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(buffer, &ptr[i]))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(regtypes, buffer, &ptr[i]))) {
             return ret;
         }
     }
-
     return PMIX_SUCCESS;
 }
 
 
-pmix_status_t pmix_bfrops_base_pack_info(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_info(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_t *info;
@@ -571,26 +593,30 @@ pmix_status_t pmix_bfrops_base_pack_info(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         /* pack key */
         foo = info[i].key;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &foo, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack info directives */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info_directives(buffer, &info[i].flags, 1, PMIX_INFO_DIRECTIVES))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &info[i].flags, 1,
+                              PMIX_INFO_DIRECTIVES, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, info[i].value.type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, info[i].value.type))) {
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(buffer, &info[i].value))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(regtypes, buffer, &info[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_pdata(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_pdata(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *pdata;
@@ -602,22 +628,25 @@ pmix_status_t pmix_bfrops_base_pack_pdata(pmix_buffer_t *buffer, const void *src
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the proc */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_proc(buffer, &pdata[i].proc, 1, PMIX_PROC))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pdata[i].proc, 1,
+                              PMIX_PROC, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack key */
         foo = pdata[i].key;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &foo, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, pdata[i].value.type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer, pdata[i].value.type))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(buffer, &pdata[i].value))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_val(regtypes, buffer, &pdata[i].value))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -625,7 +654,8 @@ pmix_status_t pmix_bfrops_base_pack_pdata(pmix_buffer_t *buffer, const void *src
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_app(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_app(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
     pmix_app_t *app;
@@ -635,43 +665,55 @@ pmix_status_t pmix_bfrops_base_pack_app(pmix_buffer_t *buffer, const void *src,
     app = (pmix_app_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &app[i].cmd, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].cmd, 1, PMIX_STRING,
+                              regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* argv */
         nvals = pmix_argv_count(app[i].argv);
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, &nvals, 1, PMIX_INT32))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &nvals, 1, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         for (j=0; j < nvals; j++) {
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &app[i].argv[j], 1, PMIX_STRING))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].argv[j], 1, PMIX_STRING,
+                                  regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
         /* env */
         nvals = pmix_argv_count(app[i].env);
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &nvals, 1, PMIX_INT32))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &nvals, 1, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         for (j=0; j < nvals; j++) {
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &app[i].env[j], 1, PMIX_STRING))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].env[j], 1,
+                                  PMIX_STRING, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
         /* cwd */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &app[i].cwd, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].cwd, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* maxprocs */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, &app[i].maxprocs, 1, PMIX_INT))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].maxprocs, 1, PMIX_INT, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* info array */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &app[i].ninfo, 1, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < app[i].ninfo) {
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, app[i].info, app[i].ninfo, PMIX_INFO, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -680,7 +722,8 @@ pmix_status_t pmix_bfrops_base_pack_app(pmix_buffer_t *buffer, const void *src,
 }
 
 
-pmix_status_t pmix_bfrops_base_pack_kval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_kval(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
@@ -691,316 +734,178 @@ pmix_status_t pmix_bfrops_base_pack_kval(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the key */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &ptr[i].key, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].key, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the value */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_value(buffer, ptr[i].value, 1, PMIX_VALUE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, ptr[i].value, 1, PMIX_VALUE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
-
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_persist(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_persist(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, const void *src,
                                             int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_BYTE, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_datatype(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_datatype(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, const void *src,
                                              int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_int16(buffer, src, num_vals, type);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
+    return ret;
 }
 
 
-pmix_status_t pmix_bfrops_base_pack_ptr(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_ptr(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
+    pmix_status_t ret;
     uint8_t foo=1;
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just pack a sentinel */
-    return pmix_bfrops_base_pack_byte(buffer, &foo, 1, PMIX_UINT8);
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, &foo, 1, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_scope(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_scope(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_range(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_range(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_cmd(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_cmd(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                         int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_info_directives(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_info_directives(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_int32(buffer, src, num_vals, PMIX_UINT32);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT32, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_pstate(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_pstate(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
                                            int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_pinfo(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
-    pmix_proc_info_t *pinfo = (pmix_proc_info_t*)src;
+    pmix_proc_info_t *pinfo = (pmix_proc_info_t *) src;
     pmix_status_t ret;
     int32_t i;
 
     for (i=0; i < num_vals; i++) {
         /* pack the proc identifier */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_proc(buffer, &pinfo[i].proc, 1, PMIX_PROC))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].proc, 1, PMIX_PROC, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the hostname and exec */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &pinfo[i].hostname, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].hostname, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &pinfo[i].executable_name, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].executable_name, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the pid and state */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pid(buffer, &pinfo[i].pid, 1, PMIX_PID))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].pid, 1, PMIX_PID, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pstate(buffer, &pinfo[i].state, 1, PMIX_PROC_STATE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pinfo[i].state, 1, PMIX_PROC_STATE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_darray(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_darray(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
                                            int32_t num_vals, pmix_data_type_t type)
 {
-    pmix_data_array_t *p = (pmix_data_array_t*)src;
+    pmix_data_array_t *p = (pmix_data_array_t *) src;
     pmix_status_t ret;
     int32_t i;
 
     for (i=0; i < num_vals; i++) {
         /* pack the actual type in the array */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(buffer, p[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_store_data_type(regtypes, buffer,
+                                                              p[i].type))) {
             return ret;
         }
         /* pack the number of array elements */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &p[i].size, 1, PMIX_SIZE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &p[i].size, 1, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 == p[i].size || PMIX_UNDEF == p[i].type) {
             /* nothing left to do */
             continue;
         }
-        /* pack the actual elements - have to do this the hard way */
-        switch(p[i].type) {
-            case PMIX_UNDEF:
-                break;
-            case PMIX_BOOL:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_bool(buffer, p[i].array, p[i].size, PMIX_BOOL))) {
-                    return ret;
-                }
-                break;
-            case PMIX_BYTE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, p[i].array, p[i].size, PMIX_BYTE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_STRING:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, p[i].array, p[i].size, PMIX_STRING))) {
-                    return ret;
-                }
-                break;
-            case PMIX_SIZE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, p[i].array, p[i].size, PMIX_SIZE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PID:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pid(buffer, p[i].array, p[i].size, PMIX_PID))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, p[i].array, p[i].size, PMIX_INT))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT8:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, p[i].array, p[i].size, PMIX_INT8))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT16:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int16(buffer, p[i].array, p[i].size, PMIX_INT16))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT32:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, p[i].array, p[i].size, PMIX_INT32))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT64:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, p[i].array, p[i].size, PMIX_INT64))) {
-                    return ret;
-                }
-                break;
-            case PMIX_UINT:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, p[i].array, p[i].size, PMIX_UINT))) {
-                    return ret;
-                }
-                break;
-            case PMIX_UINT8:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, p[i].array, p[i].size, PMIX_UINT8))) {
-                    return ret;
-                }
-                break;
-            case PMIX_UINT16:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int16(buffer, p[i].array, p[i].size, PMIX_UINT16))) {
-                    return ret;
-                }
-                break;
-            case PMIX_UINT32:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, p[i].array, p[i].size, PMIX_UINT32))) {
-                    return ret;
-                }
-                break;
-            case PMIX_UINT64:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, p[i].array, p[i].size, PMIX_UINT64))) {
-                    return ret;
-                }
-                break;
-            case PMIX_FLOAT:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_float(buffer, p[i].array, p[i].size, PMIX_FLOAT))) {
-                    return ret;
-                }
-                break;
-            case PMIX_DOUBLE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_double(buffer, p[i].array, p[i].size, PMIX_DOUBLE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_TIMEVAL:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_timeval(buffer, p[i].array, p[i].size, PMIX_TIMEVAL))) {
-                    return ret;
-                }
-                break;
-            case PMIX_TIME:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_time(buffer, p[i].array, p[i].size, PMIX_TIME))) {
-                    return ret;
-                }
-                break;
-            case PMIX_STATUS:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_status(buffer, p[i].array, p[i].size, PMIX_STATUS))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INFO:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, p[i].array, p[i].size, PMIX_INFO))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_proc(buffer, p[i].array, p[i].size, PMIX_PROC))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC_RANK:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_rank(buffer, p[i].array, p[i].size, PMIX_PROC_RANK))) {
-                    return ret;
-                }
-                break;
-            case PMIX_BYTE_OBJECT:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_bo(buffer, p[i].array, p[i].size, PMIX_BYTE_OBJECT))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PERSIST:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_persist(buffer, p[i].array, p[i].size, PMIX_PERSIST))) {
-                    return ret;
-                }
-                break;
-            case PMIX_POINTER:
-                 if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_ptr(buffer, p[i].array, p[i].size, PMIX_POINTER))) {
-                     return ret;
-                 }
-                 break;
-            case PMIX_SCOPE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_scope(buffer, p[i].array, p[i].size, PMIX_SCOPE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_DATA_RANGE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_range(buffer, p[i].array, p[i].size, PMIX_DATA_RANGE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC_STATE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pstate(buffer, p[i].array, p[i].size, PMIX_PROC_STATE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC_INFO:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pinfo(buffer, p[i].array, p[i].size, PMIX_PROC_INFO))) {
-                    return ret;
-                }
-                break;
-            case PMIX_DATA_ARRAY:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_darray(buffer, p[i].array, p[i].size, PMIX_DATA_ARRAY))) {
-                    return ret;
-                }
-                break;
-            case PMIX_QUERY:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_query(buffer, p[i].array, p[i].size, PMIX_QUERY))) {
-                    return ret;
-                }
-                break;
-            case PMIX_VALUE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_value(buffer, p[i].array, p[i].size, PMIX_QUERY))) {
-                    return ret;
-                }
-                break;
-            case PMIX_ALLOC_DIRECTIVE:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_alloc_directive(buffer, p[i].array, p[i].size, PMIX_ALLOC_DIRECTIVE))) {
-                    return ret;
-                }
-                break;
-            case PMIX_ENVAR:
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_envar(buffer, p[i].array, p[i].size, PMIX_ENVAR))) {
-                    return ret;
-                }
-                break;
-
-            default:
-                pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
-                            __FILE__, __LINE__, (int)p[i].type);
-            return PMIX_ERROR;
+        /* pack the actual elements */
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, p[i].array, p[i].size, p[i].type, regtypes);
+        if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
+            pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
+                        __FILE__, __LINE__, (int)p[i].type);
+        }
+        if (PMIX_SUCCESS != ret) {
+            return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_rank(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_rank(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_int32(buffer, src, num_vals, PMIX_UINT32);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT32, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_query(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_query(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_query_t *pq = (pmix_query_t*)src;
@@ -1011,24 +916,29 @@ pmix_status_t pmix_bfrops_base_pack_query(pmix_buffer_t *buffer, const void *src
     for (i=0; i < num_vals; i++) {
         /* pack the number of keys */
         nkeys = pmix_argv_count(pq[i].keys);
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &nkeys, 1, PMIX_INT32))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &nkeys, 1, PMIX_UINT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < nkeys) {
             /* pack the keys */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, pq[i].keys, nkeys, PMIX_STRING))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, pq[i].keys, nkeys, PMIX_STRING, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
         /* pack the number of qualifiers */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &pq[i].nqual, 1, PMIX_SIZE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &pq[i].nqual, 1, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < pq[i].nqual) {
             /* pack any provided qualifiers */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, pq[i].qualifiers, pq[i].nqual, PMIX_INFO))) {
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, pq[i].qualifiers, pq[i].nqual, PMIX_INFO, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
+
         }
     }
     return PMIX_SUCCESS;
@@ -1037,7 +947,8 @@ pmix_status_t pmix_bfrops_base_pack_query(pmix_buffer_t *buffer, const void *src
 
 /********************/
 /* PACK FUNCTIONS FOR VALUE TYPES */
-pmix_status_t pmix_bfrops_base_pack_val(pmix_buffer_t *buffer,
+pmix_status_t pmix_bfrops_base_pack_val(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer,
                                         pmix_value_t *p)
 {
     pmix_status_t ret;
@@ -1045,189 +956,47 @@ pmix_status_t pmix_bfrops_base_pack_val(pmix_buffer_t *buffer,
     switch (p->type) {
         case PMIX_UNDEF:
             break;
-        case PMIX_BOOL:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_bool(buffer, &p->data.flag, 1, PMIX_BOOL))) {
-                return ret;
-            }
-            break;
-        case PMIX_BYTE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, &p->data.byte, 1, PMIX_BYTE))) {
-                return ret;
-            }
-            break;
-        case PMIX_STRING:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &p->data.string, 1, PMIX_STRING))) {
-                return ret;
-            }
-            break;
-        case PMIX_SIZE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &p->data.size, 1, PMIX_SIZE))) {
-                return ret;
-            }
-            break;
-        case PMIX_PID:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pid(buffer, &p->data.pid, 1, PMIX_PID))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, &p->data.integer, 1, PMIX_INT))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT8:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, &p->data.int8, 1, PMIX_INT8))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT16:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int16(buffer, &p->data.int16, 1, PMIX_INT16))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT32:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &p->data.int32, 1, PMIX_INT32))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT64:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, &p->data.int64, 1, PMIX_INT64))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int(buffer, &p->data.uint, 1, PMIX_UINT))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT8:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, &p->data.uint8, 1, PMIX_UINT8))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT16:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int16(buffer, &p->data.uint16, 1, PMIX_UINT16))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT32:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int32(buffer, &p->data.uint32, 1, PMIX_UINT32))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT64:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_int64(buffer, &p->data.uint64, 1, PMIX_UINT64))) {
-                return ret;
-            }
-            break;
-        case PMIX_FLOAT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_float(buffer, &p->data.fval, 1, PMIX_FLOAT))) {
-                return ret;
-            }
-            break;
-        case PMIX_DOUBLE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_double(buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
-                return ret;
-            }
-            break;
-        case PMIX_TIMEVAL:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_timeval(buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
-                return ret;
-            }
-            break;
-        case PMIX_TIME:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_time(buffer, &p->data.time, 1, PMIX_TIME))) {
-                return ret;
-            }
-            break;
-        case PMIX_STATUS:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_status(buffer, &p->data.status, 1, PMIX_STATUS))) {
-                return ret;
-            }
-            break;
-        case PMIX_PROC:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_proc(buffer, p->data.proc, 1, PMIX_PROC))) {
-                return ret;
-            }
-            break;
-        case PMIX_PROC_RANK:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_rank(buffer, &p->data.rank, 1, PMIX_PROC_RANK))) {
-                return ret;
-            }
-            break;
-        case PMIX_BYTE_OBJECT:
-        case PMIX_COMPRESSED_STRING:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_bo(buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
-                return ret;
-            }
-            break;
-        case PMIX_PERSIST:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_persist(buffer, &p->data.persist, 1, PMIX_PERSIST))) {
-                return ret;
-            }
-            break;
-       case PMIX_POINTER:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_ptr(buffer, &p->data.ptr, 1, PMIX_POINTER))) {
-                return ret;
-            }
-            break;
-        case PMIX_SCOPE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_scope(buffer, &p->data.scope, 1, PMIX_SCOPE))) {
-                return ret;
-            }
-            break;
-        case PMIX_DATA_RANGE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_range(buffer, &p->data.range, 1, PMIX_DATA_RANGE))) {
-                return ret;
-            }
-            break;
-        case PMIX_PROC_STATE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pstate(buffer, &p->data.state, 1, PMIX_PROC_STATE))) {
-                return ret;
-            }
-            break;
         case PMIX_PROC_INFO:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_pinfo(buffer, p->data.pinfo, 1, PMIX_PROC_INFO))) {
-                return ret;
-            }
-            break;
         case PMIX_DATA_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_darray(buffer, p->data.darray, 1, PMIX_DATA_ARRAY))) {
+        case PMIX_PROC:
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, p->data.ptr, 1, p->type, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
             break;
-        case PMIX_ALLOC_DIRECTIVE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_alloc_directive(buffer, &p->data.adir, 1, PMIX_ALLOC_DIRECTIVE))) {
-                return ret;
-            }
-            break;
-        case PMIX_ENVAR:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_envar(buffer, &p->data.envar, 1, PMIX_ENVAR))) {
-                return ret;
-            }
-            break;
-
         default:
-            pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
-                        __FILE__, __LINE__, (int)p->type);
-            return PMIX_ERROR;
+            PMIX_BFROPS_PACK_TYPE(ret, buffer, &p->data, 1, p->type, regtypes);
+            if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
+                pmix_output(0, "PACK-PMIX-VALUE[%s:%d]: UNSUPPORTED TYPE %d",
+                            __FILE__, __LINE__, (int)p->type);
+                return PMIX_ERROR;
+            } else if (PMIX_SUCCESS != ret) {
+                return ret;
+            }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                    pmix_buffer_t *buffer, const void *src,
                                                     int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_iof_channel(pmix_pointer_array_t *regtypes,
+                                                pmix_buffer_t *buffer, const void *src,
                                                 int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_pack_int16(buffer, src, num_vals, PMIX_UINT16);
+    pmix_status_t ret;
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_UINT16, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_pack_envar(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix_bfrops_base_pack_envar(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
                                           int32_t num_vals, pmix_data_type_t type)
 {
     pmix_envar_t *ptr = (pmix_envar_t*)src;
@@ -1236,15 +1005,18 @@ pmix_status_t pmix_bfrops_base_pack_envar(pmix_buffer_t *buffer, const void *src
 
     for (i=0; i < num_vals; ++i) {
         /* pack the name */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &ptr[i].envar, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].envar, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the value */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_string(buffer, &ptr[i].value, 1, PMIX_STRING))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].value, 1, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* pack the separator */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, &ptr[i].separator, 1, PMIX_BYTE))) {
+        PMIX_BFROPS_PACK_TYPE(ret, buffer, &ptr[i].separator, 1, PMIX_BYTE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
  *
@@ -41,7 +41,6 @@ static pmix_status_t pmix_bfrops_base_unpack_buffer(pmix_pointer_array_t *regtyp
 {
     pmix_status_t rc;
     pmix_data_type_t local_type;
-    pmix_bfrop_type_info_t *info;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrops_base_unpack_buffer( %p, %p, %lu, %d )\n",
@@ -49,7 +48,7 @@ static pmix_status_t pmix_bfrops_base_unpack_buffer(pmix_pointer_array_t *regtyp
 
     /** Unpack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -59,14 +58,8 @@ static pmix_status_t pmix_bfrops_base_unpack_buffer(pmix_pointer_array_t *regtyp
             return PMIX_ERR_PACK_MISMATCH;
         }
     }
-
-    /* Lookup the unpack function for this type and call it */
-    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(regtypes, type))) {
-        PMIX_ERROR_LOG(PMIX_ERR_UNPACK_FAILURE);
-        return PMIX_ERR_UNPACK_FAILURE;
-    }
-
-    return info->odti_unpack_fn(buffer, dst, num_vals, type);
+    PMIX_BFROPS_UNPACK_TYPE(rc, buffer, dst, num_vals, type, regtypes);
+    return rc;
 }
 
 pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
@@ -103,7 +96,7 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
      * int32_t as used here.
      */
      if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             *num_vals = 0;
             /* don't error log here as the user may be unpacking past
              * the end of the buffer, which isn't necessarily an error */
@@ -117,7 +110,8 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
     }
 
     n=1;
-    if (PMIX_SUCCESS != (rc = pmix_bfrops_base_unpack_int32(buffer, &local_num, &n, PMIX_INT32))) {
+    PMIX_BFROPS_UNPACK_TYPE(rc, buffer, &local_num, &n, PMIX_INT32, regtypes);
+    if (PMIX_SUCCESS != rc) {
         *num_vals = 0;
             /* don't error log here as the user may be unpacking past
              * the end of the buffer, which isn't necessarily an error */
@@ -152,29 +146,24 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
     return ret;
 }
 
-static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t unpack_gentype(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, void *dest,
                                     int32_t *num_vals, pmix_data_type_t type)
 {
+    pmix_status_t ret;
+
     switch(type) {
         case PMIX_INT8:
         case PMIX_UINT8:
-        return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, type);
-        break;
-
         case PMIX_INT16:
         case PMIX_UINT16:
-        return pmix_bfrops_base_unpack_int16(buffer, dest, num_vals, type);
-        break;
-
         case PMIX_INT32:
         case PMIX_UINT32:
-        return pmix_bfrops_base_unpack_int32(buffer, dest, num_vals, type);
-        break;
-
         case PMIX_INT64:
         case PMIX_UINT64:
-        return pmix_bfrops_base_unpack_int64(buffer, dest, num_vals, type);
-        break;
+
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, type, regtypes);
+        return ret;
 
         default:
         return PMIX_ERR_UNKNOWN_DATA_TYPE;
@@ -186,7 +175,8 @@ static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
 /*
  * BOOL
  */
- pmix_status_t pmix_bfrops_base_unpack_bool(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix_bfrops_base_unpack_bool(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
  {
     int32_t i;
@@ -222,24 +212,25 @@ static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
 /*
  * INT
  */
-pmix_status_t pmix_bfrops_base_unpack_int(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_INT) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(buffer, dest, num_vals, BFROP_TYPE_INT))) {
+        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer, dest, num_vals, BFROP_TYPE_INT))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(int, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, int, remote_type, ret);
     }
 
     return ret;
@@ -248,24 +239,30 @@ pmix_status_t pmix_bfrops_base_unpack_int(pmix_buffer_t *buffer, void *dest,
 /*
  * SIZE_T
  */
-pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer,
+                                                        &remote_type))) {
+        PMIX_ERROR_LOG(ret);
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_SIZE_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
+        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer,
+                                                  dest, num_vals,
+                                                  BFROP_TYPE_SIZE_T))) {
+            PMIX_ERROR_LOG(ret);
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(size_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, size_t, remote_type, ret);
     }
 
     return ret;
@@ -274,24 +271,25 @@ pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_buffer_t *buffer, void *dest,
 /*
  * PID_T
  */
-pmix_status_t pmix_bfrops_base_unpack_pid(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_pid(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_PID_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
+        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(pid_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, pid_t, remote_type, ret);
     }
 
     return ret;
@@ -303,7 +301,8 @@ pmix_status_t pmix_bfrops_base_unpack_pid(pmix_buffer_t *buffer, void *dest,
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix_bfrops_base_unpack_byte(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_byte(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
@@ -323,7 +322,8 @@ pmix_status_t pmix_bfrops_base_unpack_byte(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_int16(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_int16(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -348,7 +348,8 @@ pmix_status_t pmix_bfrops_base_unpack_int16(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_int32(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_int32(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -373,13 +374,18 @@ pmix_status_t pmix_bfrops_base_unpack_int32(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                               pmix_buffer_t *buffer, void *dest,
                                                int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_int16(buffer, dest, num_vals, type);
+    pmix_status_t ret;
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT16, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_int64(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_int64(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
@@ -404,7 +410,8 @@ pmix_status_t pmix_bfrops_base_unpack_int64(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_string(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_string(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
                                              int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
@@ -412,7 +419,8 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_buffer_t *buffer, void *dest,
     char **sdest = (char**) dest;
 
     for (i = 0; i < (*num_vals); ++i) {
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, &len, &n, PMIX_INT32))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer,  &len, &n, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 ==  len) {   /* zero-length string - unpack the NULL */
@@ -422,7 +430,8 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_buffer_t *buffer, void *dest,
             if (NULL == sdest[i]) {
                 return PMIX_ERR_OUT_OF_RESOURCE;
             }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, sdest[i], &len, PMIX_BYTE))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, sdest[i], &len, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -431,7 +440,8 @@ pmix_status_t pmix_bfrops_base_unpack_string(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_float(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_float(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
@@ -442,16 +452,12 @@ pmix_status_t pmix_bfrops_base_unpack_float(pmix_buffer_t *buffer, void *dest,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_float * %d\n", (int)*num_vals);
 
-    /* check to see if there's enough data in buffer */
-    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(float))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &convert, &n, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL != convert) {
@@ -463,7 +469,8 @@ pmix_status_t pmix_bfrops_base_unpack_float(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_double(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_double(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
                                              int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
@@ -474,16 +481,12 @@ pmix_status_t pmix_bfrops_base_unpack_double(pmix_buffer_t *buffer, void *dest,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_double * %d\n", (int)*num_vals);
 
-    /* check to see if there's enough data in buffer */
-    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(double))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &convert, &n, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL != convert) {
@@ -495,7 +498,8 @@ pmix_status_t pmix_bfrops_base_unpack_double(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                              pmix_buffer_t *buffer, void *dest,
                                               int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
@@ -506,15 +510,11 @@ pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack_timeval * %d\n", (int)*num_vals);
 
-    /* check to see if there's enough data in buffer */
-    if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(struct timeval))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=2;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int64(buffer, tmp, &n, PMIX_INT64))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmp, &n, PMIX_INT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         tt.tv_sec = tmp[0];
@@ -524,7 +524,8 @@ pmix_status_t pmix_bfrops_base_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_time(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_time(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
@@ -539,15 +540,11 @@ pmix_status_t pmix_bfrops_base_unpack_time(pmix_buffer_t *buffer, void *dest,
      pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                          "pmix_bfrop_unpack_time * %d\n", (int)*num_vals);
 
-    /* check to see if there's enough data in buffer */
-     if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(uint64_t)))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int64(buffer, &ui64, &n, PMIX_UINT64))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ui64, &n, PMIX_UINT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         tmp = (time_t)ui64;
@@ -557,19 +554,18 @@ pmix_status_t pmix_bfrops_base_unpack_time(pmix_buffer_t *buffer, void *dest,
 }
 
 
-pmix_status_t pmix_bfrops_base_unpack_status(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_status(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
                                              int32_t *num_vals, pmix_data_type_t type)
 {
-     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                          "pmix_bfrop_unpack_status * %d\n", (int)*num_vals);
 
-    /* check to see if there's enough data in buffer */
-    if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(pmix_status_t)))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
-    return pmix_bfrops_base_unpack_int32(buffer, dest, num_vals, PMIX_INT32);
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT32, regtypes);
+    return ret;
 }
 
 
@@ -578,161 +574,24 @@ pmix_status_t pmix_bfrops_base_unpack_status(pmix_buffer_t *buffer, void *dest,
 /*
  * PMIX_VALUE
  */
-pmix_status_t pmix_bfrops_base_unpack_val(pmix_buffer_t *buffer,
+pmix_status_t pmix_bfrops_base_unpack_val(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer,
                                           pmix_value_t *val)
 {
     int m;
-    pmix_status_t ret;
+    pmix_status_t ret = PMIX_SUCCESS;
 
     m = 1;
     switch (val->type) {
         case PMIX_UNDEF:
             break;
-        case PMIX_BOOL:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_bool(buffer, &val->data.flag, &m, PMIX_BOOL))) {
-                return ret;
-            }
-            break;
-        case PMIX_BYTE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &val->data.byte, &m, PMIX_BYTE))) {
-                return ret;
-            }
-            break;
-        case PMIX_STRING:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &val->data.string, &m, PMIX_STRING))) {
-                return ret;
-            }
-            break;
-        case PMIX_SIZE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &val->data.size, &m, PMIX_SIZE))) {
-                return ret;
-            }
-            break;
-        case PMIX_PID:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pid(buffer, &val->data.pid, &m, PMIX_PID))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int(buffer, &val->data.integer, &m, PMIX_INT))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT8:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &val->data.int8, &m, PMIX_INT8))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT16:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int16(buffer, &val->data.int16, &m, PMIX_INT16))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT32:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, &val->data.int32, &m, PMIX_INT32))) {
-                return ret;
-            }
-            break;
-        case PMIX_INT64:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int64(buffer, &val->data.int64, &m, PMIX_INT64))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int(buffer, &val->data.uint, &m, PMIX_UINT))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT8:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &val->data.uint8, &m, PMIX_UINT8))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT16:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int16(buffer, &val->data.uint16, &m, PMIX_UINT16))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT32:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, &val->data.uint32, &m, PMIX_UINT32))) {
-                return ret;
-            }
-            break;
-        case PMIX_UINT64:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int64(buffer, &val->data.uint64, &m, PMIX_UINT64))) {
-                return ret;
-            }
-            break;
-        case PMIX_FLOAT:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_float(buffer, &val->data.fval, &m, PMIX_FLOAT))) {
-                return ret;
-            }
-            break;
-        case PMIX_DOUBLE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_double(buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
-                return ret;
-            }
-            break;
-        case PMIX_TIMEVAL:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_timeval(buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
-                return ret;
-            }
-            break;
-        case PMIX_TIME:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_time(buffer, &val->data.time, &m, PMIX_TIME))) {
-                return ret;
-            }
-            break;
-        case PMIX_STATUS:
-             if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_status(buffer, &val->data.status, &m, PMIX_STATUS))) {
-                 return ret;
-             }
-             break;
         case PMIX_PROC:
             /* this field is now a pointer, so we must allocate storage for it */
             PMIX_PROC_CREATE(val->data.proc, m);
             if (NULL == val->data.proc) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_proc(buffer, val->data.proc, &m, PMIX_PROC))) {
-                return ret;
-            }
-            break;
-        case PMIX_PROC_RANK:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_rank(buffer, &val->data.rank, &m, PMIX_PROC_RANK))) {
-                return ret;
-            }
-            break;
-        case PMIX_BYTE_OBJECT:
-        case PMIX_COMPRESSED_STRING:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_bo(buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
-                return ret;
-            }
-            break;
-        case PMIX_PERSIST:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_persist(buffer, &val->data.proc, &m, PMIX_PERSIST))) {
-                return ret;
-            }
-            break;
-        case PMIX_POINTER:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_ptr(buffer, &val->data.ptr, &m, PMIX_POINTER))) {
-                return ret;
-            }
-            break;
-        case PMIX_SCOPE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_scope(buffer, &val->data.scope, &m, PMIX_SCOPE))) {
-                return ret;
-            }
-            break;
-        case PMIX_DATA_RANGE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_range(buffer, &val->data.range, &m, PMIX_DATA_RANGE))) {
-                return ret;
-            }
-            break;
-        case PMIX_PROC_STATE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pstate(buffer, &val->data.state, &m, PMIX_PROC_STATE))) {
-                return ret;
-            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.proc, &m, PMIX_PROC, regtypes);
             break;
         case PMIX_PROC_INFO:
             /* this is now a pointer, so allocate storage for it */
@@ -740,9 +599,7 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_buffer_t *buffer,
             if (NULL == val->data.pinfo) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pinfo(buffer, val->data.pinfo, &m, PMIX_PROC_INFO))) {
-                return ret;
-            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.pinfo, &m, PMIX_PROC_INFO, regtypes);
             break;
         case PMIX_DATA_ARRAY:
             /* this is now a pointer, so allocate storage for it */
@@ -750,29 +607,20 @@ pmix_status_t pmix_bfrops_base_unpack_val(pmix_buffer_t *buffer,
             if (NULL == val->data.darray) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_darray(buffer, val->data.darray, &m, PMIX_DATA_ARRAY))) {
-                return ret;
-            }
-            break;
-        case PMIX_ALLOC_DIRECTIVE:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_alloc_directive(buffer, &val->data.adir, &m, PMIX_ALLOC_DIRECTIVE))) {
-                return ret;
-            }
-            break;
-        case PMIX_ENVAR:
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_envar(buffer, &val->data.envar, &m, PMIX_ENVAR))) {
-                return ret;
-            }
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, val->data.darray, &m, PMIX_DATA_ARRAY, regtypes);
             break;
         default:
-            pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
-            return PMIX_ERROR;
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &val->data, &m, val->type, regtypes);
+            if (PMIX_ERR_UNKNOWN_DATA_TYPE == ret) {
+                pmix_output(0, "UNPACK-PMIX-VALUE: UNSUPPORTED TYPE %d", (int)val->type);
+            }
     }
 
-    return PMIX_SUCCESS;
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_value(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_value(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
@@ -784,12 +632,12 @@ pmix_status_t pmix_bfrops_base_unpack_value(pmix_buffer_t *buffer, void *dest,
 
     for (i = 0; i < n; ++i) {
         /* unpack the type */
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &ptr[i].type))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
         /* unpack value */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(buffer, &ptr[i])) ) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(regtypes, buffer, &ptr[i])) ) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -797,7 +645,8 @@ pmix_status_t pmix_bfrops_base_unpack_value(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_info(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_info(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_t *ptr;
@@ -817,7 +666,8 @@ pmix_status_t pmix_bfrops_base_unpack_info(pmix_buffer_t *buffer, void *dest,
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &tmp, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -828,26 +678,28 @@ pmix_status_t pmix_bfrops_base_unpack_info(pmix_buffer_t *buffer, void *dest,
         free(tmp);
         /* unpack the directives */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_info_directives(buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
-         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &ptr[i].value.type))) {
+         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &ptr[i].value.type))) {
             return ret;
         }
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix_bfrop_unpack: info type %d", ptr[i].value.type);
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(regtypes, buffer, &ptr[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *ptr;
@@ -865,13 +717,15 @@ pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         PMIX_PDATA_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].proc, &m, PMIX_PROC, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &tmp, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL == tmp) {
@@ -883,14 +737,14 @@ pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         /* unpack value - since the value structure is statically-defined
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
-         if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &ptr[i].value.type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &ptr[i].value.type))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix_bfrop_unpack: pdata type %d %s", ptr[i].value.type, ptr[i].value.data.string);
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_val(regtypes, buffer, &ptr[i].value))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -898,7 +752,8 @@ pmix_status_t pmix_bfrops_base_unpack_pdata(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_buf(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_buf(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
@@ -913,12 +768,14 @@ pmix_status_t pmix_bfrops_base_unpack_buf(pmix_buffer_t *buffer, void *dest,
         PMIX_CONSTRUCT(&ptr[i], pmix_buffer_t);
         /* unpack the type of buffer */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &ptr[i].type, &m, PMIX_BYTE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].type, &m, PMIX_BYTE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &nbytes, &m, PMIX_SIZE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nbytes, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         m = nbytes;
@@ -929,7 +786,8 @@ pmix_status_t pmix_bfrops_base_unpack_buf(pmix_buffer_t *buffer, void *dest,
                 return PMIX_ERR_NOMEM;
             }
             /* unpack the bytes */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].base_ptr, &m, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -941,7 +799,8 @@ pmix_status_t pmix_bfrops_base_unpack_buf(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_proc(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_proc(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *ptr;
@@ -962,8 +821,8 @@ pmix_status_t pmix_bfrops_base_unpack_proc(pmix_buffer_t *buffer, void *dest,
         /* unpack nspace */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
-            PMIX_ERROR_LOG(ret);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &tmp, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL == tmp) {
@@ -974,15 +833,16 @@ pmix_status_t pmix_bfrops_base_unpack_proc(pmix_buffer_t *buffer, void *dest,
         free(tmp);
         /* unpack the rank */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_rank(buffer, &ptr[i].rank, &m, PMIX_PROC_RANK))) {
-            PMIX_ERROR_LOG(ret);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].rank, &m, PMIX_PROC_RANK, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_app_t *ptr;
@@ -1002,19 +862,22 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
         PMIX_APP_CONSTRUCT(&ptr[i]);
         /* unpack cmd */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].cmd, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack argc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int(buffer, &nval, &m, PMIX_INT32))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nval, &m, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack argv */
         for (k=0; k < nval; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &tmp, &m, PMIX_STRING, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -1025,13 +888,15 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack env */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, &nval, &m, PMIX_INT32))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nval, &m, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         for (k=0; k < nval; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &tmp, &m, PMIX_STRING, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -1042,23 +907,27 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack cwd */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].cwd, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].cwd, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack maxprocs */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int(buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].maxprocs, &m, PMIX_INT, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack info array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].ninfo, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < ptr[i].ninfo) {
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
             m = ptr[i].ninfo;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_info(buffer, ptr[i].info, &m, PMIX_INFO))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].info, &m, PMIX_INFO, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -1066,7 +935,8 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_kval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_kval(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
@@ -1083,29 +953,33 @@ pmix_status_t pmix_bfrops_base_unpack_kval(pmix_buffer_t *buffer, void *dest,
         PMIX_CONSTRUCT(&ptr[i], pmix_kval_t);
         /* unpack the key */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].key, &m, PMIX_STRING))) {
-            PMIX_ERROR_LOG(ret);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].key, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* allocate the space */
         ptr[i].value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         /* unpack the value */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].value, &m, PMIX_VALUE))) {
-            PMIX_ERROR_LOG(ret);
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].value, &m, PMIX_VALUE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_persist(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_persist(pmix_pointer_array_t *regtypes,
+                                              pmix_buffer_t *buffer, void *dest,
                                               int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_BYTE, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_bo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_bo(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                          int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_byte_object_t *ptr;
@@ -1122,13 +996,15 @@ pmix_status_t pmix_bfrops_base_unpack_bo(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_byte_object_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].size, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].bytes = (char*)malloc(ptr[i].size * sizeof(char));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].bytes, &m, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -1136,49 +1012,68 @@ pmix_status_t pmix_bfrops_base_unpack_bo(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_ptr(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
     uint8_t foo=1;
     int32_t cnt=1;
+    pmix_status_t ret;
 
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just unpack the sentinel */
-    return pmix_bfrops_base_unpack_byte(buffer, &foo, &cnt, PMIX_UINT8);
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &foo, &cnt, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_scope(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_scope(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_range(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_range(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_cmd(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_info_directives(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_info_directives(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT32, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_pstate(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_pstate(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
                                              int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
 
-pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_info_t *ptr;
@@ -1195,39 +1090,46 @@ pmix_status_t pmix_bfrops_base_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
         PMIX_PROC_INFO_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].proc, &m, PMIX_PROC, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack the hostname */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].hostname, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].hostname, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack the executable */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].executable_name, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].executable_name, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack pid */
-         m=1;
-         if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pid(buffer, &ptr[i].pid, &m, PMIX_PID))) {
+        m=1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].pid, &m, PMIX_PID, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack state */
-         m=1;
-         if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pstate(buffer, &ptr[i].state, &m, PMIX_PROC_STATE))) {
+        m=1;
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].state, &m, PMIX_PROC_STATE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_darray(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
                                              int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_data_array_t *ptr;
     int32_t i, n, m;
     pmix_status_t ret;
+    pmix_data_type_t t;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix_bfrop_unpack: %d data arrays", *num_vals);
@@ -1239,12 +1141,13 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_data_array_t));
         /* unpack the type */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(buffer, &ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrop_get_data_type(regtypes, buffer, &ptr[i].type))) {
             return ret;
         }
         /* unpack the number of array elements */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].size, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 == ptr[i].size || PMIX_UNDEF == ptr[i].type) {
@@ -1253,262 +1156,31 @@ pmix_status_t pmix_bfrops_base_unpack_darray(pmix_buffer_t *buffer, void *dest,
         }
         /* allocate storage for the array and unpack the array elements */
         m = ptr[i].size;
-        switch(ptr[i].type) {
-            case PMIX_BOOL:
-                ptr[i].array = (bool*)malloc(m * sizeof(bool));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_bool(buffer, ptr[i].array, &m, PMIX_BOOL))) {
-                    return ret;
-                }
-                break;
-            case PMIX_BYTE:
-            case PMIX_INT8:
-            case PMIX_UINT8:
-                ptr[i].array = (uint8_t*)malloc(m * sizeof(uint8_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT16:
-            case PMIX_UINT16:
-                ptr[i].array = (uint16_t*)malloc(m * sizeof(uint16_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int16(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT32:
-            case PMIX_UINT32:
-                ptr[i].array = (uint32_t*)malloc(m * sizeof(uint32_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT64:
-            case PMIX_UINT64:
-                ptr[i].array = (uint64_t*)malloc(m * sizeof(uint64_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int64(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_STRING:
-                ptr[i].array = (char**)malloc(m * sizeof(char*));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_SIZE:
-                ptr[i].array = (size_t*)malloc(m * sizeof(size_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PID:
-                ptr[i].array = (pid_t*)malloc(m * sizeof(pid_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pid(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INT:
-            case PMIX_UINT:
-                ptr[i].array = (int*)malloc(m * sizeof(int));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_FLOAT:
-                ptr[i].array = (float*)malloc(m * sizeof(float));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_float(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_DOUBLE:
-                ptr[i].array = (double*)malloc(m * sizeof(double));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_double(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_TIMEVAL:
-                ptr[i].array = (struct timeval *)malloc(m * sizeof(struct timeval));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_timeval(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_TIME:
-                ptr[i].array = (time_t*)malloc(m * sizeof(time_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_time(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_STATUS:
-                ptr[i].array = (pmix_status_t*)malloc(m * sizeof(pmix_status_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_status(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_INFO:
-                ptr[i].array = (pmix_info_t*)malloc(m * sizeof(pmix_info_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_info(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC:
-                ptr[i].array = (pmix_proc_t*)malloc(m * sizeof(pmix_proc_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_proc(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_BYTE_OBJECT:
-            case PMIX_COMPRESSED_STRING:
-                ptr[i].array = (pmix_byte_object_t*)malloc(m * sizeof(pmix_byte_object_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_bo(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PERSIST:
-                ptr[i].array = (pmix_persistence_t*)malloc(m * sizeof(pmix_persistence_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_persist(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_POINTER:
-                ptr[i].array = (char*)malloc(m * sizeof(char*));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_ptr(buffer, ptr[i].array, &m, PMIX_POINTER))) {
-                    return ret;
-                }
-                break;
-            case PMIX_SCOPE:
-                ptr[i].array = (pmix_scope_t*)malloc(m * sizeof(pmix_scope_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_scope(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_DATA_RANGE:
-                ptr[i].array = (pmix_data_range_t*)malloc(m * sizeof(pmix_data_range_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_range(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC_STATE:
-                ptr[i].array = (pmix_proc_state_t*)malloc(m * sizeof(pmix_proc_state_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pstate(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_PROC_INFO:
-                ptr[i].array = (pmix_proc_info_t*)malloc(m * sizeof(pmix_proc_info_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_pinfo(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_QUERY:
-                ptr[i].array = (pmix_query_t*)malloc(m * sizeof(pmix_query_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_query(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_VALUE:
-                ptr[i].array = (pmix_value_t*)malloc(m * sizeof(pmix_value_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            case PMIX_ENVAR:
-                ptr[i].array = (pmix_envar_t*)malloc(m * sizeof(pmix_envar_t));
-                if (NULL == ptr[i].array) {
-                    return PMIX_ERR_NOMEM;
-                }
-                if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_envar(buffer, ptr[i].array, &m, ptr[i].type))) {
-                    return ret;
-                }
-                break;
-            default:
-                return PMIX_ERR_NOT_SUPPORTED;
+        t = ptr[i].type;
+
+        PMIX_DATA_ARRAY_CONSTRUCT(&ptr[i], m, t);
+        if (NULL == ptr[i].array) {
+            return PMIX_ERR_NOMEM;
+        }
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].array, &m, t, regtypes);
+        if (PMIX_SUCCESS != ret) {
+            return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_rank(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_rank(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT32, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_query(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_query_t *ptr;
@@ -1526,7 +1198,8 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, void *dest,
         PMIX_QUERY_CONSTRUCT(&ptr[i]);
         /* unpack the number of keys */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_int32(buffer, &nkeys, &m, PMIX_INT32))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &nkeys, &m, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < nkeys) {
@@ -1536,20 +1209,23 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, void *dest,
             }
             /* unpack keys */
             m=nkeys;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, ptr[i].keys, &m, PMIX_STRING))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].keys, &m, PMIX_STRING, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
         /* unpack the number of qualifiers */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].nqual, &m, PMIX_SIZE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].nqual, &m, PMIX_SIZE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 < ptr[i].nqual) {
             /* unpack the qualifiers */
             PMIX_INFO_CREATE(ptr[i].qualifiers, ptr[i].nqual);
             m =  ptr[i].nqual;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_info(buffer, ptr[i].qualifiers, &m, PMIX_INFO))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].qualifiers, &m, PMIX_INFO, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -1557,19 +1233,26 @@ pmix_status_t pmix_bfrops_base_unpack_query(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                      pmix_buffer_t *buffer, void *dest,
                                                       int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT8, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_iof_channel(pmix_pointer_array_t *regtypes,
+                                                  pmix_buffer_t *buffer, void *dest,
                                                   int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix_bfrops_base_unpack_int16(buffer, dest, num_vals, PMIX_UINT16);
+    pmix_status_t ret;
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_UINT16, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix_bfrops_base_unpack_envar(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix_bfrops_base_unpack_envar(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_envar_t *ptr;
@@ -1586,17 +1269,20 @@ pmix_status_t pmix_bfrops_base_unpack_envar(pmix_buffer_t *buffer, void *dest,
         PMIX_ENVAR_CONSTRUCT(&ptr[i]);
         /* unpack the name */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].envar, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].envar, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack the value */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_string(buffer, &ptr[i].value, &m, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].value, &m, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         /* unpack the separator */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, &ptr[i].separator, &m, PMIX_BYTE))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].separator, &m, PMIX_BYTE, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
     }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -11,8 +11,8 @@
  *                         All rights reserved.
  * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
- * Copyright (c) 2015      Research Organization for Information Science
- *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2015-2019 Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
  * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * $COPYRIGHT$
@@ -900,7 +900,7 @@ pmix_status_t pmix_bfrops_base_unpack_app(pmix_pointer_array_t *regtypes,
         if (0 < ptr[i].ninfo) {
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
             m = ptr[i].ninfo;
-            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ptr[i].info, &m, PMIX_INFO, regtypes);
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, ptr[i].info, &m, PMIX_INFO, regtypes);
             if (PMIX_SUCCESS != ret) {
                 return ret;
             }

--- a/src/mca/bfrops/base/bfrop_base_unpack.c
+++ b/src/mca/bfrops/base/bfrop_base_unpack.c
@@ -146,30 +146,6 @@ pmix_status_t pmix_bfrops_base_unpack(pmix_pointer_array_t *regtypes,
     return ret;
 }
 
-static pmix_status_t unpack_gentype(pmix_pointer_array_t *regtypes,
-                                    pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type)
-{
-    pmix_status_t ret;
-
-    switch(type) {
-        case PMIX_INT8:
-        case PMIX_UINT8:
-        case PMIX_INT16:
-        case PMIX_UINT16:
-        case PMIX_INT32:
-        case PMIX_UINT32:
-        case PMIX_INT64:
-        case PMIX_UINT64:
-
-        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, type, regtypes);
-        return ret;
-
-        default:
-        return PMIX_ERR_UNKNOWN_DATA_TYPE;
-    }
-}
-
 /* UNPACK GENERIC SYSTEM TYPES */
 
 /*
@@ -226,8 +202,7 @@ pmix_status_t pmix_bfrops_base_unpack_int(pmix_pointer_array_t *regtypes,
     if (remote_type == BFROP_TYPE_INT) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer, dest, num_vals, BFROP_TYPE_INT))) {
-        }
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, BFROP_TYPE_INT, regtypes);
     } else {
         /* slow path - types are different sizes */
         PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, int, remote_type, ret);
@@ -255,9 +230,9 @@ pmix_status_t pmix_bfrops_base_unpack_sizet(pmix_pointer_array_t *regtypes,
     if (remote_type == BFROP_TYPE_SIZE_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer,
-                                                  dest, num_vals,
-                                                  BFROP_TYPE_SIZE_T))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, BFROP_TYPE_SIZE_T,
+                                regtypes);
+        if (PMIX_SUCCESS != ret) {
             PMIX_ERROR_LOG(ret);
         }
     } else {
@@ -285,8 +260,7 @@ pmix_status_t pmix_bfrops_base_unpack_pid(pmix_pointer_array_t *regtypes,
     if (remote_type == BFROP_TYPE_PID_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = unpack_gentype(regtypes, buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
-        }
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, BFROP_TYPE_PID_T, regtypes);
     } else {
         /* slow path - types are different sizes */
         PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, pid_t, remote_type, ret);

--- a/src/mca/bfrops/v12/bfrop_v12.c
+++ b/src/mca/bfrops/v12/bfrop_v12.c
@@ -14,6 +14,8 @@
  * Copyright (c) 201-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -444,13 +446,15 @@ int pmix12_v2_to_v1_datatype(pmix_data_type_t v2type)
     return v1type;
 }
 
-pmix_status_t pmix12_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer,
+                                          pmix_data_type_t type)
 {
     int v1type;
 
     v1type = pmix12_v2_to_v1_datatype(type);
 
-    return pmix12_bfrop_pack_datatype(buffer, &v1type, 1, PMIX_INT);
+    return pmix12_bfrop_pack_datatype(regtypes, buffer, &v1type, 1, PMIX_INT);
 }
 
 pmix_data_type_t pmix12_v1_to_v2_datatype(int v1type)
@@ -491,13 +495,14 @@ pmix_data_type_t pmix12_v1_to_v2_datatype(int v1type)
     return v2type;
 }
 
-pmix_status_t pmix12_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
+pmix_status_t pmix12_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, pmix_data_type_t *type)
 {
     int32_t n=1;
     int v1type;
     pmix_status_t rc;
 
-    rc = pmix12_bfrop_unpack_datatype(buffer, &v1type, &n, PMIX_INT);
+    rc = pmix12_bfrop_unpack_datatype(regtypes, buffer, &v1type, &n, PMIX_INT);
     if (UINT16_MAX < v1type) {
         *type = 0;
         return PMIX_ERR_UNKNOWN_DATA_TYPE;

--- a/src/mca/bfrops/v12/internal.h
+++ b/src/mca/bfrops/v12/internal.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -122,175 +124,249 @@ pmix_value_cmp_t pmix12_bfrop_value_cmp(pmix_value_t *p,
 /*
  * Specialized functions
  */
-pmix_status_t pmix12_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_buffer(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
 
-pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
-                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_buffer(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dst,
+                                         int32_t *num_vals, pmix_data_type_t type);
 
 /*
  * Internal pack functions
  */
 
-pmix_status_t pmix12_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_bool(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_byte(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
-                                        int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_string(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                        int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_sizet(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_pid(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
 
-pmix_status_t pmix12_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_int(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-/* compatibility functions - no corresponding PMIx v1.x definitions */
-pmix_status_t pmix12_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_int16(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_info_directives(pmix_buffer_t *buffer, const void *src,
-                                               int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_proc_state(pmix_buffer_t *buffer, const void *src,
-                                          int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_int32(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_proc_info(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_datatype(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                          int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_int64(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix12_bfrop_pack_float(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_double(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix12_bfrop_pack_timeval(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_time(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
+
+pmix_status_t pmix12_bfrop_pack_value(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_proc(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_app(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_info(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_buf(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_kval(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_persist(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_bo(pmix_pointer_array_t *regtypes,
+                                   pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_pdata(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+/* compatibility functions - no corresponding PMIx v1.x definitions */
+pmix_status_t pmix12_bfrop_pack_ptr(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_scope(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_status(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_range(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_cmd(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_info_directives(pmix_pointer_array_t *regtypes,
+                                                pmix_buffer_t *buffer, const void *src,
+                                                int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_proc_state(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
+                                           int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_darray(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_proc_info(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
+                                          int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_query(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_pack_rank(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type);
 
 
 /*
  * Internal unpack functions
  */
-pmix_status_t pmix12_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
-                                        int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_bool(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_byte(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
-                                          int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
-                                        int32_t *num_vals, pmix_data_type_t type);
-
-pmix_status_t pmix12_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_string(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                          int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_pid(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
 
-pmix_status_t pmix12_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_int(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
-                                         int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-/* compatibility functions - no corresponding PMIx v1.x definitions */
-pmix_status_t pmix12_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_int16(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_info_directives(pmix_buffer_t *buffer, void *dest,
-                                                 int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_proc_state(pmix_buffer_t *buffer, void *dest,
-                                            int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_int32(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_proc_info(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                            int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_int64(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix12_bfrop_unpack_float(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_double(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+
+pmix_status_t pmix12_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_time(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix12_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
+
+pmix_status_t pmix12_bfrop_unpack_value(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_proc(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_app(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_info(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_buf(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_kval(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_persist(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_bo(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+/* compatibility functions - no corresponding PMIx v1.x definitions */
+pmix_status_t pmix12_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_scope(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_status(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_range(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_info_directives(pmix_pointer_array_t *regtypes,
+                                                  pmix_buffer_t *buffer, void *dest,
+                                                  int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_proc_state(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
+                                             int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_darray(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_proc_info(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
+                                            int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_query(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_unpack_rank(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
 
 
 /*
@@ -408,9 +484,12 @@ pmix_status_t pmix12_bfrop_print_rank(char **output, char *prefix,
 /*
  * Internal helper functions
  */
-pmix_status_t pmix12_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
+pmix_status_t pmix12_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer,
+                                          pmix_data_type_t type);
 
-pmix_status_t pmix12_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type);
+pmix_status_t pmix12_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, pmix_data_type_t *type);
 
 int pmix12_v2_to_v1_datatype(pmix_data_type_t v2type);
 

--- a/src/mca/bfrops/v12/pack.c
+++ b/src/mca/bfrops/v12/pack.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -37,11 +37,12 @@
 #include "bfrop_v12.h"
 #include "internal.h"
 
- pmix_status_t pmix12_bfrop_pack(pmix_buffer_t *buffer,
+pmix_status_t pmix12_bfrop_pack(pmix_buffer_t *buffer,
                                 const void *src, int32_t num_vals,
                                 pmix_data_type_t type)
 {
     pmix_status_t rc;
+    pmix_pointer_array_t *regtypes = &mca_bfrops_v12_component.types;
 
     /* check for error */
     if (NULL == buffer) {
@@ -50,21 +51,22 @@
 
     /* Pack the number of values */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix12_bfrop_store_data_type(buffer, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (rc = pmix12_bfrop_store_data_type(regtypes, buffer, PMIX_INT32))) {
             return rc;
         }
     }
-    if (PMIX_SUCCESS != (rc = pmix12_bfrop_pack_int32(buffer, &num_vals, 1, PMIX_INT32))) {
+    if (PMIX_SUCCESS != (rc = pmix12_bfrop_pack_int32(regtypes, buffer, &num_vals, 1, PMIX_INT32))) {
         return rc;
     }
 
     /* Pack the value(s) */
-    return pmix12_bfrop_pack_buffer(buffer, src, num_vals, type);
+    return pmix12_bfrop_pack_buffer(regtypes, buffer, src, num_vals, type);
 }
 
-pmix_status_t pmix12_bfrop_pack_buffer(pmix_buffer_t *buffer,
-                                      const void *src, int32_t num_vals,
-                                      pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_buffer(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer,
+                                       const void *src, int32_t num_vals,
+                                       pmix_data_type_t type)
 {
     pmix_status_t rc;
     pmix_bfrop_type_info_t *info;
@@ -95,7 +97,7 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_buffer_t *buffer,
 
     /* Pack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix12_bfrop_store_data_type(buffer, v1type))) {
+        if (PMIX_SUCCESS != (rc = pmix12_bfrop_store_data_type(regtypes, buffer, v1type))) {
             return rc;
         }
     }
@@ -111,7 +113,7 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_buffer_t *buffer,
         return PMIX_ERR_PACK_FAILURE;
     }
 
-    return info->odti_pack_fn(buffer, src, num_vals, v1type);
+    return info->odti_pack_fn(regtypes, buffer, src, num_vals, v1type);
 }
 
 
@@ -120,8 +122,9 @@ pmix_status_t pmix12_bfrop_pack_buffer(pmix_buffer_t *buffer,
 /*
  * BOOL
  */
-pmix_status_t pmix12_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_bool(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     uint8_t *dst;
     int32_t i;
@@ -152,54 +155,57 @@ pmix_status_t pmix12_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
 /*
  * INT
  */
-pmix_status_t pmix12_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_int(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them */
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(buffer, BFROP_TYPE_INT))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pmix12_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_INT);
+    return pmix12_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_INT);
 }
 
 /*
  * SIZE_T
  */
-pmix_status_t pmix12_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_sizet(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(buffer, BFROP_TYPE_SIZE_T))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
         return ret;
     }
 
-    return pmix12_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_SIZE_T);
+    return pmix12_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_SIZE_T);
 }
 
 /*
  * PID_T
  */
-pmix_status_t pmix12_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_pid(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(buffer, BFROP_TYPE_PID_T))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_PID_T))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pmix12_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_PID_T);
+    return pmix12_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_PID_T);
 }
 
 
@@ -208,8 +214,9 @@ pmix_status_t pmix12_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix12_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_byte(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     char *dst;
 
@@ -232,8 +239,9 @@ pmix_status_t pmix12_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
 /*
  * INT16
  */
-pmix_status_t pmix12_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_int16(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint16_t tmp, *srctmp = (uint16_t*) src;
@@ -259,8 +267,9 @@ pmix_status_t pmix12_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
 /*
  * INT32
  */
-pmix_status_t pmix12_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_int32(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint32_t tmp, *srctmp = (uint32_t*) src;
@@ -283,17 +292,19 @@ pmix_status_t pmix12_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
-                                        int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_datatype(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
+                                         int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix12_bfrop_pack_int32(buffer, src, num_vals, type);
+    return pmix12_bfrop_pack_int32(regtypes, buffer, src, num_vals, type);
 }
 
 /*
  * INT64
  */
-pmix_status_t pmix12_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_int64(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint64_t tmp, tmp2;
@@ -321,8 +332,9 @@ pmix_status_t pmix12_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
 /*
  * STRING
  */
-pmix_status_t pmix12_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_string(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     int ret = PMIX_SUCCESS;
     int32_t i, len;
@@ -331,16 +343,16 @@ pmix_status_t pmix12_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) {  /* got zero-length string/NULL pointer - store NULL */
             len = 0;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(regtypes, buffer, &len, 1, PMIX_INT32))) {
                 return ret;
             }
         } else {
             len = (int32_t)strlen(ssrc[i]) + 1;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(regtypes, buffer, &len, 1, PMIX_INT32))) {
                 return ret;
             }
             if (PMIX_SUCCESS != (ret =
-                                 pmix12_bfrop_pack_byte(buffer, ssrc[i], len, PMIX_BYTE))) {
+                                 pmix12_bfrop_pack_byte(regtypes, buffer, ssrc[i], len, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -350,8 +362,9 @@ pmix_status_t pmix12_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
 }
 
 /* FLOAT */
-pmix_status_t pmix12_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_float(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -362,7 +375,7 @@ pmix_status_t pmix12_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;
         }
@@ -373,8 +386,9 @@ pmix_status_t pmix12_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
 }
 
 /* DOUBLE */
-pmix_status_t pmix12_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_double(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -385,7 +399,7 @@ pmix_status_t pmix12_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;
         }
@@ -396,8 +410,9 @@ pmix_status_t pmix12_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIMEVAL */
-pmix_status_t pmix12_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_timeval(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type)
 {
     int64_t tmp[2];
     pmix_status_t ret = PMIX_SUCCESS;
@@ -407,7 +422,7 @@ pmix_status_t pmix12_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t)ssrc[i].tv_sec;
         tmp[1] = (int64_t)ssrc[i].tv_usec;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int64(buffer, tmp, 2, PMIX_INT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int64(regtypes, buffer, tmp, 2, PMIX_INT64))) {
             return ret;
         }
     }
@@ -416,8 +431,9 @@ pmix_status_t pmix12_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIME */
-pmix_status_t pmix12_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_time(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -429,7 +445,7 @@ pmix_status_t pmix12_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
      */
     for (i = 0; i < num_vals; ++i) {
         ui64 = (uint64_t)ssrc[i];
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int64(buffer, &ui64, 1, PMIX_UINT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int64(regtypes, buffer, &ui64, 1, PMIX_UINT64))) {
             return ret;
         }
     }
@@ -439,7 +455,8 @@ pmix_status_t pmix12_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
 
 
 /* PACK FUNCTIONS FOR GENERIC PMIX TYPES */
-static pmix_status_t pack_val(pmix_buffer_t *buffer,
+static pmix_status_t pack_val(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer,
                               pmix_value_t *p)
 {
     pmix_status_t ret;
@@ -448,97 +465,97 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
 
     switch (p->type) {
     case PMIX_BOOL:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.flag, 1, PMIX_BOOL))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.flag, 1, PMIX_BOOL))) {
             return ret;
         }
         break;
     case PMIX_BYTE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.byte, 1, PMIX_BYTE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.byte, 1, PMIX_BYTE))) {
             return ret;
         }
         break;
     case PMIX_STRING:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.string, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.string, 1, PMIX_STRING))) {
             return ret;
         }
         break;
     case PMIX_SIZE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.size, 1, PMIX_SIZE))) {
             return ret;
         }
         break;
     case PMIX_PID:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.pid, 1, PMIX_PID))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.pid, 1, PMIX_PID))) {
             return ret;
         }
         break;
     case PMIX_INT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.integer, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.integer, 1, PMIX_INT))) {
             return ret;
         }
         break;
     case PMIX_INT8:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.int8, 1, PMIX_INT8))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.int8, 1, PMIX_INT8))) {
             return ret;
         }
         break;
     case PMIX_INT16:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.int16, 1, PMIX_INT16))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.int16, 1, PMIX_INT16))) {
             return ret;
         }
         break;
     case PMIX_INT32:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.int32, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.int32, 1, PMIX_INT32))) {
             return ret;
         }
         break;
     case PMIX_INT64:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.int64, 1, PMIX_INT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.int64, 1, PMIX_INT64))) {
             return ret;
         }
         break;
     case PMIX_UINT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.uint, 1, PMIX_UINT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.uint, 1, PMIX_UINT))) {
             return ret;
         }
         break;
     case PMIX_UINT8:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.uint8, 1, PMIX_UINT8))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.uint8, 1, PMIX_UINT8))) {
             return ret;
         }
         break;
     case PMIX_UINT16:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.uint16, 1, PMIX_UINT16))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.uint16, 1, PMIX_UINT16))) {
             return ret;
         }
         break;
     case PMIX_UINT32:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.uint32, 1, PMIX_UINT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.uint32, 1, PMIX_UINT32))) {
             return ret;
         }
         break;
     case PMIX_UINT64:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.uint64, 1, PMIX_UINT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.uint64, 1, PMIX_UINT64))) {
             return ret;
         }
         break;
     case PMIX_FLOAT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.fval, 1, PMIX_FLOAT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.fval, 1, PMIX_FLOAT))) {
             return ret;
         }
         break;
     case PMIX_DOUBLE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
             return ret;
         }
         break;
     case PMIX_TIMEVAL:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
             return ret;
         }
         break;
     case PMIX_BYTE_OBJECT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
             return ret;
         }
         break;
@@ -549,7 +566,7 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
         }
         array.size = p->data.darray->size;
         array.array = (pmix_info_t*)p->data.darray->array;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &array, 1, PMIX_INFO_ARRAY))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &array, 1, PMIX_INFO_ARRAY))) {
             return ret;
         }
         break;
@@ -557,7 +574,7 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
     case PMIX_PROC_RANK:
         /* must convert this to an int */
         rank = p->data.rank;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(buffer, &rank, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_buffer(regtypes, buffer, &rank, 1, PMIX_INT))) {
             return ret;
         }
         break;
@@ -572,8 +589,9 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
 /*
  * PMIX_VALUE
  */
-pmix_status_t pmix12_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_value(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
     int32_t i;
@@ -587,11 +605,11 @@ pmix_status_t pmix12_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
          * using the store_data_type function. This means we lose the translation!
          * So get it here */
         v1type = pmix12_v2_to_v1_datatype(ptr[i].type);
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &v1type, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &v1type, 1, PMIX_INT))) {
             return ret;
         }
         /* now pack the right field */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &ptr[i]))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &ptr[i]))) {
             return ret;
         }
     }
@@ -600,8 +618,9 @@ pmix_status_t pmix12_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
 }
 
 
-pmix_status_t pmix12_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_info(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_t *info;
     int32_t i;
@@ -614,26 +633,27 @@ pmix_status_t pmix12_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         /* pack key */
         foo = info[i].key;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &foo, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the type - unfortunately, v1.2 directly packed the int instead of
          * using the store_data_type function. This means we lose the translation!
          * So get it here */
         v1type = pmix12_v2_to_v1_datatype(info[i].value.type);
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &v1type, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &v1type, 1, PMIX_INT))) {
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &info[i].value))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &info[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_pdata(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *pdata;
     int32_t i;
@@ -645,31 +665,32 @@ pmix_status_t pmix12_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the proc */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_proc(buffer, &pdata[i].proc, 1, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_proc(regtypes, buffer, &pdata[i].proc, 1, PMIX_PROC))) {
             return ret;
         }
         /* pack key */
         foo = pdata[i].key;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &foo, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the type - unfortunately, v1.2 directly packed the int instead of
          * using the store_data_type function. This means we lose the translation!
          * So get it here */
         v1type = pmix12_v2_to_v1_datatype(pdata[i].value.type);
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &v1type, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &v1type, 1, PMIX_INT))) {
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &pdata[i].value))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &pdata[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_buf(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
     int32_t i;
@@ -679,12 +700,12 @@ pmix_status_t pmix12_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the number of bytes */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(buffer, &ptr[i].bytes_used, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(regtypes, buffer, &ptr[i].bytes_used, 1, PMIX_SIZE))) {
             return ret;
         }
         /* pack the bytes */
         if (0 < ptr[i].bytes_used) {
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(buffer, ptr[i].base_ptr, ptr[i].bytes_used, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(regtypes, buffer, ptr[i].base_ptr, ptr[i].bytes_used, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -692,8 +713,9 @@ pmix_status_t pmix12_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_proc(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *proc;
     int32_t i;
@@ -703,18 +725,19 @@ pmix_status_t pmix12_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         char *ptr = proc[i].nspace;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &ptr, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &ptr, 1, PMIX_STRING))) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &proc[i].rank, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &proc[i].rank, 1, PMIX_INT))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_app(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_app_t *app;
     int32_t i, j, nvals;
@@ -724,39 +747,39 @@ pmix_status_t pmix12_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
     app = (pmix_app_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &app[i].cmd, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &app[i].cmd, 1, PMIX_STRING))) {
             return ret;
         }
         /* argv */
         argc = pmix_argv_count(app[i].argv);
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &argc, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &argc, 1, PMIX_INT))) {
             return ret;
         }
         for (j=0; j < argc; j++) {
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &app[i].argv[j], 1, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &app[i].argv[j], 1, PMIX_STRING))) {
                 return ret;
             }
         }
         /* env */
         nvals = pmix_argv_count(app[i].env);
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(buffer, &nvals, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int32(regtypes, buffer, &nvals, 1, PMIX_INT32))) {
             return ret;
         }
         for (j=0; j < nvals; j++) {
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &app[i].env[j], 1, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &app[i].env[j], 1, PMIX_STRING))) {
                 return ret;
             }
         }
         /* maxprocs */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(buffer, &app[i].maxprocs, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_int(regtypes, buffer, &app[i].maxprocs, 1, PMIX_INT))) {
             return ret;
         }
         /* info array */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(regtypes, buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < app[i].ninfo) {
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_info(buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_info(regtypes, buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -765,8 +788,9 @@ pmix_status_t pmix12_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
 }
 
 
-pmix_status_t pmix12_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_kval(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
     int32_t i;
@@ -776,11 +800,11 @@ pmix_status_t pmix12_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the key */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(buffer, &ptr[i].key, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_string(regtypes, buffer, &ptr[i].key, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the value */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_value(buffer, ptr[i].value, 1, ptr[i].value->type))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_value(regtypes, buffer, ptr[i].value, 1, ptr[i].value->type))) {
             return ret;
         }
     }
@@ -788,8 +812,9 @@ pmix_status_t pmix12_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i;
@@ -799,12 +824,12 @@ pmix_status_t pmix12_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             /* pack the values */
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_info(regtypes, buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -813,8 +838,9 @@ pmix_status_t pmix12_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i;
@@ -823,11 +849,11 @@ pmix_status_t pmix12_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
     ptr = (pmix_modex_data_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if( 0 < ptr[i].size){
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(regtypes, buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
                 return ret;
             }
         }
@@ -835,14 +861,16 @@ pmix_status_t pmix12_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_persist(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix12_bfrop_pack_int(buffer, src, num_vals, PMIX_INT);
+    return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);
 }
 
-pmix_status_t pmix12_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_bo(pmix_pointer_array_t *regtypes,
+                                   pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     int i;
@@ -850,11 +878,11 @@ pmix_status_t pmix12_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
 
     bo = (pmix_byte_object_t*)src;
     for (i=0; i < num_vals; i++) {
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(buffer, &bo[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_sizet(regtypes, buffer, &bo[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < bo[i].size) {
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_pack_byte(regtypes, buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -862,15 +890,17 @@ pmix_status_t pmix12_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_ptr(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     /* v1.x has no concept of packing a pointer, so just return */
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_scope(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_scope_t *scope = (pmix_scope_t*)src;
     unsigned int *v1scope;
@@ -885,21 +915,23 @@ pmix_status_t pmix12_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
     for (i=0; i < num_vals; i++) {
         v1scope[i] = (unsigned int)scope[i];
     }
-    ret = pmix12_bfrop_pack_int(buffer, (void*)v1scope, num_vals, PMIX_UINT);
+    ret = pmix12_bfrop_pack_int(regtypes, buffer, (void*)v1scope, num_vals, PMIX_UINT);
     free(v1scope);
     return ret;
 }
 
-pmix_status_t pmix12_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_status(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     /* v1.2 declares pmix_status_t as an enum, which translates to int and
      * matches that of v2 */
-    return pmix12_bfrop_pack_int(buffer, src, num_vals, PMIX_INT);
+    return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);
 }
 
-pmix_status_t pmix12_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_range(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_data_range_t *range = (pmix_data_range_t*)src;
     unsigned int *v1range;
@@ -914,13 +946,14 @@ pmix_status_t pmix12_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
     for (i=0; i < num_vals; i++) {
         v1range[i] = (unsigned int)range[i];
     }
-    ret = pmix12_bfrop_pack_int(buffer, (void*)v1range, num_vals, PMIX_UINT);
+    ret = pmix12_bfrop_pack_int(regtypes, buffer, (void*)v1range, num_vals, PMIX_UINT);
     free(v1range);
     return ret;
 }
 
-pmix_status_t pmix12_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_cmd(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_cmd_t *cmd = (pmix_cmd_t*)src;
     int *v1cmd;
@@ -935,48 +968,54 @@ pmix_status_t pmix12_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
     for (i=0; i < num_vals; i++) {
         v1cmd[i] = cmd[i];
     }
-    ret = pmix12_bfrop_pack_int(buffer, (void*)v1cmd, num_vals, PMIX_INT);
+    ret = pmix12_bfrop_pack_int(regtypes, buffer, (void*)v1cmd, num_vals, PMIX_INT);
     free(v1cmd);
     return ret;
 }
 
-pmix_status_t pmix12_bfrop_pack_info_directives(pmix_buffer_t *buffer, const void *src,
-                                               int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_info_directives(pmix_pointer_array_t *regtypes,
+                                                pmix_buffer_t *buffer, const void *src,
+                                                int32_t num_vals, pmix_data_type_t type)
 {
     /* v1.x has no concept of an info directive, so just return */
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_proc_state(pmix_buffer_t *buffer, const void *src,
-                                          int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_pack_proc_state(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, const void *src,
+                                           int32_t num_vals, pmix_data_type_t type)
 {
     /* v1.x has no concept of proc state, so just return */
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_darray(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix12_bfrop_pack_proc_info(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, const void *src,
+                                          int32_t num_vals, pmix_data_type_t type)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+
+}
+
+pmix_status_t pmix12_bfrop_pack_query(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_pack_proc_info(pmix_buffer_t *buffer, const void *src,
-                                         int32_t num_vals, pmix_data_type_t type)
-{
-    return PMIX_ERR_NOT_SUPPORTED;
-
-}
-
-pmix_status_t pmix12_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix12_bfrop_pack_rank(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type)
-{
-    return PMIX_ERR_NOT_SUPPORTED;
-}
-
-pmix_status_t pmix12_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
 {
     /* v1 rank is just an int, not a separate data type - it is defined
      * to be an unint32 in v2 */
-    return pmix12_bfrop_pack_int(buffer, src, num_vals, PMIX_INT);
+    return pmix12_bfrop_pack_int(regtypes, buffer, src, num_vals, PMIX_INT);
 }

--- a/src/mca/bfrops/v12/unpack.c
+++ b/src/mca/bfrops/v12/unpack.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -34,28 +34,29 @@
 #include "bfrop_v12.h"
 #include "internal.h"
 
-static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t unpack_gentype(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, void *dest,
                                     int32_t *num_vals, pmix_data_type_t type)
 {
     switch(type) {
         case PMIX_INT8:
         case PMIX_UINT8:
-        return pmix12_bfrop_unpack_byte(buffer, dest, num_vals, type);
+        return pmix12_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT16:
         case PMIX_UINT16:
-        return pmix12_bfrop_unpack_int16(buffer, dest, num_vals, type);
+        return pmix12_bfrop_unpack_int16(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT32:
         case PMIX_UINT32:
-        return pmix12_bfrop_unpack_int32(buffer, dest, num_vals, type);
+        return pmix12_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT64:
         case PMIX_UINT64:
-        return pmix12_bfrop_unpack_int64(buffer, dest, num_vals, type);
+        return pmix12_bfrop_unpack_int64(regtypes, buffer, dest, num_vals, type);
         break;
 
         default:
@@ -64,12 +65,13 @@ static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
 }
 
 pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
-                                 void *dst, int32_t *num_vals,
-                                 pmix_data_type_t type)
+                                  void *dst, int32_t *num_vals,
+                                  pmix_data_type_t type)
 {
     pmix_status_t rc, ret;
     int32_t local_num, n=1;
     pmix_data_type_t local_type;
+    pmix_pointer_array_t *regtypes = &mca_bfrops_v12_component.types;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix12_bfrop_unpack: for type %d", (int)type);
@@ -101,7 +103,7 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
      * int32_t as used here.
      */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix12_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix12_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             *num_vals = 0;
             /* don't error log here as the user may be unpacking past
              * the end of the buffer, which isn't necessarily an error */
@@ -115,7 +117,7 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
     }
 
     n=1;
-    if (PMIX_SUCCESS != (rc = pmix12_bfrop_unpack_int32(buffer, &local_num, &n, PMIX_INT32))) {
+    if (PMIX_SUCCESS != (rc = pmix12_bfrop_unpack_int32(regtypes, buffer, &local_num, &n, PMIX_INT32))) {
         *num_vals = 0;
         /* don't error log here as the user may be unpacking past
          * the end of the buffer, which isn't necessarily an error */
@@ -134,8 +136,9 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
      */
     if (local_num > *num_vals) {
         local_num = *num_vals;
-        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack: inadequate space ( %p, %p, %lu, %d )\n",
-                       (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
+        pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                            "pmix12_bfrop_unpack: inadequate space ( %p, %p, %lu, %d )\n",
+                            (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
         ret = PMIX_ERR_UNPACK_INADEQUATE_SPACE;
     } else {  /** enough or more than enough storage */
         *num_vals = local_num;  /** let the user know how many we actually unpacked */
@@ -143,7 +146,7 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
     }
 
     /** Unpack the value(s) */
-    if (PMIX_SUCCESS != (rc = pmix12_bfrop_unpack_buffer(buffer, dst, &local_num, type))) {
+    if (PMIX_SUCCESS != (rc = pmix12_bfrop_unpack_buffer(regtypes, buffer, dst, &local_num, type))) {
         PMIX_ERROR_LOG(rc);
         *num_vals = 0;
         ret = rc;
@@ -152,12 +155,12 @@ pmix_status_t pmix12_bfrop_unpack(pmix_buffer_t *buffer,
     return ret;
 }
 
-pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
-                                       pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_buffer(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
+                                         pmix_data_type_t type)
 {
     pmix_status_t rc;
     pmix_data_type_t local_type, v1type;
-    pmix_bfrop_type_info_t *info;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
                    (void*)buffer, dst, (long unsigned int)*num_vals, (int)type);
@@ -182,7 +185,7 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
 
     /** Unpack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix12_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix12_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             PMIX_ERROR_LOG(rc);
             return rc;
         }
@@ -193,18 +196,8 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
             return PMIX_ERR_PACK_MISMATCH;
         }
     }
+    PMIX_BFROPS_UNPACK_TYPE(rc, buffer, dst, num_vals, v1type, regtypes);
 
-    /* Lookup the unpack function for this type and call it */
-
-    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v12_component.types, v1type))) {
-        PMIX_ERROR_LOG(PMIX_ERR_UNPACK_FAILURE);
-        return PMIX_ERR_UNPACK_FAILURE;
-    }
-
-    rc = info->odti_unpack_fn(buffer, dst, num_vals, v1type);
-    if (PMIX_SUCCESS != rc) {
-        PMIX_ERROR_LOG(rc);
-    }
     return rc;
 }
 
@@ -214,8 +207,9 @@ pmix_status_t pmix12_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
 /*
  * BOOL
  */
-pmix_status_t pmix12_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_bool(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint8_t *src;
@@ -248,24 +242,25 @@ pmix_status_t pmix12_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
 /*
  * INT
  */
-pmix_status_t pmix12_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_int(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_INT) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, dest, num_vals, BFROP_TYPE_INT))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(int, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, int, remote_type, ret);
     }
 
     return ret;
@@ -274,24 +269,25 @@ pmix_status_t pmix12_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
 /*
  * SIZE_T
  */
-pmix_status_t pmix12_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_SIZE_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(size_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, size_t, remote_type, ret);
     }
 
     return ret;
@@ -300,24 +296,25 @@ pmix_status_t pmix12_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
 /*
  * PID_T
  */
-pmix_status_t pmix12_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_pid(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix12_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_PID_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(pid_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, pid_t, remote_type, ret);
     }
 
     return ret;
@@ -329,8 +326,9 @@ pmix_status_t pmix12_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix12_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_byte(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_byte * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
@@ -347,8 +345,9 @@ pmix_status_t pmix12_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_int16(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint16_t tmp, *desttmp = (uint16_t*) dest;
@@ -370,8 +369,9 @@ pmix_status_t pmix12_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_int32(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint32_t tmp, *desttmp = (uint32_t*) dest;
@@ -393,19 +393,22 @@ pmix_status_t pmix12_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
+                                           int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix12_bfrop_unpack_int32(buffer, dest, num_vals, type);
+    return pmix12_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, type);
 }
 
-pmix_status_t pmix12_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_int64(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint64_t tmp, *desttmp = (uint64_t*) dest;
 
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_int64 * %d\n", (int)*num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix12_bfrop_unpack_int64 * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(tmp))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -422,15 +425,17 @@ pmix_status_t pmix12_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
-                             int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_string(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     int32_t i, len, n=1;
     char **sdest = (char**) dest;
 
     for (i = 0; i < (*num_vals); ++i) {
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int32(buffer, &len, &n, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int32(regtypes, buffer,
+                                                             &len, &n, PMIX_INT32))) {
             return ret;
         }
         if (0 ==  len) {   /* zero-length string - unpack the NULL */
@@ -440,7 +445,9 @@ pmix_status_t pmix12_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
             if (NULL == sdest[i]) {
                 return PMIX_ERR_OUT_OF_RESOURCE;
             }
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(buffer, sdest[i], &len, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(regtypes, buffer,
+                                                                sdest[i], &len,
+                                                                PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -449,15 +456,17 @@ pmix_status_t pmix12_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_float(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     float *desttmp = (float*) dest, tmp;
     pmix_status_t ret;
     char *convert;
 
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_float * %d\n", (int)*num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix12_bfrop_unpack_float * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(float))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -467,7 +476,8 @@ pmix_status_t pmix12_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer,
+                                                              &convert, &n, PMIX_STRING))) {
             return ret;
         }
         if (NULL != convert) {
@@ -479,15 +489,17 @@ pmix_status_t pmix12_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
-                             int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_double(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     double *desttmp = (double*) dest, tmp;
     pmix_status_t ret;
     char *convert;
 
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_double * %d\n", (int)*num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix12_bfrop_unpack_double * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(double))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -497,7 +509,9 @@ pmix_status_t pmix12_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer,
+                                                              &convert, &n,
+                                                              PMIX_STRING))) {
             return ret;
         }
         if (NULL != convert) {
@@ -509,15 +523,17 @@ pmix_status_t pmix12_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
-                              int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     int64_t tmp[2];
     struct timeval *desttmp = (struct timeval *) dest, tt;
     pmix_status_t ret;
 
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_timeval * %d\n", (int)*num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix12_bfrop_unpack_timeval * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*sizeof(struct timeval))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -526,7 +542,8 @@ pmix_status_t pmix12_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=2;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int64(buffer, tmp, &n, PMIX_INT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int64(regtypes, buffer,
+                                                             tmp, &n, PMIX_INT64))) {
             return ret;
         }
         tt.tv_sec = tmp[0];
@@ -536,8 +553,9 @@ pmix_status_t pmix12_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_time(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     time_t *desttmp = (time_t *) dest, tmp;
@@ -548,7 +566,8 @@ pmix_status_t pmix12_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
      * to uint64_t as a generic safe size
      */
 
-    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output, "pmix12_bfrop_unpack_time * %d\n", (int)*num_vals);
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+                        "pmix12_bfrop_unpack_time * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(uint64_t)))) {
         return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
@@ -557,7 +576,8 @@ pmix_status_t pmix12_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int64(buffer, &ui64, &n, PMIX_UINT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int64(regtypes, buffer,
+                                                             &ui64, &n, PMIX_UINT64))) {
             return ret;
         }
         tmp = (time_t)ui64;
@@ -572,7 +592,8 @@ pmix_status_t pmix12_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
 /*
  * PMIX_VALUE
  */
-static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
+static pmix_status_t unpack_val(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, pmix_value_t *val)
 {
     int32_t m;
     pmix_status_t ret;
@@ -580,92 +601,92 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
     m = 1;
     switch (val->type) {
     case PMIX_BOOL:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.flag, &m, PMIX_BOOL))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.flag, &m, PMIX_BOOL))) {
             return ret;
         }
         break;
     case PMIX_BYTE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.byte, &m, PMIX_BYTE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.byte, &m, PMIX_BYTE))) {
             return ret;
         }
         break;
     case PMIX_STRING:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.string, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.string, &m, PMIX_STRING))) {
             return ret;
         }
         break;
     case PMIX_SIZE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.size, &m, PMIX_SIZE))) {
             return ret;
         }
         break;
     case PMIX_PID:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.pid, &m, PMIX_PID))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.pid, &m, PMIX_PID))) {
             return ret;
         }
         break;
     case PMIX_INT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.integer, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.integer, &m, PMIX_INT))) {
             return ret;
         }
         break;
     case PMIX_INT8:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.int8, &m, PMIX_INT8))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.int8, &m, PMIX_INT8))) {
             return ret;
         }
         break;
     case PMIX_INT16:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.int16, &m, PMIX_INT16))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.int16, &m, PMIX_INT16))) {
             return ret;
         }
         break;
     case PMIX_INT32:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.int32, &m, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.int32, &m, PMIX_INT32))) {
             return ret;
         }
         break;
     case PMIX_INT64:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.int64, &m, PMIX_INT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.int64, &m, PMIX_INT64))) {
             return ret;
         }
         break;
     case PMIX_UINT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.uint, &m, PMIX_UINT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint, &m, PMIX_UINT))) {
             return ret;
         }
         break;
     case PMIX_UINT8:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.uint8, &m, PMIX_UINT8))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint8, &m, PMIX_UINT8))) {
             return ret;
         }
         break;
     case PMIX_UINT16:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.uint16, &m, PMIX_UINT16))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint16, &m, PMIX_UINT16))) {
             return ret;
         }
         break;
     case PMIX_UINT32:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.uint32, &m, PMIX_UINT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint32, &m, PMIX_UINT32))) {
             return ret;
         }
         break;
     case PMIX_UINT64:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.uint64, &m, PMIX_UINT64))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint64, &m, PMIX_UINT64))) {
             return ret;
         }
         break;
     case PMIX_FLOAT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.fval, &m, PMIX_FLOAT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.fval, &m, PMIX_FLOAT))) {
             return ret;
         }
         break;
     case PMIX_DOUBLE:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
             return ret;
         }
         break;
     case PMIX_TIMEVAL:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
             return ret;
         }
         break;
@@ -676,12 +697,12 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
         val->data.darray->type = PMIX_INFO_ARRAY;
         val->data.darray->size = m;
         /* unpack into it */
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
             return ret;
         }
         break;
     case PMIX_BYTE_OBJECT:
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_buffer(regtypes, buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
             return ret;
         }
         break;
@@ -693,8 +714,9 @@ static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_value(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
     int32_t i, m, n;
@@ -707,7 +729,7 @@ pmix_status_t pmix12_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < n; ++i) {
         /* unpack the type */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &v1type, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &v1type, &m, PMIX_INT))) {
             return ret;
         }
         /* convert the type - unfortunately, v1.2 directly packed the int instead of
@@ -715,15 +737,16 @@ pmix_status_t pmix12_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
          * So get it here */
         ptr[i].type = pmix12_v1_to_v2_datatype(v1type);
         /* unpack value */
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i])) ) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i])) ) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_info(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_t *ptr;
     int32_t i, n, m;
@@ -743,7 +766,7 @@ pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             return ret;
         }
         if (NULL == tmp) {
@@ -755,7 +778,7 @@ pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &v1type, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &v1type, &m, PMIX_INT))) {
             return ret;
         }
         /* convert the type - unfortunately, v1.2 directly packed the int instead of
@@ -765,15 +788,16 @@ pmix_status_t pmix12_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix12_bfrop_unpack: info type %d", ptr[i].value.type);
         m=1;
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *ptr;
     int32_t i, n, m;
@@ -791,13 +815,13 @@ pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         PMIX_PDATA_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_proc(regtypes, buffer, &ptr[i].proc, &m, PMIX_PROC))) {
             return ret;
         }
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             return ret;
         }
         if (NULL == tmp) {
@@ -809,7 +833,7 @@ pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &v1type, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &v1type, &m, PMIX_INT))) {
             return ret;
         }
         /* convert the type - unfortunately, v1.2 directly packed the int instead of
@@ -819,15 +843,16 @@ pmix_status_t pmix12_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix12_bfrop_unpack: pdata type %d", ptr[i].value.type);
         m=1;
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_buf(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
     int32_t i, n, m;
@@ -840,7 +865,7 @@ pmix_status_t pmix12_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < n; ++i) {
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(buffer, &nbytes, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(regtypes, buffer, &nbytes, &m, PMIX_SIZE))) {
             return ret;
         }
         m = nbytes;
@@ -848,7 +873,7 @@ pmix_status_t pmix12_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
         if (0 < nbytes) {
             ptr[i].base_ptr = (char*)malloc(nbytes);
             /* unpack the bytes */
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(regtypes, buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -860,8 +885,9 @@ pmix_status_t pmix12_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_proc(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *ptr;
     int32_t i, n, m;
@@ -881,7 +907,7 @@ pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         /* unpack nspace */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             return ret;
         }
         if (NULL == tmp) {
@@ -891,7 +917,7 @@ pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         free(tmp);
         /* unpack the rank */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &ptr[i].rank, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &ptr[i].rank, &m, PMIX_INT))) {
             return ret;
         }
         /* we have to do some conversion here as the definition of rank
@@ -905,8 +931,9 @@ pmix_status_t pmix12_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_app(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_app_t *ptr;
     int32_t i, k, n, m;
@@ -926,19 +953,19 @@ pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         PMIX_APP_CONSTRUCT(&ptr[i]);
         /* unpack cmd */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
             return ret;
         }
         /* unpack argc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &argc, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &argc, &m, PMIX_INT))) {
             return ret;
         }
         /* unpack argv */
         for (k=0; k < argc; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -949,13 +976,13 @@ pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack env */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int32(buffer, &nval, &m, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int32(regtypes, buffer, &nval, &m, PMIX_INT32))) {
             return ret;
         }
         for (k=0; k < nval; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -966,18 +993,18 @@ pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack maxprocs */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_int(regtypes, buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
             return ret;
         }
         /* unpack info array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].ninfo) {
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
             m = ptr[i].ninfo;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_info(buffer, ptr[i].info, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_info(regtypes, buffer, ptr[i].info, &m, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -985,8 +1012,9 @@ pmix_status_t pmix12_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_kval(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
     int32_t i, n, m;
@@ -1002,7 +1030,7 @@ pmix_status_t pmix12_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
         PMIX_CONSTRUCT(&ptr[i], pmix_kval_t);
         /* unpack the key */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(buffer, &ptr[i].key, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_string(regtypes, buffer, &ptr[i].key, &m, PMIX_STRING))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -1010,7 +1038,7 @@ pmix_status_t pmix12_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
         ptr[i].value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         /* unpack the value */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_value(buffer, ptr[i].value, &m, PMIX_VALUE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_value(regtypes, buffer, ptr[i].value, &m, PMIX_VALUE))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -1018,8 +1046,9 @@ pmix_status_t pmix12_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i, n, m;
@@ -1037,13 +1066,13 @@ pmix_status_t pmix12_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_info_array_t));
         /* unpack the size of this array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_value(regtypes, buffer, ptr[i].array, &m, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -1051,8 +1080,9 @@ pmix_status_t pmix12_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i, n, m;
@@ -1068,13 +1098,13 @@ pmix_status_t pmix12_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].blob = (uint8_t*)malloc(ptr[i].size * sizeof(uint8_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(buffer, ptr[i].blob, &m, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(regtypes, buffer, ptr[i].blob, &m, PMIX_UINT8))) {
                 return ret;
             }
         }
@@ -1083,14 +1113,16 @@ pmix_status_t pmix12_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
 }
 
 
-pmix_status_t pmix12_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_persist(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix12_bfrop_unpack_int(buffer, dest, num_vals, PMIX_INT);
+    return pmix12_bfrop_unpack_int(regtypes, buffer, dest, num_vals, PMIX_INT);
 }
 
-pmix_status_t pmix12_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
-                         int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_bo(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_byte_object_t *ptr;
     int32_t i, n, m;
@@ -1106,13 +1138,13 @@ pmix_status_t pmix12_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_byte_object_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].bytes = (char*)malloc(ptr[i].size * sizeof(char));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix12_bfrop_unpack_byte(regtypes, buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -1120,68 +1152,79 @@ pmix_status_t pmix12_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix12_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
-{
-    return PMIX_ERR_NOT_SUPPORTED;
-}
-
-pmix_status_t pmix12_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_scope(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_status(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_range(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_info_directives(pmix_buffer_t *buffer, void *dest,
-                                                 int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix12_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_proc_state(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_info_directives(pmix_pointer_array_t *regtypes,
+                                                  pmix_buffer_t *buffer, void *dest,
+                                                  int32_t *num_vals, pmix_data_type_t type)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix12_bfrop_unpack_proc_state(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, void *dest,
+                                             int32_t *num_vals, pmix_data_type_t type)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix12_bfrop_unpack_darray(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
+{
+    return PMIX_ERR_NOT_SUPPORTED;
+}
+
+pmix_status_t pmix12_bfrop_unpack_proc_info(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                             int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_query(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }
 
-pmix_status_t pmix12_bfrop_unpack_proc_info(pmix_buffer_t *buffer, void *dest,
-                                           int32_t *num_vals, pmix_data_type_t type)
-{
-    return PMIX_ERR_NOT_SUPPORTED;
-}
-
-pmix_status_t pmix12_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix12_bfrop_unpack_rank(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type)
-{
-    return PMIX_ERR_NOT_SUPPORTED;
-}
-
-pmix_status_t pmix12_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
 {
     return PMIX_ERR_NOT_SUPPORTED;
 }

--- a/src/mca/bfrops/v20/bfrop_pmix20.c
+++ b/src/mca/bfrops/v20/bfrop_pmix20.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2017 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -436,20 +438,22 @@ pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type)
     return v20type;
 }
 
-pmix_status_t pmix20_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, pmix_data_type_t type)
 {
     pmix_data_type_t v20type;
 
     v20type = pmix20_v21_to_v20_datatype(type);
-    return pmix20_bfrop_pack_datatype(buffer, &v20type, 1, PMIX_DATA_TYPE);
+    return pmix20_bfrop_pack_datatype(regtypes, buffer, &v20type, 1, PMIX_DATA_TYPE);
 }
 
-pmix_status_t pmix20_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type)
+pmix_status_t pmix20_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, pmix_data_type_t *type)
 {
     int32_t n=1;
     pmix_status_t rc;
 
-    rc = pmix20_bfrop_unpack_datatype(buffer, type, &n, PMIX_DATA_TYPE);
+    rc = pmix20_bfrop_unpack_datatype(regtypes, buffer, type, &n, PMIX_DATA_TYPE);
 
     return rc;
 }

--- a/src/mca/bfrops/v20/internal.h
+++ b/src/mca/bfrops/v20/internal.h
@@ -15,6 +15,8 @@
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -123,176 +125,254 @@ pmix_value_cmp_t pmix20_bfrop_value_cmp(pmix_value_t *p,
 /*
  * Specialized functions
  */
-pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_pack_buffer(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer,
+                                       const void *src, int32_t num_vals,
+                                       pmix_data_type_t type);
 
-pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst,
+pmix_status_t pmix20_bfrop_unpack_buffer(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dst,
                                          int32_t *num_vals, pmix_data_type_t type);
 
 /*
  * Internal pack functions
  */
 
-pmix_status_t pmix20_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_bool(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_byte(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_string(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                        int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_sizet(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_pid(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
 
-pmix_status_t pmix20_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_int(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_int16(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_int32(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_datatype(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                        int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_int64(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
 
-pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_float(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_double(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_time(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_timeval(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_time(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_status(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_value(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_proc(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_app(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_info(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_buf(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_kval(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_persist(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_scope(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_range(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_cmd(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_infodirs(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_infodirs(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
                                        int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_bo(pmix_pointer_array_t *regtypes,
+                                   pmix_buffer_t *buffer, const void *src,
                                  int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_pdata(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_ptr(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                   int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_pstate(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_pstate(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_pinfo(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_pinfo(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_darray(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_query(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_rank(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                    int32_t num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                pmix_buffer_t *buffer, const void *src,
                                               int32_t num_vals, pmix_data_type_t type);
 /**** DEPRECATED ****/
-pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
 /********************/
 
 /*
  * Internal unpack functions
  */
- pmix_status_t pmix20_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_bool(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_byte(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_string(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_pid(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
 
- pmix_status_t pmix20_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_int(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_int16(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_int32(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_int64(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
 
- pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_float(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_double(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
                                          int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_time(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
-                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
-                                         int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_status(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                           int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_value(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_proc(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_app(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_info(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_buf(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_kval(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_persist(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_scope(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_range(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_pointer_array_t *regtypes,
+                                            pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type);
+ pmix_status_t pmix20_bfrop_unpack_bo(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
                                     int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_pstate(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_pstate(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
                                        int32_t *num_vals, pmix_data_type_t type);
- pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
+ pmix_status_t pmix20_bfrop_unpack_darray(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_query(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_rank(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
                                      int32_t *num_vals, pmix_data_type_t type);
-pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                  pmix_buffer_t *buffer, void *dest,
                                                 int32_t *num_vals, pmix_data_type_t type);
 /**** DEPRECATED ****/
-pmix_status_t pmix20_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type);
 /********************/
 
@@ -414,9 +494,11 @@ pmix_status_t pmix20_bfrop_print_array(char **output, char *prefix,
  * Internal helper functions
  */
 
-pmix_status_t pmix20_bfrop_store_data_type(pmix_buffer_t *buffer, pmix_data_type_t type);
+pmix_status_t pmix20_bfrop_store_data_type(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, pmix_data_type_t type);
 
-pmix_status_t pmix20_bfrop_get_data_type(pmix_buffer_t *buffer, pmix_data_type_t *type);
+pmix_status_t pmix20_bfrop_get_data_type(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, pmix_data_type_t *type);
 
 pmix_data_type_t pmix20_v21_to_v20_datatype(pmix_data_type_t v21type);
 

--- a/src/mca/bfrops/v20/pack.c
+++ b/src/mca/bfrops/v20/pack.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2018 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -39,10 +39,11 @@
 #include "internal.h"
 
 pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer,
-                              const void *src, int32_t num_vals,
-                              pmix_data_type_t type)
+                                const void *src, int32_t num_vals,
+                                pmix_data_type_t type)
  {
     pmix_status_t rc;
+    pmix_pointer_array_t *regtypes = &mca_bfrops_v20_component.types;
 
     /* check for error */
     if (NULL == buffer) {
@@ -51,21 +52,24 @@ pmix_status_t pmix20_bfrop_pack(pmix_buffer_t *buffer,
 
     /* Pack the number of values */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(buffer, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(regtypes, buffer,
+                                                               PMIX_INT32))) {
             return rc;
         }
     }
-    if (PMIX_SUCCESS != (rc = pmix20_bfrop_pack_int32(buffer, &num_vals, 1, PMIX_INT32))) {
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_pack_int32(regtypes, buffer,
+                                                      &num_vals, 1, PMIX_INT32))) {
         return rc;
     }
 
     /* Pack the value(s) */
-    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, type);
+    return pmix20_bfrop_pack_buffer(regtypes, buffer, src, num_vals, type);
 }
 
-pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer,
-                                     const void *src, int32_t num_vals,
-                                     pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_buffer(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer,
+                                       const void *src, int32_t num_vals,
+                                       pmix_data_type_t type)
 {
     pmix_data_type_t v20type;
     pmix_status_t rc;
@@ -86,7 +90,7 @@ pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer,
 
     /* Pack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(buffer, v20type))) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_store_data_type(regtypes, buffer, v20type))) {
             return rc;
         }
     }
@@ -97,7 +101,7 @@ pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer,
         return PMIX_ERR_PACK_FAILURE;
     }
 
-    return info->odti_pack_fn(buffer, src, num_vals, v20type);
+    return info->odti_pack_fn(regtypes, buffer, src, num_vals, v20type);
 }
 
 
@@ -106,8 +110,9 @@ pmix_status_t pmix20_bfrop_pack_buffer(pmix_buffer_t *buffer,
 /*
  * BOOL
  */
-pmix_status_t pmix20_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_bool(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
  {
     uint8_t *dst;
     int32_t i;
@@ -139,54 +144,57 @@ pmix_status_t pmix20_bfrop_pack_bool(pmix_buffer_t *buffer, const void *src,
 /*
  * INT
  */
-pmix_status_t pmix20_bfrop_pack_int(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_int(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them */
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_INT))) {
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_INT))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_INT);
+    return pmix20_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_INT);
 }
 
 /*
  * SIZE_T
  */
-pmix_status_t pmix20_bfrop_pack_sizet(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_sizet(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
+ {
+    pmix_status_t ret;
+
+    /* System types need to always be described so we can properly
+       unpack them. */
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_SIZE_T))) {
+        return ret;
+    }
+
+    return pmix20_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_SIZE_T);
+}
+
+/*
+ * PID_T
+ */
+pmix_status_t pmix20_bfrop_pack_pid(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret;
 
     /* System types need to always be described so we can properly
        unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_SIZE_T))) {
-        return ret;
-    }
-
-    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_SIZE_T);
-}
-
-/*
- * PID_T
- */
-pmix_status_t pmix20_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
- {
-    pmix_status_t ret;
-
-    /* System types need to always be described so we can properly
-       unpack them. */
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, BFROP_TYPE_PID_T))) {
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, BFROP_TYPE_PID_T))) {
         return ret;
     }
 
     /* Turn around and pack the real type */
-    return pmix20_bfrop_pack_buffer(buffer, src, num_vals, BFROP_TYPE_PID_T);
+    return pmix20_bfrop_pack_buffer(regtypes, buffer, src, num_vals, BFROP_TYPE_PID_T);
 }
 
 
@@ -195,8 +203,9 @@ pmix_status_t pmix20_bfrop_pack_pid(pmix_buffer_t *buffer, const void *src,
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix20_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_byte(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
  {
     char *dst;
 
@@ -220,8 +229,9 @@ pmix_status_t pmix20_bfrop_pack_byte(pmix_buffer_t *buffer, const void *src,
 /*
  * INT16
  */
-pmix_status_t pmix20_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_int16(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
  {
     int32_t i;
     uint16_t tmp, *srctmp = (uint16_t*) src;
@@ -248,8 +258,9 @@ pmix_status_t pmix20_bfrop_pack_int16(pmix_buffer_t *buffer, const void *src,
 /*
  * INT32
  */
-pmix_status_t pmix20_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_int32(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
  {
     int32_t i;
     uint32_t tmp, *srctmp = (uint32_t*) src;
@@ -273,17 +284,22 @@ pmix_status_t pmix20_bfrop_pack_int32(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_datatype(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_datatype(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
+                                         int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_int16(buffer, src, num_vals, type);
+    pmix_status_t ret;
+
+    PMIX_BFROPS_PACK_TYPE(ret, buffer, src, num_vals, PMIX_INT16, regtypes);
+    return ret;
 }
 
 /*
  * INT64
  */
-pmix_status_t pmix20_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_int64(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
  {
     int32_t i;
     uint64_t tmp, tmp2;
@@ -312,8 +328,9 @@ pmix_status_t pmix20_bfrop_pack_int64(pmix_buffer_t *buffer, const void *src,
 /*
  * STRING
  */
-pmix_status_t pmix20_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_string(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i, len;
@@ -322,16 +339,16 @@ pmix_status_t pmix20_bfrop_pack_string(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         if (NULL == ssrc[i]) {  /* got zero-length string/NULL pointer - store NULL */
         len = 0;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(regtypes, buffer, &len, 1, PMIX_INT32))) {
             return ret;
         }
     } else {
         len = (int32_t)strlen(ssrc[i]) + 1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &len, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(regtypes, buffer, &len, 1, PMIX_INT32))) {
             return ret;
         }
         if (PMIX_SUCCESS != (ret =
-            pmix20_bfrop_pack_byte(buffer, ssrc[i], len, PMIX_BYTE))) {
+            pmix20_bfrop_pack_byte(regtypes, buffer, ssrc[i], len, PMIX_BYTE))) {
             return ret;
     }
 }
@@ -341,8 +358,9 @@ return PMIX_SUCCESS;
 }
 
 /* FLOAT */
-pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_float(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -353,7 +371,7 @@ pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;
         }
@@ -364,8 +382,9 @@ pmix_status_t pmix20_bfrop_pack_float(pmix_buffer_t *buffer, const void *src,
 }
 
 /* DOUBLE */
-pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_double(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -376,7 +395,7 @@ pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
         if (0 > asprintf(&convert, "%f", ssrc[i])) {
             return PMIX_ERR_NOMEM;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &convert, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &convert, 1, PMIX_STRING))) {
             free(convert);
             return ret;
         }
@@ -387,8 +406,9 @@ pmix_status_t pmix20_bfrop_pack_double(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIMEVAL */
-pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
-                                      int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_timeval(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type)
 {
     int64_t tmp[2];
     pmix_status_t ret = PMIX_SUCCESS;
@@ -398,7 +418,7 @@ pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         tmp[0] = (int64_t)ssrc[i].tv_sec;
         tmp[1] = (int64_t)ssrc[i].tv_usec;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(buffer, tmp, 2, PMIX_INT64))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(regtypes, buffer, tmp, 2, PMIX_INT64))) {
             return ret;
         }
     }
@@ -407,8 +427,9 @@ pmix_status_t pmix20_bfrop_pack_timeval(pmix_buffer_t *buffer, const void *src,
 }
 
 /* TIME */
-pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_time(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -420,7 +441,7 @@ pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
      */
      for (i = 0; i < num_vals; ++i) {
         ui64 = (uint64_t)ssrc[i];
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(buffer, &ui64, 1, PMIX_UINT64))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int64(regtypes, buffer, &ui64, 1, PMIX_UINT64))) {
             return ret;
         }
     }
@@ -429,8 +450,9 @@ pmix_status_t pmix20_bfrop_pack_time(pmix_buffer_t *buffer, const void *src,
 }
 
 /* STATUS */
-pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_status(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret = PMIX_SUCCESS;
     int32_t i;
@@ -439,7 +461,7 @@ pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         status = (int32_t)ssrc[i];
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &status, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(regtypes, buffer, &status, 1, PMIX_INT32))) {
             return ret;
         }
     }
@@ -449,7 +471,8 @@ pmix_status_t pmix20_bfrop_pack_status(pmix_buffer_t *buffer, const void *src,
 
 
 /* PACK FUNCTIONS FOR GENERIC PMIX TYPES */
-static pmix_status_t pack_val(pmix_buffer_t *buffer,
+static pmix_status_t pack_val(pmix_pointer_array_t *regtypes,
+                              pmix_buffer_t *buffer,
                               pmix_value_t *p)
 {
     pmix_status_t ret;
@@ -458,158 +481,158 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
         case PMIX_UNDEF:
             break;
         case PMIX_BOOL:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.flag, 1, PMIX_BOOL))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.flag, 1, PMIX_BOOL))) {
                 return ret;
             }
             break;
         case PMIX_BYTE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.byte, 1, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.byte, 1, PMIX_BYTE))) {
                 return ret;
             }
             break;
         case PMIX_STRING:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.string, 1, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.string, 1, PMIX_STRING))) {
                 return ret;
             }
             break;
         case PMIX_SIZE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.size, 1, PMIX_SIZE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.size, 1, PMIX_SIZE))) {
                 return ret;
             }
             break;
         case PMIX_PID:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.pid, 1, PMIX_PID))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.pid, 1, PMIX_PID))) {
                 return ret;
             }
             break;
         case PMIX_INT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.integer, 1, PMIX_INT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.integer, 1, PMIX_INT))) {
                 return ret;
             }
             break;
         case PMIX_INT8:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int8, 1, PMIX_INT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.int8, 1, PMIX_INT8))) {
                 return ret;
             }
             break;
         case PMIX_INT16:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int16, 1, PMIX_INT16))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.int16, 1, PMIX_INT16))) {
                 return ret;
             }
             break;
         case PMIX_INT32:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int32, 1, PMIX_INT32))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.int32, 1, PMIX_INT32))) {
                 return ret;
             }
             break;
         case PMIX_INT64:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.int64, 1, PMIX_INT64))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.int64, 1, PMIX_INT64))) {
                 return ret;
             }
             break;
         case PMIX_UINT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint, 1, PMIX_UINT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.uint, 1, PMIX_UINT))) {
                 return ret;
             }
             break;
         case PMIX_UINT8:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint8, 1, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.uint8, 1, PMIX_UINT8))) {
                 return ret;
             }
             break;
         case PMIX_UINT16:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint16, 1, PMIX_UINT16))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.uint16, 1, PMIX_UINT16))) {
                 return ret;
             }
             break;
         case PMIX_UINT32:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint32, 1, PMIX_UINT32))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.uint32, 1, PMIX_UINT32))) {
                 return ret;
             }
             break;
         case PMIX_UINT64:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.uint64, 1, PMIX_UINT64))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.uint64, 1, PMIX_UINT64))) {
                 return ret;
             }
             break;
         case PMIX_FLOAT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.fval, 1, PMIX_FLOAT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.fval, 1, PMIX_FLOAT))) {
                 return ret;
             }
             break;
         case PMIX_DOUBLE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.dval, 1, PMIX_DOUBLE))) {
                 return ret;
             }
             break;
         case PMIX_TIMEVAL:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.tv, 1, PMIX_TIMEVAL))) {
                 return ret;
             }
             break;
         case PMIX_TIME:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.time, 1, PMIX_TIME))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.time, 1, PMIX_TIME))) {
                 return ret;
             }
             break;
         case PMIX_STATUS:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.status, 1, PMIX_STATUS))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.status, 1, PMIX_STATUS))) {
                 return ret;
             }
             break;
         case PMIX_PROC:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.proc, 1, PMIX_PROC))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, p->data.proc, 1, PMIX_PROC))) {
                 return ret;
             }
             break;
         case PMIX_PROC_RANK:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.rank, 1, PMIX_PROC_RANK))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.rank, 1, PMIX_PROC_RANK))) {
                 return ret;
             }
             break;
         case PMIX_BYTE_OBJECT:
         case PMIX_COMPRESSED_STRING:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.bo, 1, PMIX_BYTE_OBJECT))) {
                 return ret;
             }
             break;
         case PMIX_PERSIST:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.persist, 1, PMIX_PERSIST))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.persist, 1, PMIX_PERSIST))) {
                 return ret;
             }
             break;
         case PMIX_POINTER:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.ptr, 1, PMIX_POINTER))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.ptr, 1, PMIX_POINTER))) {
                 return ret;
             }
             break;
         case PMIX_SCOPE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.scope, 1, PMIX_SCOPE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.scope, 1, PMIX_SCOPE))) {
                 return ret;
             }
             break;
         case PMIX_DATA_RANGE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.range, 1, PMIX_DATA_RANGE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.range, 1, PMIX_DATA_RANGE))) {
                 return ret;
             }
             break;
         case PMIX_PROC_STATE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, &p->data.state, 1, PMIX_PROC_STATE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, &p->data.state, 1, PMIX_PROC_STATE))) {
                 return ret;
             }
             break;
         case PMIX_PROC_INFO:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.pinfo, 1, PMIX_PROC_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, p->data.pinfo, 1, PMIX_PROC_INFO))) {
                 return ret;
             }
             break;
         case PMIX_DATA_ARRAY:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_DATA_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, p->data.darray, 1, PMIX_DATA_ARRAY))) {
                 return ret;
             }
             break;
         case PMIX_QUERY:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p->data.darray, 1, PMIX_QUERY))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, p->data.darray, 1, PMIX_QUERY))) {
                 return ret;
             }
             break;
@@ -623,7 +646,8 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
 /*
  * PMIX_VALUE
  */
- pmix_status_t pmix20_bfrop_pack_value(pmix_buffer_t *buffer, const void *src,
+ pmix_status_t pmix20_bfrop_pack_value(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type)
  {
     pmix_value_t *ptr;
@@ -634,11 +658,11 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(buffer, ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_store_data_type(regtypes, buffer, ptr[i].type))) {
             return ret;
         }
         /* now pack the right field */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &ptr[i]))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &ptr[i]))) {
             return ret;
         }
     }
@@ -647,8 +671,9 @@ static pmix_status_t pack_val(pmix_buffer_t *buffer,
 }
 
 
-pmix_status_t pmix20_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_info(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_t *info;
     int32_t i;
@@ -660,27 +685,28 @@ pmix_status_t pmix20_bfrop_pack_info(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         /* pack key */
         foo = info[i].key;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &foo, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack info directives flag */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_infodirs(buffer, &info[i].flags, 1, PMIX_INFO_DIRECTIVES))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_infodirs(regtypes, buffer, &info[i].flags, 1, PMIX_INFO_DIRECTIVES))) {
             return ret;
         }
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &info[i].value.type, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(regtypes, buffer, &info[i].value.type, 1, PMIX_INT))) {
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &info[i].value))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &info[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_pdata(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *pdata;
     int32_t i;
@@ -691,28 +717,29 @@ pmix_status_t pmix20_bfrop_pack_pdata(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the proc */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(buffer, &pdata[i].proc, 1, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(regtypes, buffer, &pdata[i].proc, 1, PMIX_PROC))) {
             return ret;
         }
         /* pack key */
         foo = pdata[i].key;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &foo, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &foo, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &pdata[i].value.type, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(regtypes, buffer, &pdata[i].value.type, 1, PMIX_INT))) {
             return ret;
         }
         /* pack value */
-        if (PMIX_SUCCESS != (ret = pack_val(buffer, &pdata[i].value))) {
+        if (PMIX_SUCCESS != (ret = pack_val(regtypes, buffer, &pdata[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_buf(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
     int32_t i;
@@ -722,12 +749,12 @@ pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the number of bytes */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i].bytes_used, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &ptr[i].bytes_used, 1, PMIX_SIZE))) {
             return ret;
         }
         /* pack the bytes */
         if (0 < ptr[i].bytes_used) {
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, ptr[i].base_ptr, ptr[i].bytes_used, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(regtypes, buffer, ptr[i].base_ptr, ptr[i].bytes_used, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -735,8 +762,9 @@ pmix_status_t pmix20_bfrop_pack_buf(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_proc(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *proc;
     int32_t i;
@@ -746,18 +774,19 @@ pmix_status_t pmix20_bfrop_pack_proc(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         char *ptr = proc[i].nspace;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &ptr, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &ptr, 1, PMIX_STRING))) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_rank(buffer, &proc[i].rank, 1, PMIX_PROC_RANK))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_rank(regtypes, buffer, &proc[i].rank, 1, PMIX_PROC_RANK))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_app(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     pmix_app_t *app;
     int32_t i, j, nvals;
@@ -766,43 +795,43 @@ pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
     app = (pmix_app_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].cmd, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &app[i].cmd, 1, PMIX_STRING))) {
             return ret;
         }
         /* argv */
         nvals = pmix_argv_count(app[i].argv);
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &nvals, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(regtypes, buffer, &nvals, 1, PMIX_INT32))) {
             return ret;
         }
         for (j=0; j < nvals; j++) {
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].argv[j], 1, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &app[i].argv[j], 1, PMIX_STRING))) {
                 return ret;
             }
         }
         /* env */
         nvals = pmix_argv_count(app[i].env);
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &nvals, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(regtypes, buffer, &nvals, 1, PMIX_INT32))) {
             return ret;
         }
         for (j=0; j < nvals; j++) {
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].env[j], 1, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &app[i].env[j], 1, PMIX_STRING))) {
                 return ret;
             }
         }
         /* cwd */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &app[i].cwd, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &app[i].cwd, 1, PMIX_STRING))) {
             return ret;
         }
         /* maxprocs */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(buffer, &app[i].maxprocs, 1, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int(regtypes, buffer, &app[i].maxprocs, 1, PMIX_INT))) {
             return ret;
         }
         /* info array */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &app[i].ninfo, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < app[i].ninfo) {
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(regtypes, buffer, app[i].info, app[i].ninfo, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -811,8 +840,9 @@ pmix_status_t pmix20_bfrop_pack_app(pmix_buffer_t *buffer, const void *src,
 }
 
 
-pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
-                                   int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_kval(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
+                                     int32_t num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
     int32_t i;
@@ -824,11 +854,11 @@ pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
     for (i = 0; i < num_vals; ++i) {
         /* pack the key */
         st = ptr[i].key;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &st, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &st, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the value */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_value(buffer, ptr[i].value, 1, PMIX_VALUE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_value(regtypes, buffer, ptr[i].value, 1, PMIX_VALUE))) {
             return ret;
         }
     }
@@ -836,8 +866,9 @@ pmix_status_t pmix20_bfrop_pack_kval(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i;
@@ -846,11 +877,11 @@ pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
     ptr = (pmix_modex_data_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if( 0 < ptr[i].size){
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(regtypes, buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
                 return ret;
             }
         }
@@ -858,38 +889,44 @@ pmix_status_t pmix20_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_persist(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_persist(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, const void *src,
+                                        int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_scope(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_pack_scope(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_range(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_pack_cmd(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_pack_range(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_infodirs(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, const void *src,
+                                         int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_pack_int32(regtypes, buffer, src, num_vals, PMIX_UINT32);
 }
 
-pmix_status_t pmix20_bfrop_pack_cmd(pmix_buffer_t *buffer, const void *src,
-                                  int32_t num_vals, pmix_data_type_t type)
-{
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
-}
-
-pmix_status_t pmix20_bfrop_pack_infodirs(pmix_buffer_t *buffer, const void *src,
-                                       int32_t num_vals, pmix_data_type_t type)
-{
-    return pmix20_bfrop_pack_int32(buffer, src, num_vals, PMIX_UINT32);
-}
-
-pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
-                                 int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_bo(pmix_pointer_array_t *regtypes,
+                                   pmix_buffer_t *buffer, const void *src,
+                                   int32_t num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     int i;
@@ -897,11 +934,11 @@ pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
 
     bo = (pmix_byte_object_t*)src;
     for (i=0; i < num_vals; i++) {
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &bo[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &bo[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < bo[i].size) {
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_byte(regtypes, buffer, bo[i].bytes, bo[i].size, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -909,23 +946,26 @@ pmix_status_t pmix20_bfrop_pack_bo(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_ptr(pmix_buffer_t *buffer, const void *src,
-                        int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_ptr(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, const void *src,
+                                    int32_t num_vals, pmix_data_type_t type)
 {
     uint8_t foo=1;
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just pack a sentinel */
-    return pmix20_bfrop_pack_byte(buffer, &foo, 1, PMIX_UINT8);
+    return pmix20_bfrop_pack_byte(regtypes, buffer, &foo, 1, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_pack_pstate(pmix_buffer_t *buffer, const void *src,
-                                     int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_pstate(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_pack_pinfo(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_pinfo(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_proc_info_t *pinfo = (pmix_proc_info_t*)src;
     pmix_status_t ret;
@@ -933,29 +973,30 @@ pmix_status_t pmix20_bfrop_pack_pinfo(pmix_buffer_t *buffer, const void *src,
 
     for (i=0; i < num_vals; i++) {
         /* pack the proc identifier */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(buffer, &pinfo[i].proc, 1, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_proc(regtypes, buffer, &pinfo[i].proc, 1, PMIX_PROC))) {
             return ret;
         }
         /* pack the hostname and exec */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &pinfo[i].hostname, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &pinfo[i].hostname, 1, PMIX_STRING))) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, &pinfo[i].executable_name, 1, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, &pinfo[i].executable_name, 1, PMIX_STRING))) {
             return ret;
         }
         /* pack the pid and state */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pid(buffer, &pinfo[i].pid, 1, PMIX_PID))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pid(regtypes, buffer, &pinfo[i].pid, 1, PMIX_PID))) {
             return ret;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pstate(buffer, &pinfo[i].state, 1, PMIX_PROC_STATE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_pstate(regtypes, buffer, &pinfo[i].state, 1, PMIX_PROC_STATE))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_darray(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, const void *src,
+                                       int32_t num_vals, pmix_data_type_t type)
 {
     pmix_data_array_t *p = (pmix_data_array_t*)src;
     pmix_status_t ret;
@@ -963,11 +1004,11 @@ pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
 
     for (i=0; i < num_vals; i++) {
         /* pack the actual type in the array */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_datatype(buffer, &p[i].type, 1, PMIX_DATA_TYPE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_datatype(regtypes, buffer, &p[i].type, 1, PMIX_DATA_TYPE))) {
             return ret;
         }
         /* pack the number of array elements */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &p[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &p[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 == p[i].size || PMIX_UNDEF == p[i].type) {
@@ -975,21 +1016,23 @@ pmix_status_t pmix20_bfrop_pack_darray(pmix_buffer_t *buffer, const void *src,
             continue;
         }
         /* pack the actual elements */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(buffer, p[i].array, p[i].size, p[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_buffer(regtypes, buffer, p[i].array, p[i].size, p[i].type))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_rank(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_rank(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, const void *src,
                                      int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_int32(buffer, src, num_vals, PMIX_UINT32);
+    return pmix20_bfrop_pack_int32(regtypes, buffer, src, num_vals, PMIX_UINT32);
 }
 
-pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_query(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
+                                      int32_t num_vals, pmix_data_type_t type)
 {
     pmix_query_t *pq = (pmix_query_t*)src;
     pmix_status_t ret;
@@ -999,22 +1042,22 @@ pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
     for (i=0; i < num_vals; i++) {
         /* pack the number of keys */
         nkeys = pmix_argv_count(pq[i].keys);
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(buffer, &nkeys, 1, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_int32(regtypes, buffer, &nkeys, 1, PMIX_INT32))) {
             return ret;
         }
         if (0 < nkeys) {
             /* pack the keys */
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(buffer, pq[i].keys, nkeys, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_string(regtypes, buffer, pq[i].keys, nkeys, PMIX_STRING))) {
                 return ret;
             }
         }
         /* pack the number of qualifiers */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(buffer, &pq[i].nqual, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_sizet(regtypes, buffer, &pq[i].nqual, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < pq[i].nqual) {
             /* pack any provided qualifiers */
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(buffer, pq[i].qualifiers, pq[i].nqual, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_pack_info(regtypes, buffer, pq[i].qualifiers, pq[i].nqual, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -1022,14 +1065,16 @@ pmix_status_t pmix20_bfrop_pack_query(pmix_buffer_t *buffer, const void *src,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_buffer_t *buffer, const void *src,
-                                              int32_t num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_pack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                pmix_buffer_t *buffer, const void *src,
+                                                int32_t num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_pack_byte(buffer, src, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_pack_byte(regtypes, buffer, src, num_vals, PMIX_UINT8);
 }
 
 /**** DEPRECATED ****/
-pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+pmix_status_t pmix20_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, const void *src,
                                       int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
@@ -1040,12 +1085,12 @@ pmix_status_t pmix20_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             /* pack the values */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(regtypes, buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
                 return ret;
             }
         }

--- a/src/mca/bfrops/v20/unpack.c
+++ b/src/mca/bfrops/v20/unpack.c
@@ -13,7 +13,7 @@
  * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2015      Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2016      Mellanox Technologies, Inc.
+ * Copyright (c) 2016-2019 Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
  * $COPYRIGHT$
@@ -34,28 +34,29 @@
 #include "bfrop_pmix20.h"
 #include "internal.h"
 
-static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t unpack_gentype(pmix_pointer_array_t *regtypes,
+                                    pmix_buffer_t *buffer, void *dest,
                                     int32_t *num_vals, pmix_data_type_t type)
 {
     switch(type) {
         case PMIX_INT8:
         case PMIX_UINT8:
-        return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, type);
+        return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT16:
         case PMIX_UINT16:
-        return pmix20_bfrop_unpack_int16(buffer, dest, num_vals, type);
+        return pmix20_bfrop_unpack_int16(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT32:
         case PMIX_UINT32:
-        return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, type);
+        return pmix20_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, type);
         break;
 
         case PMIX_INT64:
         case PMIX_UINT64:
-        return pmix20_bfrop_unpack_int64(buffer, dest, num_vals, type);
+        return pmix20_bfrop_unpack_int64(regtypes, buffer, dest, num_vals, type);
         break;
 
         default:
@@ -64,12 +65,13 @@ static pmix_status_t unpack_gentype(pmix_buffer_t *buffer, void *dest,
 }
 
 pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
-                                void *dst, int32_t *num_vals,
-                                pmix_data_type_t type)
+                                  void *dst, int32_t *num_vals,
+                                  pmix_data_type_t type)
  {
     pmix_status_t rc, ret;
     int32_t local_num, n=1;
     pmix_data_type_t local_type;
+    pmix_pointer_array_t *regtypes = &mca_bfrops_v20_component.types;
 
     /* check for error */
     if (NULL == buffer || NULL == dst || NULL == num_vals) {
@@ -96,7 +98,7 @@ pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
      * int32_t as used here.
      */
      if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             *num_vals = 0;
             /* don't error log here as the user may be unpacking past
              * the end of the buffer, which isn't necessarily an error */
@@ -109,7 +111,8 @@ pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
     }
 
     n=1;
-    if (PMIX_SUCCESS != (rc = pmix20_bfrop_unpack_int32(buffer, &local_num, &n, PMIX_INT32))) {
+    PMIX_BFROPS_UNPACK_TYPE(rc, buffer, &local_num, &n, PMIX_INT32, regtypes);
+    if (PMIX_SUCCESS != rc) {
         *num_vals = 0;
             /* don't error log here as the user may be unpacking past
              * the end of the buffer, which isn't necessarily an error */
@@ -137,7 +140,7 @@ pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
     }
 
     /** Unpack the value(s) */
-    if (PMIX_SUCCESS != (rc = pmix20_bfrop_unpack_buffer(buffer, dst, &local_num, type))) {
+    if (PMIX_SUCCESS != (rc = pmix20_bfrop_unpack_buffer(regtypes, buffer, dst, &local_num, type))) {
         *num_vals = 0;
         ret = rc;
     }
@@ -145,12 +148,12 @@ pmix_status_t pmix20_bfrop_unpack(pmix_buffer_t *buffer,
     return ret;
 }
 
-pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
-                                       pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_buffer(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dst, int32_t *num_vals,
+                                         pmix_data_type_t type)
 {
     pmix_status_t rc;
     pmix_data_type_t local_type, v20type;
-    pmix_bfrop_type_info_t *info;
 
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_buffer( %p, %p, %lu, %d )\n",
@@ -167,7 +170,7 @@ pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
 
     /** Unpack the declared data type */
     if (PMIX_BFROP_BUFFER_FULLY_DESC == buffer->type) {
-        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(buffer, &local_type))) {
+        if (PMIX_SUCCESS != (rc = pmix20_bfrop_get_data_type(regtypes, buffer, &local_type))) {
             return rc;
         }
         /* if the data types don't match, then return an error */
@@ -176,14 +179,8 @@ pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
             return PMIX_ERR_PACK_MISMATCH;
         }
     }
-
-    /* Lookup the unpack function for this type and call it */
-
-    if (NULL == (info = (pmix_bfrop_type_info_t*)pmix_pointer_array_get_item(&mca_bfrops_v20_component.types, v20type))) {
-        return PMIX_ERR_UNPACK_FAILURE;
-    }
-
-    return info->odti_unpack_fn(buffer, dst, num_vals, v20type);
+    PMIX_BFROPS_UNPACK_TYPE(rc, buffer, dst, num_vals, v20type, regtypes);
+    return rc;
 }
 
 
@@ -192,8 +189,9 @@ pmix_status_t pmix20_bfrop_unpack_buffer(pmix_buffer_t *buffer, void *dst, int32
 /*
  * BOOL
  */
-pmix_status_t pmix20_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_bool(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
  {
     int32_t i;
     uint8_t *src;
@@ -227,24 +225,26 @@ pmix_status_t pmix20_bfrop_unpack_bool(pmix_buffer_t *buffer, void *dest,
 /*
  * INT
  */
-pmix_status_t pmix20_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_int(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_INT) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, dest,
+                                                              num_vals, BFROP_TYPE_INT))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(int, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, int, remote_type, ret);
     }
 
     return ret;
@@ -253,24 +253,26 @@ pmix_status_t pmix20_bfrop_unpack_int(pmix_buffer_t *buffer, void *dest,
 /*
  * SIZE_T
  */
-pmix_status_t pmix20_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_sizet(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_SIZE_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_SIZE_T))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer,
+                                                              dest, num_vals, BFROP_TYPE_SIZE_T))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(size_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, size_t, remote_type, ret);
     }
 
     return ret;
@@ -279,24 +281,25 @@ pmix_status_t pmix20_bfrop_unpack_sizet(pmix_buffer_t *buffer, void *dest,
 /*
  * PID_T
  */
-pmix_status_t pmix20_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_pid(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
  {
     pmix_status_t ret;
     pmix_data_type_t remote_type;
 
-    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &remote_type))) {
+    if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &remote_type))) {
         return ret;
     }
 
     if (remote_type == BFROP_TYPE_PID_T) {
         /* fast path it if the sizes are the same */
         /* Turn around and unpack the real type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, dest, num_vals, BFROP_TYPE_PID_T))) {
         }
     } else {
         /* slow path - types are different sizes */
-        PMIX_BFROP_UNPACK_SIZE_MISMATCH(pid_t, remote_type, ret);
+        PMIX_BFROP_UNPACK_SIZE_MISMATCH(regtypes, pid_t, remote_type, ret);
     }
 
     return ret;
@@ -308,8 +311,9 @@ pmix_status_t pmix20_bfrop_unpack_pid(pmix_buffer_t *buffer, void *dest,
 /*
  * BYTE, CHAR, INT8
  */
-pmix_status_t pmix20_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_byte(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
  {
     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                         "pmix20_bfrop_unpack_byte * %d\n", (int)*num_vals);
@@ -327,8 +331,9 @@ pmix_status_t pmix20_bfrop_unpack_byte(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_int16(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint16_t tmp, *desttmp = (uint16_t*) dest;
@@ -351,8 +356,9 @@ pmix_status_t pmix20_bfrop_unpack_int16(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_int32(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint32_t tmp, *desttmp = (uint32_t*) dest;
@@ -375,14 +381,19 @@ pmix_status_t pmix20_bfrop_unpack_int32(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_datatype(pmix_buffer_t *buffer, void *dest,
-                                         int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_datatype(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
+                                           int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_int16(buffer, dest, num_vals, type);
+    pmix_status_t ret;
+
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT16, regtypes);
+    return ret;
 }
 
-pmix_status_t pmix20_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_int64(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i;
     uint64_t tmp, *desttmp = (uint64_t*) dest;
@@ -405,15 +416,17 @@ pmix_status_t pmix20_bfrop_unpack_int64(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_string(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_status_t ret;
     int32_t i, len, n=1;
     char **sdest = (char**) dest;
 
     for (i = 0; i < (*num_vals); ++i) {
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &len, &n, PMIX_INT32))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &len, &n, PMIX_INT32, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (0 ==  len) {   /* zero-length string - unpack the NULL */
@@ -423,7 +436,8 @@ pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
             if (NULL == sdest[i]) {
                 return PMIX_ERR_OUT_OF_RESOURCE;
             }
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, sdest[i], &len, PMIX_BYTE))) {
+            PMIX_BFROPS_UNPACK_TYPE(ret, buffer, sdest[i], &len, PMIX_BYTE, regtypes);
+            if (PMIX_SUCCESS != ret) {
                 return ret;
             }
         }
@@ -432,8 +446,9 @@ pmix_status_t pmix20_bfrop_unpack_string(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_float(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     float *desttmp = (float*) dest, tmp;
@@ -451,7 +466,8 @@ pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &convert, &n, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL != convert) {
@@ -463,8 +479,9 @@ pmix_status_t pmix20_bfrop_unpack_float(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_double(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     double *desttmp = (double*) dest, tmp;
@@ -482,7 +499,8 @@ pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
         convert = NULL;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &convert, &n, PMIX_STRING))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &convert, &n, PMIX_STRING, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         if (NULL != convert) {
@@ -494,8 +512,9 @@ pmix_status_t pmix20_bfrop_unpack_double(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
-                                        int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_timeval(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     int64_t tmp[2];
@@ -512,7 +531,8 @@ pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=2;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int64(buffer, tmp, &n, PMIX_INT64))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, tmp, &n, PMIX_INT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         tt.tv_sec = tmp[0];
@@ -522,8 +542,9 @@ pmix_status_t pmix20_bfrop_unpack_timeval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_time(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     int32_t i, n;
     time_t *desttmp = (time_t *) dest, tmp;
@@ -536,15 +557,11 @@ pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
 
      pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                          "pmix20_bfrop_unpack_time * %d\n", (int)*num_vals);
-    /* check to see if there's enough data in buffer */
-     if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(uint64_t)))) {
-        return PMIX_ERR_UNPACK_READ_PAST_END_OF_BUFFER;
-    }
-
     /* unpack the data */
     for (i = 0; i < (*num_vals); ++i) {
         n=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int64(buffer, &ui64, &n, PMIX_UINT64))) {
+        PMIX_BFROPS_UNPACK_TYPE(ret, buffer, &ui64, &n, PMIX_UINT64, regtypes);
+        if (PMIX_SUCCESS != ret) {
             return ret;
         }
         tmp = (time_t)ui64;
@@ -554,10 +571,13 @@ pmix_status_t pmix20_bfrop_unpack_time(pmix_buffer_t *buffer, void *dest,
 }
 
 
-pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_status(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
-     pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
+    pmix_status_t ret;
+
+    pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                          "pmix20_bfrop_unpack_status * %d\n", (int)*num_vals);
     /* check to see if there's enough data in buffer */
     if (pmix_bfrop_too_small(buffer, (*num_vals)*(sizeof(pmix_status_t)))) {
@@ -565,7 +585,8 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
     }
 
     /* unpack the data */
-    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_INT32);
+    PMIX_BFROPS_UNPACK_TYPE(ret, buffer, dest, num_vals, PMIX_INT32, regtypes);
+    return ret;
 }
 
 
@@ -574,8 +595,9 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
 /*
  * PMIX_VALUE
  */
- static pmix_status_t unpack_val(pmix_buffer_t *buffer, pmix_value_t *val)
- {
+static pmix_status_t unpack_val(pmix_pointer_array_t *regtypes,
+                                pmix_buffer_t *buffer, pmix_value_t *val)
+{
     int32_t m;
     pmix_status_t ret;
 
@@ -584,102 +606,102 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
         case PMIX_UNDEF:
             break;
         case PMIX_BOOL:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.flag, &m, PMIX_BOOL))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.flag, &m, PMIX_BOOL))) {
                 return ret;
             }
             break;
         case PMIX_BYTE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.byte, &m, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.byte, &m, PMIX_BYTE))) {
                 return ret;
             }
             break;
         case PMIX_STRING:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.string, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.string, &m, PMIX_STRING))) {
                 return ret;
             }
             break;
         case PMIX_SIZE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.size, &m, PMIX_SIZE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.size, &m, PMIX_SIZE))) {
                 return ret;
             }
             break;
         case PMIX_PID:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.pid, &m, PMIX_PID))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.pid, &m, PMIX_PID))) {
                 return ret;
             }
             break;
         case PMIX_INT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.integer, &m, PMIX_INT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.integer, &m, PMIX_INT))) {
                 return ret;
             }
             break;
         case PMIX_INT8:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int8, &m, PMIX_INT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.int8, &m, PMIX_INT8))) {
                 return ret;
             }
             break;
         case PMIX_INT16:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int16, &m, PMIX_INT16))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.int16, &m, PMIX_INT16))) {
                 return ret;
             }
             break;
         case PMIX_INT32:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int32, &m, PMIX_INT32))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.int32, &m, PMIX_INT32))) {
                 return ret;
             }
             break;
         case PMIX_INT64:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.int64, &m, PMIX_INT64))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.int64, &m, PMIX_INT64))) {
                 return ret;
             }
             break;
         case PMIX_UINT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint, &m, PMIX_UINT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint, &m, PMIX_UINT))) {
                 return ret;
             }
             break;
         case PMIX_UINT8:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint8, &m, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint8, &m, PMIX_UINT8))) {
                 return ret;
             }
             break;
         case PMIX_UINT16:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint16, &m, PMIX_UINT16))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint16, &m, PMIX_UINT16))) {
                 return ret;
             }
             break;
         case PMIX_UINT32:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint32, &m, PMIX_UINT32))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint32, &m, PMIX_UINT32))) {
                 return ret;
             }
             break;
         case PMIX_UINT64:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.uint64, &m, PMIX_UINT64))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.uint64, &m, PMIX_UINT64))) {
                 return ret;
             }
             break;
         case PMIX_FLOAT:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.fval, &m, PMIX_FLOAT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.fval, &m, PMIX_FLOAT))) {
                 return ret;
             }
             break;
         case PMIX_DOUBLE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.dval, &m, PMIX_DOUBLE))) {
                 return ret;
             }
             break;
         case PMIX_TIMEVAL:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.tv, &m, PMIX_TIMEVAL))) {
                 return ret;
             }
             break;
         case PMIX_TIME:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.time, &m, PMIX_TIME))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.time, &m, PMIX_TIME))) {
                 return ret;
             }
             break;
         case PMIX_STATUS:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.status, &m, PMIX_STATUS))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.status, &m, PMIX_STATUS))) {
                 return ret;
             }
             break;
@@ -689,43 +711,43 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             if (NULL == val->data.proc) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.proc, &m, PMIX_PROC))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, val->data.proc, &m, PMIX_PROC))) {
                 return ret;
             }
             break;
         case PMIX_PROC_RANK:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.rank, &m, PMIX_PROC_RANK))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.rank, &m, PMIX_PROC_RANK))) {
                 return ret;
             }
             break;
         case PMIX_BYTE_OBJECT:
         case PMIX_COMPRESSED_STRING:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.bo, &m, PMIX_BYTE_OBJECT))) {
                 return ret;
             }
             break;
         case PMIX_PERSIST:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.proc, &m, PMIX_PROC))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.proc, &m, PMIX_PROC))) {
                 return ret;
             }
             break;
         case PMIX_POINTER:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.ptr, &m, PMIX_POINTER))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.ptr, &m, PMIX_POINTER))) {
                 return ret;
             }
             break;
         case PMIX_SCOPE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.scope, &m, PMIX_SCOPE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.scope, &m, PMIX_SCOPE))) {
                 return ret;
             }
             break;
         case PMIX_DATA_RANGE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.range, &m, PMIX_DATA_RANGE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.range, &m, PMIX_DATA_RANGE))) {
                 return ret;
             }
             break;
         case PMIX_PROC_STATE:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.state, &m, PMIX_PROC_STATE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.state, &m, PMIX_PROC_STATE))) {
                 return ret;
             }
             break;
@@ -735,7 +757,7 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             if (NULL == val->data.pinfo) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.pinfo, &m, PMIX_PROC_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, val->data.pinfo, &m, PMIX_PROC_INFO))) {
                 return ret;
             }
             break;
@@ -745,12 +767,12 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             if (NULL == val->data.darray) {
                 return PMIX_ERR_NOMEM;
             }
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_DATA_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, val->data.darray, &m, PMIX_DATA_ARRAY))) {
                 return ret;
             }
             break;
         case PMIX_QUERY:
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, val->data.darray, &m, PMIX_QUERY))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, val->data.darray, &m, PMIX_QUERY))) {
                 return ret;
             }
             break;
@@ -762,7 +784,7 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
             val->data.darray->type = PMIX_INFO_ARRAY;
             val->data.darray->size = m;
             /* unpack into it */
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, &val->data.darray->array, &m, PMIX_INFO_ARRAY))) {
                 return ret;
             }
             break;
@@ -775,8 +797,9 @@ pmix_status_t pmix20_bfrop_unpack_status(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_value(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_value_t *ptr;
     int32_t i, n;
@@ -787,19 +810,20 @@ pmix_status_t pmix20_bfrop_unpack_value(pmix_buffer_t *buffer, void *dest,
 
     for (i = 0; i < n; ++i) {
         /* unpack the type */
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(buffer, &ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_get_data_type(regtypes, buffer, &ptr[i].type))) {
             return ret;
         }
         /* unpack value */
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i])) ) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i])) ) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_info(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_t *ptr;
     int32_t i, n, m;
@@ -818,7 +842,7 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -830,7 +854,7 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
         free(tmp);
         /* unpack the flags */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_infodirs(buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_infodirs(regtypes, buffer, &ptr[i].flags, &m, PMIX_INFO_DIRECTIVES))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -838,14 +862,14 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
          m=1;
-         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].value.type, &m, PMIX_INT))) {
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(regtypes, buffer, &ptr[i].value.type, &m, PMIX_INT))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix20_bfrop_unpack: info type %d", ptr[i].value.type);
         m=1;
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i].value))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -853,8 +877,9 @@ pmix_status_t pmix20_bfrop_unpack_info(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_pdata(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_pdata_t *ptr;
     int32_t i, n, m;
@@ -871,13 +896,13 @@ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
         PMIX_PDATA_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(regtypes, buffer, &ptr[i].proc, &m, PMIX_PROC))) {
             return ret;
         }
         /* unpack key */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             return ret;
         }
         if (NULL == tmp) {
@@ -889,21 +914,22 @@ pmix_status_t pmix20_bfrop_unpack_pdata(pmix_buffer_t *buffer, void *dest,
          * instead of a pointer in this struct, we directly unpack it to
          * avoid the malloc */
          m=1;
-         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].value.type, &m, PMIX_INT))) {
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(regtypes, buffer, &ptr[i].value.type, &m, PMIX_INT))) {
             return ret;
         }
         pmix_output_verbose(20, pmix_bfrops_base_framework.framework_output,
                             "pmix20_bfrop_unpack: pdata type %d", ptr[i].value.type);
         m=1;
-        if (PMIX_SUCCESS != (ret = unpack_val(buffer, &ptr[i].value))) {
+        if (PMIX_SUCCESS != (ret = unpack_val(regtypes, buffer, &ptr[i].value))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_buf(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_buffer_t *ptr;
     int32_t i, n, m;
@@ -916,7 +942,7 @@ pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
     for (i = 0; i < n; ++i) {
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &nbytes, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &nbytes, &m, PMIX_SIZE))) {
             return ret;
         }
         m = nbytes;
@@ -924,7 +950,7 @@ pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
         if (0 < nbytes) {
             ptr[i].base_ptr = (char*)malloc(nbytes);
             /* unpack the bytes */
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(regtypes, buffer, ptr[i].base_ptr, &m, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -936,8 +962,9 @@ pmix_status_t pmix20_bfrop_unpack_buf(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_proc(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_t *ptr;
     int32_t i, n, m;
@@ -957,7 +984,7 @@ pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         /* unpack nspace */
         m=1;
         tmp = NULL;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
             return ret;
         }
         if (NULL == tmp) {
@@ -967,15 +994,16 @@ pmix_status_t pmix20_bfrop_unpack_proc(pmix_buffer_t *buffer, void *dest,
         free(tmp);
         /* unpack the rank */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_rank(buffer, &ptr[i].rank, &m, PMIX_PROC_RANK))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_rank(regtypes, buffer, &ptr[i].rank, &m, PMIX_PROC_RANK))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_app(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_app_t *ptr;
     int32_t i, k, n, m;
@@ -994,19 +1022,19 @@ pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         PMIX_APP_CONSTRUCT(&ptr[i]);
         /* unpack cmd */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &ptr[i].cmd, &m, PMIX_STRING))) {
             return ret;
         }
         /* unpack argc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &nval, &m, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(regtypes, buffer, &nval, &m, PMIX_INT32))) {
             return ret;
         }
         /* unpack argv */
         for (k=0; k < nval; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -1017,13 +1045,13 @@ pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack env */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &nval, &m, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(regtypes, buffer, &nval, &m, PMIX_INT32))) {
             return ret;
         }
         for (k=0; k < nval; k++) {
             m=1;
             tmp = NULL;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &tmp, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &tmp, &m, PMIX_STRING))) {
                 return ret;
             }
             if (NULL == tmp) {
@@ -1034,23 +1062,23 @@ pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
         }
         /* unpack cwd */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].cwd, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &ptr[i].cwd, &m, PMIX_STRING))) {
             return ret;
         }
         /* unpack maxprocs */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int(regtypes, buffer, &ptr[i].maxprocs, &m, PMIX_INT))) {
             return ret;
         }
         /* unpack info array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].ninfo, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].ninfo) {
             PMIX_INFO_CREATE(ptr[i].info, ptr[i].ninfo);
             m = ptr[i].ninfo;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(buffer, ptr[i].info, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(regtypes, buffer, ptr[i].info, &m, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -1058,8 +1086,9 @@ pmix_status_t pmix20_bfrop_unpack_app(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
-                           int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_kval(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_kval_t *ptr;
     int32_t i, n, m;
@@ -1075,7 +1104,7 @@ pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
         PMIX_CONSTRUCT(&ptr[i], pmix_kval_t);
         /* unpack the key */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].key, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &ptr[i].key, &m, PMIX_STRING))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -1083,7 +1112,7 @@ pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
         ptr[i].value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
         /* unpack the value */
         m = 1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(buffer, ptr[i].value, &m, PMIX_VALUE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(regtypes, buffer, ptr[i].value, &m, PMIX_VALUE))) {
             PMIX_ERROR_LOG(ret);
             return ret;
         }
@@ -1091,8 +1120,9 @@ pmix_status_t pmix20_bfrop_unpack_kval(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i, n, m;
@@ -1108,13 +1138,13 @@ pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].blob = (uint8_t*)malloc(ptr[i].size * sizeof(uint8_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].blob, &m, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(regtypes, buffer, ptr[i].blob, &m, PMIX_UINT8))) {
                 return ret;
             }
         }
@@ -1122,38 +1152,44 @@ pmix_status_t pmix20_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_persist(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_persist(pmix_pointer_array_t *regtypes,
+                                          pmix_buffer_t *buffer, void *dest,
+                                          int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_scope(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
                                         int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_unpack_scope(pmix_buffer_t *buffer, void *dest,
+pmix_status_t pmix20_bfrop_unpack_range(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
+{
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
+}
+
+pmix_status_t pmix20_bfrop_unpack_cmd(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
                                       int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_unpack_range(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_pointer_array_t *regtypes,
+                                           pmix_buffer_t *buffer, void *dest,
+                                           int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, PMIX_UINT32);
 }
 
-pmix_status_t pmix20_bfrop_unpack_cmd(pmix_buffer_t *buffer, void *dest,
-                                    int32_t *num_vals, pmix_data_type_t type)
-{
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
-}
-
-pmix_status_t pmix20_bfrop_unpack_infodirs(pmix_buffer_t *buffer, void *dest,
-                                         int32_t *num_vals, pmix_data_type_t type)
-{
-    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
-}
-
-pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
-                         int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_bo(pmix_pointer_array_t *regtypes,
+                                     pmix_buffer_t *buffer, void *dest,
+                                     int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_byte_object_t *ptr;
     int32_t i, n, m;
@@ -1169,13 +1205,13 @@ pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_byte_object_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].bytes = (char*)malloc(ptr[i].size * sizeof(char));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_byte(regtypes, buffer, ptr[i].bytes, &m, PMIX_BYTE))) {
                 return ret;
             }
         }
@@ -1183,26 +1219,29 @@ pmix_status_t pmix20_bfrop_unpack_bo(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_ptr(pmix_buffer_t *buffer, void *dest,
-                          int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_ptr(pmix_pointer_array_t *regtypes,
+                                      pmix_buffer_t *buffer, void *dest,
+                                      int32_t *num_vals, pmix_data_type_t type)
 {
     uint8_t foo=1;
     int32_t cnt=1;
 
     /* it obviously makes no sense to pack a pointer and
      * send it somewhere else, so we just unpack the sentinel */
-    return pmix20_bfrop_unpack_byte(buffer, &foo, &cnt, PMIX_UINT8);
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, &foo, &cnt, PMIX_UINT8);
 }
 
-pmix_status_t pmix20_bfrop_unpack_pstate(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_pstate(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 
-pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_proc_info_t *ptr;
     int32_t i, n, m;
@@ -1218,35 +1257,36 @@ pmix_status_t pmix20_bfrop_unpack_pinfo(pmix_buffer_t *buffer, void *dest,
         PMIX_PROC_INFO_CONSTRUCT(&ptr[i]);
         /* unpack the proc */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(buffer, &ptr[i].proc, &m, PMIX_PROC))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_proc(regtypes, buffer, &ptr[i].proc, &m, PMIX_PROC))) {
             return ret;
         }
         /* unpack the hostname */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].hostname, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &ptr[i].hostname, &m, PMIX_STRING))) {
             return ret;
         }
         /* unpack the executable */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, &ptr[i].executable_name, &m, PMIX_STRING))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, &ptr[i].executable_name, &m, PMIX_STRING))) {
             return ret;
         }
         /* unpack pid */
          m=1;
-         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pid(buffer, &ptr[i].pid, &m, PMIX_PID))) {
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pid(regtypes, buffer, &ptr[i].pid, &m, PMIX_PID))) {
             return ret;
         }
         /* unpack state */
          m=1;
-         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pstate(buffer, &ptr[i].state, &m, PMIX_PROC_STATE))) {
+         if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_pstate(regtypes, buffer, &ptr[i].state, &m, PMIX_PROC_STATE))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_darray(pmix_pointer_array_t *regtypes,
+                                         pmix_buffer_t *buffer, void *dest,
+                                         int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_data_array_t *ptr;
     int32_t i, n, m;
@@ -1263,12 +1303,12 @@ pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_data_array_t));
         /* unpack the type */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_datatype(buffer, &ptr[i].type, &m, PMIX_DATA_TYPE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_datatype(regtypes, buffer, &ptr[i].type, &m, PMIX_DATA_TYPE))) {
             return ret;
         }
         /* unpack the number of array elements */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 == ptr[i].size || PMIX_UNDEF == ptr[i].type) {
@@ -1359,21 +1399,23 @@ pmix_status_t pmix20_bfrop_unpack_darray(pmix_buffer_t *buffer, void *dest,
         if (NULL == (ptr[i].array = malloc(m * nbytes))) {
             return PMIX_ERR_NOMEM;
         }
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(buffer, ptr[i].array, &m, ptr[i].type))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_buffer(regtypes, buffer, ptr[i].array, &m, ptr[i].type))) {
             return ret;
         }
     }
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_rank(pmix_buffer_t *buffer, void *dest,
-                                     int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_rank(pmix_pointer_array_t *regtypes,
+                                       pmix_buffer_t *buffer, void *dest,
+                                       int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_int32(buffer, dest, num_vals, PMIX_UINT32);
+    return pmix20_bfrop_unpack_int32(regtypes, buffer, dest, num_vals, PMIX_UINT32);
 }
 
-pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_query(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_query_t *ptr;
     int32_t i, n, m;
@@ -1390,7 +1432,7 @@ pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
         PMIX_QUERY_CONSTRUCT(&ptr[i]);
         /* unpack the number of keys */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(buffer, &nkeys, &m, PMIX_INT32))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_int32(regtypes, buffer, &nkeys, &m, PMIX_INT32))) {
             return ret;
         }
         if (0 < nkeys) {
@@ -1400,20 +1442,20 @@ pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
             }
             /* unpack keys */
             m=nkeys;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(buffer, ptr[i].keys, &m, PMIX_STRING))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_string(regtypes, buffer, ptr[i].keys, &m, PMIX_STRING))) {
                 return ret;
             }
         }
         /* unpack the number of qualifiers */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].nqual, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].nqual, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].nqual) {
             /* unpack the qualifiers */
             PMIX_INFO_CREATE(ptr[i].qualifiers, ptr[i].nqual);
             m =  ptr[i].nqual;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(buffer, ptr[i].qualifiers, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_info(regtypes, buffer, ptr[i].qualifiers, &m, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -1421,16 +1463,18 @@ pmix_status_t pmix20_bfrop_unpack_query(pmix_buffer_t *buffer, void *dest,
     return PMIX_SUCCESS;
 }
 
-pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_buffer_t *buffer, void *dest,
-                                                int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_alloc_directive(pmix_pointer_array_t *regtypes,
+                                                  pmix_buffer_t *buffer, void *dest,
+                                                  int32_t *num_vals, pmix_data_type_t type)
 {
-    return pmix20_bfrop_unpack_byte(buffer, dest, num_vals, PMIX_UINT8);
+    return pmix20_bfrop_unpack_byte(regtypes, buffer, dest, num_vals, PMIX_UINT8);
 }
 
 
 /**** DEPRECATED ****/
-pmix_status_t pmix20_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
-                                      int32_t *num_vals, pmix_data_type_t type)
+pmix_status_t pmix20_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                        pmix_buffer_t *buffer, void *dest,
+                                        int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
     int32_t i, n, m;
@@ -1448,13 +1492,13 @@ pmix_status_t pmix20_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
         memset(&ptr[i], 0, sizeof(pmix_info_array_t));
         /* unpack the size of this array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix20_bfrop_unpack_value(regtypes, buffer, ptr[i].array, &m, PMIX_INFO))) {
                 return ret;
             }
         }

--- a/src/mca/bfrops/v21/bfrop_pmix21.c
+++ b/src/mca/bfrops/v21/bfrop_pmix21.c
@@ -14,6 +14,8 @@
  * Copyright (c) 2011-2013 Los Alamos National Security, LLC.  All rights
  *                         reserved.
  * Copyright (c) 2013-2018 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2019      Mellanox Technologies, Inc.
+ *                         All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -75,14 +77,18 @@ typedef struct pmix_modex_data {
     size_t size;
 } pmix_modex_data_t;
 
-static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+static pmix_status_t pmix21_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, const void *src,
                                              int32_t num_vals, pmix_data_type_t type);
-static pmix_status_t pmix21_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
+static pmix_status_t pmix21_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, const void *src,
                                     int32_t num_vals, pmix_data_type_t type);
-static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t pmix21_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                               pmix_buffer_t *buffer, void *dest,
                                                int32_t *num_vals, pmix_data_type_t type);
-static pmix_status_t pmix21_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                                       int32_t *num_vals, pmix_data_type_t type);
+static pmix_status_t pmix21_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                               pmix_buffer_t *buffer, void *dest,
+                                               int32_t *num_vals, pmix_data_type_t type);
 static pmix_status_t pmix21_bfrop_copy_array(pmix_info_array_t **dest,
                                              pmix_info_array_t *src,
                                              pmix_data_type_t type);
@@ -479,7 +485,8 @@ static const char* data_type_string(pmix_data_type_t type)
 }
 
 /**** DEPRECATED ****/
-static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *src,
+static pmix_status_t pmix21_bfrop_pack_array(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, const void *src,
                                              int32_t num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
@@ -490,12 +497,12 @@ static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *
 
     for (i = 0; i < num_vals; ++i) {
         /* pack the size */
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             /* pack the values */
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_info(regtypes, buffer, ptr[i].array, ptr[i].size, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -504,8 +511,9 @@ static pmix_status_t pmix21_bfrop_pack_array(pmix_buffer_t *buffer, const void *
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t pmix21_bfrop_pack_modex(pmix_buffer_t *buffer, const void *src,
-                                    int32_t num_vals, pmix_data_type_t type)
+static pmix_status_t pmix21_bfrop_pack_modex(pmix_pointer_array_t *regtypes,
+                                             pmix_buffer_t *buffer, const void *src,
+                                             int32_t num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i;
@@ -514,11 +522,11 @@ static pmix_status_t pmix21_bfrop_pack_modex(pmix_buffer_t *buffer, const void *
     ptr = (pmix_modex_data_t *) src;
 
     for (i = 0; i < num_vals; ++i) {
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(buffer, &ptr[i].size, 1, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_sizet(regtypes, buffer, &ptr[i].size, 1, PMIX_SIZE))) {
             return ret;
         }
         if( 0 < ptr[i].size){
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_pack_byte(regtypes, buffer, ptr[i].blob, ptr[i].size, PMIX_UINT8))) {
                 return ret;
             }
         }
@@ -529,7 +537,8 @@ static pmix_status_t pmix21_bfrop_pack_modex(pmix_buffer_t *buffer, const void *
 /********************/
 
 /**** DEPRECATED ****/
-static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest,
+static pmix_status_t pmix21_bfrop_unpack_array(pmix_pointer_array_t *regtypes,
+                                               pmix_buffer_t *buffer, void *dest,
                                                int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_info_array_t *ptr;
@@ -548,13 +557,15 @@ static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest
         memset(&ptr[i], 0, sizeof(pmix_info_array_t));
         /* unpack the size of this array */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(regtypes, buffer,
+                                                                 &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].array = (pmix_info_t*)malloc(ptr[i].size * sizeof(pmix_info_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(buffer, ptr[i].array, &m, PMIX_INFO))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_value(regtypes, buffer,
+                                                                     ptr[i].array, &m, PMIX_INFO))) {
                 return ret;
             }
         }
@@ -562,8 +573,9 @@ static pmix_status_t pmix21_bfrop_unpack_array(pmix_buffer_t *buffer, void *dest
     return PMIX_SUCCESS;
 }
 
-static pmix_status_t pmix21_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest,
-                            int32_t *num_vals, pmix_data_type_t type)
+static pmix_status_t pmix21_bfrop_unpack_modex(pmix_pointer_array_t *regtypes,
+                                               pmix_buffer_t *buffer, void *dest,
+                                               int32_t *num_vals, pmix_data_type_t type)
 {
     pmix_modex_data_t *ptr;
     int32_t i, n, m;
@@ -579,13 +591,13 @@ static pmix_status_t pmix21_bfrop_unpack_modex(pmix_buffer_t *buffer, void *dest
         memset(&ptr[i], 0, sizeof(pmix_modex_data_t));
         /* unpack the number of bytes */
         m=1;
-        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(buffer, &ptr[i].size, &m, PMIX_SIZE))) {
+        if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_sizet(regtypes, buffer, &ptr[i].size, &m, PMIX_SIZE))) {
             return ret;
         }
         if (0 < ptr[i].size) {
             ptr[i].blob = (uint8_t*)malloc(ptr[i].size * sizeof(uint8_t));
             m=ptr[i].size;
-            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(buffer, ptr[i].blob, &m, PMIX_UINT8))) {
+            if (PMIX_SUCCESS != (ret = pmix_bfrops_base_unpack_byte(regtypes, buffer, ptr[i].blob, &m, PMIX_UINT8))) {
                 return ret;
             }
         }


### PR DESCRIPTION
Corresponds to #1144.
Includes fixes: #1170, #1161, #1155