### PR TITLE
Cleanup some Python bindings and update test

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -28,9 +28,15 @@ def main():
     print("Fence result ", rc)
     print("GET")
     info = []
-    rc, get_val = foo.get({'nspace':"testnspace", 'rank':0}, "mykey", info)
+    rc, get_val = foo.get({'nspace':"testnspace", 'rank': 0}, "mykey", info)
     print("Get result: ", rc)
     print("Get value returned: ", get_val)
+    # test a fence that should return not_supported because
+    # we pass a required attribute that doesn't exist
+    procs = []
+    info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
+    rc = foo.fence(procs, info)
+    print("Fence should be not supported", rc)
     # finalize
     info = []
     foo.finalize(info)

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -776,22 +776,19 @@ cdef int fencenb(const pmix_proc_t procs[], size_t nprocs,
                  pmix_modex_cbfunc_t cbfunc, void *cbdata) with gil:
     keys = pmixservermodule.keys()
     if 'fencenb' in keys:
-        args = {}
         myprocs = []
         blist = []
         ilist = []
+        barray = None
         pmix_unload_procs(procs, nprocs, myprocs)
-        args['procs'] = myprocs
         if NULL != info:
             rc = pmix_unload_info(info, ninfo, ilist)
             if PMIX_SUCCESS != rc:
                 return rc
-            args['info'] = ilist
         if NULL != data:
             pmix_unload_bytes(data, ndata, blist)
             barray = bytearray(blist)
-            args['data'] = barray
-        rc = pmixservermodule['fencenb'](args)
+        rc = pmixservermodule['fencenb'](myprocs, ilist, barray)
     else:
         return PMIX_ERR_NOT_SUPPORTED
     # we cannot execute a callback function here as

--- a/bindings/python/server.py
+++ b/bindings/python/server.py
@@ -25,8 +25,21 @@ def clientfinalized(proc:tuple is not None):
     print("CLIENT FINALIZED", proc)
     return PMIX_SUCCESS
 
-def clientfence(args:dict is not None):
-    print("SERVER FENCE", args)
+def clientfence(procs:list, directives:list, data:bytearray):
+    # check directives
+    if directives is not None:
+        for d in directives:
+            # these are each an info dict
+            if "pmix" not in d['key']:
+                # we do not support such directives - see if
+                # it is required
+                try:
+                    if d['flags'] & PMIX_INFO_REQD:
+                        # return an error
+                        return PMIX_ERR_NOT_SUPPORTED
+                except:
+                    #it can be ignored
+                    pass
     return PMIX_SUCCESS
 
 def main():


### PR DESCRIPTION
Bring the server module "fence" function into compliance with the
standard. Update the load/unload functions to fix a couple of places
dealing with pmix_info_t. Add check of unsupported attributes to the
tests.

Signed-off-by: Ralph Castain <rhc@pmix.org>