### PR TITLE
Add Python wrapper for PMIx_Publish

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -37,6 +37,9 @@ def main():
     info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.fence(procs, info)
     print("Fence should be not supported", rc)
+    info = [{'key': 'ARBITRARY', 'flags': None, 'value':10, 'val_type':PMIX_INT}]
+    rc = foo.publish(info)
+    print("Publish result: ", rc)
     # finalize
     info = []
     foo.finalize(info)

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -308,6 +308,41 @@ cdef class PMIxClient:
             pmix_free_info(info, ninfo)
         return rc, val
 
+    # Publish the data in the info array for lookup
+    #
+    # @dicts [INPUT]
+    #          - a list of dictionaries, where
+    #            a key, flags, value, and val_type
+    #            can be defined as keys
+    def publish(self, dicts:list):
+        cdef pmix_info_t *info;
+        cdef size_t ninfo;
+        ninfo = 0
+
+        # convert the list of dictionaries to array of
+        # pmix_info_t structs
+        if dicts is not None:
+            ninfo = len(dicts)
+            if 0 < ninfo:
+                info = <pmix_info_t*> PyMem_Malloc(ninfo * sizeof(pmix_info_t))
+                if not info:
+                    return PMIX_ERR_NOMEM
+                rc = pmix_load_info(info, dicts)
+                if PMIX_SUCCESS != rc:
+                    pmix_free_info(info, ninfo)
+                    return rc
+            else:
+                info = NULL
+        else:
+            info = NULL
+
+        # pass it into the publish API
+        print("PUBLISH")
+        rc = PMIx_Publish(info, ninfo)
+        if 0 < ninfo:
+            pmix_free_info(info, ninfo)
+        return rc
+
 pmixservermodule = {}
 def setmodulefn(k, f):
     global pmixservermodule


### PR DESCRIPTION
Add python wrapper for PMIx_Publish. I am currently getting an error when calling PMIx_Lookup inside of the PMIx_Lookup python wrapper I am currently working on, so I want to get this one submitted and make sure it is correct. When running the python tests the lookup wrapper for python isn't returning a visible error. 

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>