### PR TITLE
Fix xnspace dmodex and add verbose debug

### DIFF
--- a/src/client/pmix_client_get.c
+++ b/src/client/pmix_client_get.c
@@ -294,6 +294,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
     int32_t cnt;
     pmix_proc_t proc;
     pmix_kval_t *kv;
+    bool diffnspace;
 
     pmix_output_verbose(2, pmix_client_globals.get_output,
                         "pmix: get_nb callback recvd");
@@ -315,6 +316,9 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
         goto done;
     }
 
+    /* check for a different nspace */
+    diffnspace = !PMIX_CHECK_NSPACE(pmix_globals.myid.nspace, proc.nspace);
+
     /* unpack the status */
     cnt = 1;
     PMIX_BFROPS_UNPACK(rc, pmix_client_globals.myserver,
@@ -329,7 +333,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
     if (PMIX_SUCCESS != ret) {
         goto done;
     }
-    if (PMIX_RANK_UNDEF == proc.rank) {
+    if (PMIX_RANK_UNDEF == proc.rank || diffnspace) {
         PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_globals.mypeer, buf);
     } else {
         PMIX_GDS_ACCEPT_KVS_RESP(rc, pmix_client_globals.myserver, buf);
@@ -352,7 +356,7 @@ static void _getnb_cbfunc(struct pmix_peer_t *pr,
             /* fetch the data from server peer module - since it is passing
              * it back to the user, we need a copy of it */
             cb->copy = true;
-            if (PMIX_RANK_UNDEF == proc.rank) {
+            if (PMIX_RANK_UNDEF == proc.rank || diffnspace) {
                 PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, cb);
             } else {
                 PMIX_GDS_FETCH_KV(rc, pmix_client_globals.myserver, cb);

--- a/src/server/pmix_server_get.c
+++ b/src/server/pmix_server_get.c
@@ -206,11 +206,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
     }
 
     pmix_output_verbose(2, pmix_server_globals.get_output,
-                        "%s:%d EXECUTE GET FOR %s:%d ON BEHALF OF %s:%d",
-                        pmix_globals.myid.nspace,
-                        pmix_globals.myid.rank, nspace, rank,
-                        cd->peer->info->pname.nspace,
-                        cd->peer->info->pname.rank);
+                        "%s EXECUTE GET FOR %s:%d ON BEHALF OF %s",
+                        PMIX_NAME_PRINT(&pmix_globals.myid),
+                        nspace, rank,
+                        PMIX_PNAME_PRINT(&cd->peer->info->pname));
 
     /* This call flows upward from a local client If we don't
      * know about this nspace, then it cannot refer to the
@@ -237,6 +236,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
         if (localonly) {
             /* the user doesn't want us to look for the info,
              * so we simply return at this point */
+            pmix_output_verbose(5, pmix_server_globals.get_output,
+                                "%s UNKNOWN NSPACE: LOCAL ONLY - NOT FOUND",
+                                PMIX_NAME_PRINT(&pmix_globals.myid));
             return PMIX_ERR_NOT_FOUND;
         }
         /* this is for an nspace we don't know about yet, so
@@ -254,6 +256,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             return rc;
         }
         if (PMIX_SUCCESS == rc) {
+            pmix_output_verbose(5, pmix_server_globals.get_output,
+                                "%s UNKNOWN NSPACE: DUPLICATE REQUEST - WAITING",
+                                PMIX_NAME_PRINT(&pmix_globals.myid));
             /* if they specified a timeout for this specific
              * request, set it up now */
             if (0 < tv.tv_sec) {
@@ -275,6 +280,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * up on its own, but at worst the direct modex
          * will simply overwrite the info later */
         if (NULL != pmix_host_server.direct_modex) {
+            pmix_output_verbose(5, pmix_server_globals.get_output,
+                                "%s UNKNOWN NSPACE: REQUEST PASSED TO HOST",
+                                PMIX_NAME_PRINT(&pmix_globals.myid));
             rc = pmix_host_server.direct_modex(&lcd->proc, info, ninfo, dmdx_cbfunc, lcd);
             if (PMIX_SUCCESS != rc) {
                 PMIX_INFO_FREE(info, ninfo);
@@ -292,6 +300,9 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
             }
         } else {
         /* if we don't have direct modex feature, just respond with "not found" */
+            pmix_output_verbose(5, pmix_server_globals.get_output,
+                                "%s UNKNOWN NSPACE: NO DMODEX AVAILABLE - NOT FOUND",
+                                PMIX_NAME_PRINT(&pmix_globals.myid));
             PMIX_INFO_FREE(info, ninfo);
             pmix_list_remove_item(&pmix_server_globals.local_reqs, &lcd->super);
             PMIX_RELEASE(lcd);
@@ -305,6 +316,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
      * if the rank is wildcard, or the nspace is different, then
      * they are asking for the job-level info for this nspace - provide it */
     if (PMIX_RANK_WILDCARD == rank || diffnspace) {
+        pmix_output_verbose(5, pmix_server_globals.get_output,
+                            "%s LOOKING FOR %s",
+                            PMIX_NAME_PRINT(&pmix_globals.myid),
+                            diffnspace ? "WILDCARD RANK" : "DIFF NSPACE");
         /* see if we have the job-level info - we won't have it
          * if we have no local procs and haven't already asked
          * for it, so there is no guarantee we have it */
@@ -333,6 +348,10 @@ pmix_status_t pmix_server_get(pmix_buffer_t *buf,
          * simply be added to the cb.kvs list */
         if (PMIX_RANK_WILDCARD != rank) {
             proc.rank = rank;
+            pmix_output_verbose(5, pmix_server_globals.get_output,
+                                "%s GETTING JOB-DATA FOR %s",
+                                PMIX_NAME_PRINT(&pmix_globals.myid),
+                                PMIX_NAME_PRINT(&proc));
             PMIX_GDS_FETCH_KV(rc, pmix_globals.mypeer, &cb);
             if (PMIX_SUCCESS != rc) {
                 PMIX_DESTRUCT(&cb);

--- a/src/util/name_fns.h
+++ b/src/util/name_fns.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2010      Oracle and/or its affiliates.  All rights reserved.
  * Copyright (c) 2014-2016 Research Organization for Information Science
  *                         and Technology (RIST). All rights reserved.
- * Copyright (c) 2018      Intel, Inc. All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
  * $COPYRIGHT$
  *
  * Additional copyrights may follow
@@ -30,6 +30,7 @@
 #endif
 
 #include "pmix_common.h"
+#include "src/include/pmix_globals.h"
 
 BEGIN_C_DECLS
 
@@ -37,6 +38,10 @@ BEGIN_C_DECLS
 PMIX_EXPORT char* pmix_util_print_name_args(const pmix_proc_t *name);
 #define PMIX_NAME_PRINT(n) \
     pmix_util_print_name_args(n)
+
+PMIX_EXPORT char *pmix_util_print_pname_args(const pmix_name_t *name);
+#define PMIX_PNAME_PRINT(n) \
+    pmix_util_print_pname_args(n)
 
 PMIX_EXPORT char* pmix_util_print_rank(const pmix_rank_t vpid);
 #define PMIX_RANK_PRINT(n) \


### PR DESCRIPTION
When we perform a direct modex request for information on a different
nspace, we need to store that info in the hash table. Otherwise, dstore
will simply ignore it. Add some helpful verbose debug as well.

Signed-off-by: Ralph Castain <rhc@pmix.org>