### PR TITLE
Fix python generate_regex function

### DIFF
--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -708,7 +708,7 @@ cdef class PMIxServer(PMIxClient):
             ba = bytearray(regex)
         else:
             # extract the length of the blob
-            length = int(&regex[6]) + 6 + len(&regex[6])
+            length = 5 + len(&regex[5])
             ba = bytearray(length)
             pyregex = <bytes> regex[:length]
             index = 0
@@ -728,7 +728,7 @@ cdef class PMIxServer(PMIxClient):
             ba = bytearray(ppn)
         else:
             # extract the length of the blob
-            length = int(&ppn[6]) + 6 + len(&ppn[6])
+            length = 4 + len(&ppn[4])
             ba = bytearray(length)
             index = 0
             pyppn = <bytes> ppn[:length]

--- a/bindings/python/pmix.pyx
+++ b/bindings/python/pmix.pyx
@@ -704,17 +704,27 @@ cdef class PMIxServer(PMIxClient):
         else:
             pyhosts = hosts
         rc = PMIx_generate_regex(pyhosts, &regex)
-        if "pmix" == regex[:4]:
+        if "pmix" == regex[:4].decode("ascii"):
+            # remove null characters
+            if b'\x00' in regex:
+                regex.replace(b'\x00', '')
             ba = bytearray(regex)
-        else:
-            # extract the length of the blob
-            length = 5 + len(&regex[5])
+        elif "blob" == regex[:4].decode("ascii"):
+            sz_str    = len(regex)
+            sz_prefix = 5
+            # extract length of bytearray
+            regex.split(b'\x00')
+            len_bytearray = regex[1]
+            length = len(len_bytearray) + sz_prefix + sz_str
             ba = bytearray(length)
             pyregex = <bytes> regex[:length]
             index = 0
             while index < length:
                 ba[index] = pyregex[index]
                 index += 1
+        else:
+            # last case with no ':' in string
+            ba = bytearray(regex)
         return (rc, ba)
 
     def generate_ppn(self, procs):
@@ -724,17 +734,26 @@ cdef class PMIxServer(PMIxClient):
         else:
             pyprocs = procs
         rc = PMIx_generate_ppn(pyprocs, &ppn)
-        if "pmix" == ppn[:4]:
+        if "pmix" == ppn[:4].decode("ascii"):
+            if b'\x00' in ppn:
+                ppn.replace(b'\x00', '')
             ba = bytearray(ppn)
-        else:
-            # extract the length of the blob
-            length = 4 + len(&ppn[4])
+        elif "blob" == ppn[:4].decode("ascii"):
+            sz_str    = len(ppn)
+            sz_prefix = 5
+            # extract length of bytearray
+            ppn.split(b'\x00')
+            len_bytearray = ppn[1]
+            length = len(len_bytearray) + sz_prefix + sz_str
             ba = bytearray(length)
             index = 0
             pyppn = <bytes> ppn[:length]
             while index < length:
                 ba[index] = pyppn[index]
                 index += 1
+        else: 
+            # last case with no ':' in string
+            ba = bytearray(ppn)
         return (rc, ba)
 
 cdef int clientconnected(pmix_proc_t *proc, void *server_object,

--- a/bindings/python/sched.py
+++ b/bindings/python/sched.py
@@ -53,9 +53,9 @@ def main():
 
     # setup the application
     (rc, regex) = foo.generate_regex("test000,test001,test002")
-    print("Node regex: ", regex)
+    print("Node regex, rc: ", regex, rc)
     (rc, ppn) = foo.generate_ppn("0,1,2;3,4,5;6,7")
-    print("PPN: ", ppn)
+    print("PPN, rc: ", ppn, rc)
     darray = {'type':PMIX_INFO, 'array':[{'key':PMIX_ALLOC_NETWORK_ID,
                             'value':'SIMPSCHED.net', 'val_type':PMIX_STRING},
                            {'key':PMIX_ALLOC_NETWORK_SEC_KEY, 'value':'T',


### PR DESCRIPTION
The python generate regex function was calcuating the
length of the returned regex from PMIx_generate_regex
incorrectly. It was also indexing into regex with the
incorrect values. This was caused by the recent changes
to what is returned by the PMIx_generate_regex function.

Also, code was never entering this block:

```c
if "pmix" == regex[:4]:
```

Even when it should have, so I think the second commit should fix that, where I convert
the byte literal to ascii. 

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>