### PR TITLE
Update python darray type to use dictionary

### DIFF
--- a/bindings/python/pmix.pxi
+++ b/bindings/python/pmix.pxi
@@ -569,11 +569,11 @@ cdef int pmix_load_value(pmix_value_t *value, val:dict):
         value[0].data.darray = <pmix_data_array_t*> PyMem_Malloc(sizeof(pmix_data_array_t))
         if not value[0].data.darray:
             return PMIX_ERR_NOMEM
-        value[0].data.darray[0].type = val['value'][0]
-        value[0].data.darray[0].size = len(val['value'][1])
+        value[0].data.darray[0].type = val['value']['type']
+        value[0].data.darray[0].size = len(val['value']['array'])
         try:
             pmix_load_darray(value[0].data.darray, 
-            value[0].data.darray[0].type, val['value'][1])
+            value[0].data.darray[0].type, val['value']['array'])
         except:
             return PMIX_ERR_NOT_SUPPORTED
     elif val['val_type'] == PMIX_ALLOC_DIRECTIVE:

--- a/bindings/python/server.py
+++ b/bindings/python/server.py
@@ -51,7 +51,7 @@ def main():
     # get our environment as a base
     env = os.environ.copy()
     # register an nspace for the client app
-    darray = (PMIX_SIZE, [1, 2, 3, 4, 5])
+    darray = {'type':PMIX_SIZE, 'array':[1, 2, 3, 4, 5]}
     kvals = [{'key':'testkey', 'value':darray, 'val_type':PMIX_DATA_ARRAY}]
     print("REGISTERING NSPACE")
     rc = foo.register_nspace("testnspace", 1, kvals)
@@ -101,9 +101,9 @@ def main():
 
         if stdout_done and stderr_done:
             break
-
     print("FINALIZING")
     foo.finalize()
+
 
 if __name__ == '__main__':
     global killer


### PR DESCRIPTION
Updates python darray to use a dictionary
where it was previously a tuple.

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>