### PR TITLE
Add ability to provide custom environments

### DIFF
--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -112,6 +112,9 @@ typedef uint32_t pmix_rank_t;
 /* define a boundary for valid ranks */
 #define PMIX_RANK_VALID         UINT32_MAX-50
 
+/* define a value to indicate that data applies
+ * to all apps in a job */
+#define PMIX_APP_WILDCARD  UINT32_MAX
 
 /****  PMIX ENVIRONMENTAL PARAMETERS  ****/
 /* There are a few environmental parameters used by PMIx for

--- a/src/mca/pmdl/Makefile.am
+++ b/src/mca/pmdl/Makefile.am
@@ -1,0 +1,44 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+AM_CPPFLAGS = $(LTDLINCL)
+
+# main library setup
+noinst_LTLIBRARIES = libmca_pmdl.la
+libmca_pmdl_la_SOURCES =
+
+# local files
+headers = pmdl.h
+sources =
+
+# Conditionally install the header files
+if WANT_INSTALL_HEADERS
+pmixdir = $(pmixincludedir)/$(subdir)
+nobase_pmix_HEADERS = $(headers)
+endif
+
+include base/Makefile.include
+
+libmca_pmdl_la_SOURCES += $(headers) $(sources)
+
+distclean-local:
+	rm -f base/static-components.h

--- a/src/mca/pmdl/base/Makefile.include
+++ b/src/mca/pmdl/base/Makefile.include
@@ -1,0 +1,32 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2016      Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# This makefile.am does not stand on its own - it is included from
+# src/Makefile.am
+
+headers += \
+         base/base.h
+
+sources += \
+        base/pmdl_base_frame.c \
+        base/pmdl_base_select.c \
+        base/pmdl_base_stubs.c

--- a/src/mca/pmdl/base/base.h
+++ b/src/mca/pmdl/base/base.h
@@ -1,0 +1,98 @@
+/* -*- C -*-
+ *
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2006 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015      Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ */
+#ifndef PMIX_PMDL_BASE_H_
+#define PMIX_PMDL_BASE_H_
+
+#include <src/include/pmix_config.h>
+
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h> /* for struct timeval */
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+
+#include "src/mca/pmdl/pmdl.h"
+
+
+BEGIN_C_DECLS
+
+/*
+ * MCA Framework
+ */
+PMIX_EXPORT extern pmix_mca_base_framework_t pmix_pmdl_base_framework;
+/**
+ * PMDL select function
+ *
+ * Cycle across available components and construct the list
+ * of active modules
+ */
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_select(void);
+
+/**
+ * Track an active component / module
+ */
+struct pmix_pmdl_base_active_module_t {
+    pmix_list_item_t super;
+    int pri;
+    pmix_pmdl_module_t *module;
+    pmix_pmdl_base_component_t *component;
+};
+typedef struct pmix_pmdl_base_active_module_t pmix_pmdl_base_active_module_t;
+PMIX_EXPORT PMIX_CLASS_DECLARATION(pmix_pmdl_base_active_module_t);
+
+/* framework globals */
+struct pmix_pmdl_globals_t {
+    pmix_lock_t lock;
+    pmix_list_t actives;
+    bool initialized;
+};
+typedef struct pmix_pmdl_globals_t pmix_pmdl_globals_t;
+
+PMIX_EXPORT extern pmix_pmdl_globals_t pmix_pmdl_globals;
+
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_harvest_envars(char *nspace,
+                                                        pmix_info_t info[], size_t ninfo,
+                                                        pmix_list_t *ilist);
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_setup_nspace(pmix_namespace_t *nptr,
+                                                      uint32_t appnum,
+                                                      pmix_info_t *info);
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_setup_nspace_kv(pmix_namespace_t *nptr,
+                                                         uint32_t appnum,
+                                                         pmix_kval_t *kv);
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_setup_client(pmix_namespace_t *nptr,
+                                                      pmix_rank_t rank,
+                                                      uint32_t appnum);
+PMIX_EXPORT pmix_status_t pmix_pmdl_base_setup_fork(const pmix_proc_t *peer, char ***env);
+PMIX_EXPORT void pmix_pmdl_base_deregister_nspace(const char *nptr);
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pmdl/base/pmdl_base_frame.c
+++ b/src/mca/pmdl/base/pmdl_base_frame.c
@@ -1,0 +1,97 @@
+/* -*- Mode: C; c-basic-offset:4 ; -*- */
+/*
+ * Copyright (c) 2004-2007 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2009 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2012-2013 Los Alamos National Security, Inc.  All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2015-2016 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+/** @file:
+ *
+ */
+#include <src/include/pmix_config.h>
+
+#include <pmix_common.h>
+
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+
+#include "src/class/pmix_list.h"
+#include "src/mca/base/base.h"
+#include "src/mca/pmdl/base/base.h"
+
+/*
+ * The following file was created by configure.  It contains extern
+ * statements and the definition of an array of pointers to each
+ * component's public mca_base_component_t struct.
+ */
+
+#include "src/mca/pmdl/base/static-components.h"
+
+/* Instantiate the global vars */
+pmix_pmdl_globals_t pmix_pmdl_globals = {{0}};
+pmix_pmdl_API_module_t pmix_pmdl = {
+    .harvest_envars = pmix_pmdl_base_harvest_envars,
+    .setup_nspace = pmix_pmdl_base_setup_nspace,
+    .setup_nspace_kv = pmix_pmdl_base_setup_nspace_kv,
+    .setup_client = pmix_pmdl_base_setup_client,
+    .setup_fork = pmix_pmdl_base_setup_fork,
+    .deregister_nspace = pmix_pmdl_base_deregister_nspace
+};
+
+static pmix_status_t pmix_pmdl_close(void)
+{
+  pmix_pmdl_base_active_module_t *active, *prev;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_SUCCESS;
+    }
+    pmix_pmdl_globals.initialized = false;
+
+    PMIX_LIST_FOREACH_SAFE(active, prev, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+      pmix_list_remove_item(&pmix_pmdl_globals.actives, &active->super);
+      if (NULL != active->module->finalize) {
+        active->module->finalize();
+      }
+      PMIX_RELEASE(active);
+    }
+    PMIX_DESTRUCT(&pmix_pmdl_globals.actives);
+
+    PMIX_DESTRUCT_LOCK(&pmix_pmdl_globals.lock);
+    return pmix_mca_base_framework_components_close(&pmix_pmdl_base_framework, NULL);
+}
+
+static pmix_status_t pmix_pmdl_open(pmix_mca_base_open_flag_t flags)
+{
+    /* initialize globals */
+    pmix_pmdl_globals.initialized = true;
+    PMIX_CONSTRUCT_LOCK(&pmix_pmdl_globals.lock);
+    pmix_pmdl_globals.lock.active = false;
+    PMIX_CONSTRUCT(&pmix_pmdl_globals.actives, pmix_list_t);
+
+    /* Open up all available components */
+    return pmix_mca_base_framework_components_open(&pmix_pmdl_base_framework, flags);
+}
+
+PMIX_MCA_BASE_FRAMEWORK_DECLARE(pmix, pmdl, "PMIx Network Operations",
+                                NULL, pmix_pmdl_open, pmix_pmdl_close,
+                                mca_pmdl_base_static_components, 0);
+
+PMIX_CLASS_INSTANCE(pmix_pmdl_base_active_module_t,
+                    pmix_list_item_t,
+                    NULL, NULL);

--- a/src/mca/pmdl/base/pmdl_base_select.c
+++ b/src/mca/pmdl/base/pmdl_base_select.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+#include <pmix_common.h>
+
+#include <string.h>
+
+#include "src/mca/mca.h"
+#include "src/mca/base/base.h"
+
+#include "src/mca/pmdl/base/base.h"
+
+static bool selected = false;
+
+/* Function for selecting a prioritized list of components
+ * from all those that are available. */
+int pmix_pmdl_base_select(void)
+{
+    pmix_mca_base_component_list_item_t *cli = NULL;
+    pmix_mca_base_component_t *component = NULL;
+    pmix_mca_base_module_t *module = NULL;
+    pmix_pmdl_module_t *nmodule;
+    pmix_pmdl_base_active_module_t *newmodule, *mod;
+    int rc, priority;
+    bool inserted;
+
+    if (selected) {
+        /* ensure we don't do this twice */
+        return PMIX_SUCCESS;
+    }
+    selected = true;
+
+    /* Query all available components and ask if they have a module */
+    PMIX_LIST_FOREACH(cli, &pmix_pmdl_base_framework.framework_components, pmix_mca_base_component_list_item_t) {
+        component = (pmix_mca_base_component_t *) cli->cli_component;
+
+        pmix_output_verbose(5, pmix_pmdl_base_framework.framework_output,
+                            "mca:pmdl:select: checking available component %s", component->pmix_mca_component_name);
+
+        /* If there's no query function, skip it */
+        if (NULL == component->pmix_mca_query_component) {
+            pmix_output_verbose(5, pmix_pmdl_base_framework.framework_output,
+                                "mca:pmdl:select: Skipping component [%s]. It does not implement a query function",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* Query the component */
+        pmix_output_verbose(5, pmix_pmdl_base_framework.framework_output,
+                            "mca:pmdl:select: Querying component [%s]",
+                            component->pmix_mca_component_name);
+        rc = component->pmix_mca_query_component(&module, &priority);
+
+        /* If no module was returned, then skip component */
+        if (PMIX_SUCCESS != rc || NULL == module) {
+            pmix_output_verbose(5, pmix_pmdl_base_framework.framework_output,
+                                "mca:pmdl:select: Skipping component [%s]. Query failed to return a module",
+                                component->pmix_mca_component_name );
+            continue;
+        }
+
+        /* If we got a module, keep it */
+        nmodule = (pmix_pmdl_module_t*) module;
+        /* let it initialize */
+        if (NULL != nmodule->init && PMIX_SUCCESS != nmodule->init()) {
+            continue;
+        }
+        /* add to the list of selected modules */
+        newmodule = PMIX_NEW(pmix_pmdl_base_active_module_t);
+        newmodule->pri = priority;
+        newmodule->module = nmodule;
+        newmodule->component = (pmix_pmdl_base_component_t*)cli->cli_component;
+
+        /* maintain priority order */
+        inserted = false;
+        PMIX_LIST_FOREACH(mod, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+            if (priority > mod->pri) {
+                pmix_list_insert_pos(&pmix_pmdl_globals.actives,
+                                     (pmix_list_item_t*)mod, &newmodule->super);
+                inserted = true;
+                break;
+            }
+        }
+        if (!inserted) {
+            /* must be lowest priority - add to end */
+            pmix_list_append(&pmix_pmdl_globals.actives, &newmodule->super);
+        }
+    }
+
+    if (4 < pmix_output_get_verbosity(pmix_pmdl_base_framework.framework_output)) {
+        pmix_output(0, "Final pmdl priorities");
+        /* show the prioritized list */
+        PMIX_LIST_FOREACH(mod, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+            pmix_output(0, "\tpmdl: %s Priority: %d", mod->component->base.pmix_mca_component_name, mod->pri);
+        }
+    }
+
+    return PMIX_SUCCESS;;
+}

--- a/src/mca/pmdl/base/pmdl_base_stubs.c
+++ b/src/mca/pmdl/base/pmdl_base_stubs.c
@@ -1,0 +1,218 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      Mellanox Technologies, Inc.
+ *                         All rights reserved.
+ * Copyright (c) 2018      Research Organization for Information Science
+ *                         and Technology (RIST).  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <pmix_common.h>
+#include "src/include/pmix_globals.h"
+
+#include "src/class/pmix_list.h"
+#include "src/mca/preg/preg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/pmix_environ.h"
+#include "src/server/pmix_server_ops.h"
+
+#include "src/mca/pmdl/base/base.h"
+
+
+pmix_status_t pmix_pmdl_base_harvest_envars(char *nspace,
+                                            pmix_info_t info[], size_t ninfo,
+                                            pmix_list_t *ilist)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_status_t rc;
+    pmix_namespace_t *nptr, *ns;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:harvest envars called");
+
+    /* protect against bozo inputs */
+    if (NULL == nspace || NULL == ilist) {
+        return PMIX_ERR_BAD_PARAM;
+    }
+    nptr = NULL;
+    /* find this nspace - note that it may not have
+     * been registered yet */
+    PMIX_LIST_FOREACH(ns, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (0 == strcmp(ns->nspace, nspace)) {
+            nptr = ns;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        /* add it */
+        nptr = PMIX_NEW(pmix_namespace_t);
+        if (NULL == nptr) {
+            return PMIX_ERR_NOMEM;
+        }
+        nptr->nspace = strdup(nspace);
+        pmix_list_append(&pmix_globals.nspaces, &nptr->super);
+    }
+
+    /* process the request */
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->harvest_envars) {
+            if (PMIX_SUCCESS == (rc = active->module->harvest_envars(nptr, info, ninfo, ilist))) {
+                break;
+            }
+            if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                /* true error */
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_pmdl_base_setup_nspace(pmix_namespace_t *nptr,
+                                          uint32_t appnum,
+                                          pmix_info_t *info)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:setup_nspace called");
+
+    /* process the request */
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->setup_nspace) {
+            if (PMIX_SUCCESS == (rc = active->module->setup_nspace(nptr, appnum, info))) {
+                break;
+            }
+            if (PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                /* true error */
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+pmix_status_t pmix_pmdl_base_setup_nspace_kv(pmix_namespace_t *nptr,
+                                            uint32_t appnum,
+                                            pmix_kval_t *kv)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:setup_nspace called");
+
+    /* process the request */
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->setup_nspace_kv) {
+            rc = active->module->setup_nspace_kv(nptr, appnum, kv);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                /* true error */
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* can only be called by a server */
+pmix_status_t pmix_pmdl_base_setup_client(pmix_namespace_t *nptr,
+                                          pmix_rank_t rank,
+                                          uint32_t appnum)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl: setup_client called");
+
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->setup_client) {
+            rc = active->module->setup_client(nptr, rank, appnum);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                /* true error */
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+/* can only be called by a server */
+pmix_status_t pmix_pmdl_base_setup_fork(const pmix_proc_t *proc, char ***env)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_status_t rc;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return PMIX_ERR_INIT;
+    }
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->setup_fork) {
+            rc = active->module->setup_fork(proc, env);
+            if (PMIX_SUCCESS != rc && PMIX_ERR_TAKE_NEXT_OPTION != rc) {
+                /* true error */
+                return rc;
+            }
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+void pmix_pmdl_base_deregister_nspace(const char *ns)
+{
+    pmix_pmdl_base_active_module_t *active;
+    pmix_namespace_t *nptr, *n2;
+
+    if (!pmix_pmdl_globals.initialized) {
+        return;
+    }
+
+    /* search for the namespace */
+    PMIX_LIST_FOREACH(n2, &pmix_globals.nspaces, pmix_namespace_t) {
+        if (0 == strncmp(ns, n2->nspace, PMIX_MAX_NSLEN)) {
+            nptr = n2;
+            break;
+        }
+    }
+    if (NULL == nptr) {
+        return;
+    }
+
+    PMIX_LIST_FOREACH(active, &pmix_pmdl_globals.actives, pmix_pmdl_base_active_module_t) {
+        if (NULL != active->module->deregister_nspace) {
+            active->module->deregister_nspace(nptr);
+        }
+    }
+}

--- a/src/mca/pmdl/ompi/Makefile.am
+++ b/src/mca/pmdl/ompi/Makefile.am
@@ -1,0 +1,55 @@
+# -*- makefile -*-
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2012      Los Alamos National Security, Inc.  All rights reserved.
+# Copyright (c) 2013-2019 Intel, Inc.  All rights reserved.
+# Copyright (c) 2017      Research Organization for Information Science
+#                         and Technology (RIST). All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+headers = pmdl_ompi.h
+sources = \
+        pmdl_ompi_component.c \
+        pmdl_ompi.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_pmix_pmdl_ompi_DSO
+lib =
+lib_sources =
+component = mca_pmdl_ompi.la
+component_sources = $(headers) $(sources)
+else
+lib = libmca_pmdl_ompi.la
+lib_sources = $(headers) $(sources)
+component =
+component_sources =
+endif
+
+mcacomponentdir = $(pmixlibdir)
+mcacomponent_LTLIBRARIES = $(component)
+mca_pmdl_ompi_la_SOURCES = $(component_sources)
+mca_pmdl_ompi_la_LDFLAGS = -module -avoid-version
+if NEED_LIBPMIX
+mca_pmdl_ompi_la_LIBADD = $(top_builddir)/src/libpmix.la
+endif
+
+noinst_LTLIBRARIES = $(lib)
+libmca_pmdl_ompi_la_SOURCES = $(lib_sources)
+libmca_pmdl_ompi_la_LDFLAGS = -module -avoid-version

--- a/src/mca/pmdl/ompi/pmdl_ompi.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi.c
@@ -1,0 +1,557 @@
+/*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ * Copyright (c) 2016      IBM Corporation.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include <src/include/pmix_config.h>
+
+#include <string.h>
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#include <time.h>
+
+#include <pmix.h>
+
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/include/pmix_socket_errno.h"
+#include "src/include/pmix_globals.h"
+#include "src/class/pmix_list.h"
+#include "src/class/pmix_pointer_array.h"
+#include "src/util/alfg.h"
+#include "src/util/argv.h"
+#include "src/util/error.h"
+#include "src/util/name_fns.h"
+#include "src/util/output.h"
+#include "src/util/pmix_environ.h"
+#include "src/mca/preg/preg.h"
+
+#include "src/mca/pmdl/pmdl.h"
+#include "src/mca/pmdl/base/base.h"
+#include "pmdl_ompi.h"
+
+static pmix_status_t ompi_init(void);
+static void ompi_finalize(void);
+static pmix_status_t harvest_envars(pmix_namespace_t *nptr,
+                                    pmix_info_t info[], size_t ninfo,
+                                    pmix_list_t *ilist);
+static pmix_status_t setup_nspace(pmix_namespace_t *nptr,
+                                  uint32_t appnum,
+                                  pmix_info_t *info);
+static pmix_status_t setup_nspace_kv(pmix_namespace_t *nptr,
+                                     uint32_t appnum,
+                                     pmix_kval_t *kv);
+static pmix_status_t setup_client(pmix_namespace_t *nptr,
+                                  pmix_rank_t rank,
+                                  uint32_t appnum);
+static pmix_status_t setup_fork(const pmix_proc_t *proc,
+                                char ***env);
+static void deregister_nspace(pmix_namespace_t *nptr);
+pmix_pmdl_module_t pmix_pmdl_ompi_module = {
+    .name = "ompi",
+    .init = ompi_init,
+    .finalize = ompi_finalize,
+    .harvest_envars = harvest_envars,
+    .setup_nspace = setup_nspace,
+    .setup_nspace_kv = setup_nspace_kv,
+    .setup_client = setup_client,
+    .setup_fork = setup_fork,
+    .deregister_nspace = deregister_nspace
+};
+
+/* internal structures */
+typedef struct {
+	pmix_list_item_t super;
+	bool ompi;
+	uint32_t appnum;
+	pmix_rank_t start;
+	pmix_rank_t end;
+	uint32_t num_procs;
+} pmdl_app_t;
+static void apcon(pmdl_app_t *p)
+{
+	p->ompi = false;
+	p->appnum = 0;
+	p->start = UINT32_MAX;
+	p->end = 0;
+	p->num_procs = 0;
+}
+static PMIX_CLASS_INSTANCE(pmdl_app_t,
+						   pmix_list_item_t,
+						   apcon, NULL);
+
+typedef struct {
+	pmix_list_item_t super;
+	pmix_nspace_t nspace;
+    bool ompi;
+	bool datacollected;
+	uint32_t univ_size;
+	uint32_t job_size;
+	uint32_t local_size;
+	uint32_t num_apps;
+	pmix_list_t apps;
+} pmdl_nspace_t;
+static void nscon(pmdl_nspace_t *p)
+{
+    p->ompi = false;
+	p->datacollected = false;
+	p->univ_size = 0;
+	p->job_size = 0;
+	p->local_size = 0;
+	p->num_apps = 0;
+	PMIX_CONSTRUCT(&p->apps, pmix_list_t);
+}
+static void nsdes(pmdl_nspace_t *p)
+{
+	PMIX_LIST_DESTRUCT(&p->apps);
+}
+static PMIX_CLASS_INSTANCE(pmdl_nspace_t,
+						   pmix_list_item_t,
+						   nscon, nsdes);
+
+/* internal variables */
+static pmix_list_t mynspaces;
+
+static pmix_status_t ompi_init(void)
+{
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl: ompi init");
+
+    PMIX_CONSTRUCT(&mynspaces, pmix_list_t);
+
+    return PMIX_SUCCESS;
+}
+
+static void ompi_finalize(void)
+{
+    PMIX_LIST_DESTRUCT(&mynspaces);
+}
+
+static pmix_status_t harvest_envars(pmix_namespace_t *nptr,
+                                    pmix_info_t info[], size_t ninfo,
+                                    pmix_list_t *ilist)
+{
+    char *cs_env, *string_key;
+    pmix_kval_t *kv;
+    size_t n;
+    pmdl_nspace_t *ns, *ns2;
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi:harvest envars");
+
+    /* see if we already have this nspace */
+    ns = NULL;
+    PMIX_LIST_FOREACH(ns2, &mynspaces, pmdl_nspace_t) {
+        if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
+            ns = ns2;
+            break;
+        }
+    }
+    if (NULL == ns) {
+        ns = PMIX_NEW(pmdl_nspace_t);
+        PMIX_LOAD_NSPACE(ns->nspace, nptr->nspace);
+        pmix_list_append(&mynspaces, &ns->super);
+        /* check the directives */
+        for (n=0; n < ninfo; n++) {
+            /* check the attribute */
+            if (PMIX_CHECK_KEY(&info[n], PMIX_PROGRAMMING_MODEL)) {
+                if (0 == strcasecmp(info->value.data.string, "ompi")) {
+                    ns->ompi = true;
+                    break;
+                }
+            }
+        }
+    }
+    if (!ns->ompi) {
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+    /* OMPI forwards everything that starts with OMPI_ */
+    for (n=0; NULL != environ[n]; n++) {
+        if (0 == strncmp(environ[n], "OMPI_", 5)) {
+            cs_env = strdup(environ[n]);
+            kv = PMIX_NEW(pmix_kval_t);
+            if (NULL == kv) {
+                free(cs_env);
+                return PMIX_ERR_OUT_OF_RESOURCE;
+            }
+            kv->key = strdup(PMIX_SET_ENVAR);
+            kv->value = (pmix_value_t*)malloc(sizeof(pmix_value_t));
+            if (NULL == kv->value) {
+                PMIX_RELEASE(kv);
+                free(cs_env);
+                return PMIX_ERR_OUT_OF_RESOURCE;
+            }
+            kv->value->type = PMIX_ENVAR;
+            string_key = strchr(cs_env, '=');
+            if (NULL == string_key) {
+                free(cs_env);
+                PMIX_RELEASE(kv);
+                return PMIX_ERR_BAD_PARAM;
+            }
+            *string_key = '\0';
+            ++string_key;
+            pmix_output_verbose(5, pmix_pmdl_base_framework.framework_output,
+                                "pmdl:ompi: adding envar %s", cs_env);
+            PMIX_ENVAR_LOAD(&kv->value->data.envar, cs_env, string_key, ':');
+            pmix_list_append(ilist, &kv->super);
+            free(cs_env);
+        }
+    }
+
+    return PMIX_SUCCESS;
+}
+
+
+static pmix_status_t setup_nspace(pmix_namespace_t *nptr,
+                                  uint32_t appnum,
+                                  pmix_info_t *info)
+{
+	pmdl_nspace_t *ns, *ns2;
+	pmdl_app_t *ap, *ap2;
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi: setup nspace for app %u with %s",
+                        appnum, info->value.data.string);
+
+	/* see if we already have this nspace */
+	ns = NULL;
+	PMIX_LIST_FOREACH(ns2, &mynspaces, pmdl_nspace_t) {
+		if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
+			ns = ns2;
+			break;
+		}
+	}
+	if (NULL == ns) {
+		ns = PMIX_NEW(pmdl_nspace_t);
+		PMIX_LOAD_NSPACE(ns->nspace, nptr->nspace);
+		pmix_list_append(&mynspaces, &ns->super);
+	}
+	/* see if we have this appnum yet */
+	ap = NULL;
+	PMIX_LIST_FOREACH(ap2, &ns->apps, pmdl_app_t) {
+		if (ap2->appnum == appnum) {
+			ap = ap2;
+			break;
+		}
+	}
+	if (NULL == ap) {
+		ap = PMIX_NEW(pmdl_app_t);
+		ap->appnum = appnum;
+		pmix_list_append(&ns->apps, &ap->super);
+	}
+	/* check the attribute */
+	if (PMIX_CHECK_KEY(info, PMIX_PROGRAMMING_MODEL)) {
+		if (0 == strcasecmp(info->value.data.string, "ompi")) {
+			ap->ompi = true;
+            ns->ompi = true;  // flag that at least one app is ompi
+		}
+	}
+	/* we don't care about the rest of the possible values */
+	return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_nspace_kv(pmix_namespace_t *nptr,
+                                     uint32_t appnum,
+                                     pmix_kval_t *kv)
+{
+	pmdl_nspace_t *ns, *ns2;
+	pmdl_app_t *ap, *ap2;
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi: setup nspace_kv with %s", kv->value->data.string);
+
+	/* see if we already have this nspace */
+	ns = NULL;
+	PMIX_LIST_FOREACH(ns2, &mynspaces, pmdl_nspace_t) {
+		if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
+			ns = ns2;
+			break;
+		}
+	}
+	if (NULL == ns) {
+		ns = PMIX_NEW(pmdl_nspace_t);
+		PMIX_LOAD_NSPACE(ns->nspace, nptr->nspace);
+		pmix_list_append(&mynspaces, &ns->super);
+	}
+	/* see if we have this appnum yet */
+	ap = NULL;
+	PMIX_LIST_FOREACH(ap2, &ns->apps, pmdl_app_t) {
+		if (ap2->appnum == appnum) {
+			ap = ap2;
+			break;
+		}
+	}
+	if (NULL == ap) {
+		ap = PMIX_NEW(pmdl_app_t);
+		ap->appnum = appnum;
+		pmix_list_append(&ns->apps, &ap->super);
+	}
+	/* check the attribute */
+	if (PMIX_CHECK_KEY(kv, PMIX_PROGRAMMING_MODEL)) {
+		if (0 == strcasecmp(kv->value->data.string, "ompi")) {
+			ap->ompi = true;
+            ns->ompi = true;  // flag that at least one app is ompi
+		}
+	}
+	/* we don't care about the rest of the possible values */
+	return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_client(pmix_namespace_t *nptr,
+                                  pmix_rank_t rank,
+                                  uint32_t appnum)
+{
+	pmdl_nspace_t *ns, *ns2;
+	pmdl_app_t *ap, *ap2;
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi: setup client with %s", PMIX_RANK_PRINT(rank));
+
+	/* see if we already have this nspace */
+	ns = NULL;
+	PMIX_LIST_FOREACH(ns2, &mynspaces, pmdl_nspace_t) {
+		if (PMIX_CHECK_NSPACE(ns2->nspace, nptr->nspace)) {
+			ns = ns2;
+			break;
+		}
+	}
+	if (NULL == ns) {
+		ns = PMIX_NEW(pmdl_nspace_t);
+		PMIX_LOAD_NSPACE(ns->nspace, nptr->nspace);
+		pmix_list_append(&mynspaces, &ns->super);
+	}
+	/* see if we have this appnum yet */
+	ap = NULL;
+	PMIX_LIST_FOREACH(ap2, &ns->apps, pmdl_app_t) {
+		if (ap2->appnum == appnum) {
+			ap = ap2;
+			break;
+		}
+	}
+	if (NULL == ap) {
+		ap = PMIX_NEW(pmdl_app_t);
+		ap->appnum = appnum;
+		pmix_list_append(&ns->apps, &ap->super);
+	}
+	/* adjust the ranks as necessary */
+	if (rank < ap->start) {
+		ap->start = rank;
+	}
+	if (rank > ap->end) {
+		ap->end = rank;
+	}
+	return PMIX_SUCCESS;
+}
+
+static pmix_status_t setup_fork(const pmix_proc_t *proc,
+                                char ***env)
+{
+	pmdl_nspace_t *ns, *ns2;
+	pmdl_app_t *ap, *ap2;
+	char *param;
+	pmix_proc_t wildcard, undef;
+	pmix_status_t rc;
+	pmix_value_t *val;
+	pmix_info_t info[2];
+	uint16_t u16;
+
+    pmix_output_verbose(2, pmix_pmdl_base_framework.framework_output,
+                        "pmdl:ompi: setup fork for %s", PMIX_NAME_PRINT(proc));
+
+	/* see if we already have this nspace */
+	ns = NULL;
+	PMIX_LIST_FOREACH(ns2, &mynspaces, pmdl_nspace_t) {
+		if (PMIX_CHECK_NSPACE(ns2->nspace, proc->nspace)) {
+			ns = ns2;
+			break;
+		}
+	}
+	if (NULL == ns || !ns->ompi) {
+		/* we don't know anything about this one or
+         * it doesn't have any ompi-based apps */
+		return PMIX_ERR_TAKE_NEXT_OPTION;
+	}
+	/* see if we have this rank */
+	ap = NULL;
+	PMIX_LIST_FOREACH(ap2, &ns->apps, pmdl_app_t) {
+		if (proc->rank >= ap2->start &&
+			proc->rank <= ap2->end) {
+			ap = ap2;
+			break;
+		}
+	}
+    if (NULL != ap && !ap->ompi) {
+        /* not an OMPI app */
+        return PMIX_ERR_TAKE_NEXT_OPTION;
+    }
+
+	/* do we already have the data we need here? */
+	if (!ns->datacollected) {
+	    (void)strncpy(wildcard.nspace, proc->nspace, PMIX_MAX_NSLEN);
+	    wildcard.rank = PMIX_RANK_WILDCARD;
+	    (void)strncpy(undef.nspace, proc->nspace, PMIX_MAX_NSLEN);
+	    undef.rank = PMIX_RANK_UNDEF;
+
+		/* fetch the universe size */
+	    if (PMIX_SUCCESS == (rc = PMIx_Get(&wildcard, PMIX_UNIV_SIZE, NULL, 0, &val))) {
+            PMIX_VALUE_GET_NUMBER(rc, val, ns->univ_size, uint32_t);
+            PMIX_VALUE_RELEASE(val);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+	    }
+		/* fetch the job size */
+	    if (PMIX_SUCCESS == (rc = PMIx_Get(&wildcard, PMIX_JOB_SIZE, NULL, 0, &val))) {
+            PMIX_VALUE_GET_NUMBER(rc, val, ns->job_size, uint32_t);
+            PMIX_VALUE_RELEASE(val);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+	    }
+		/* fetch the number of local procs */
+	    if (PMIX_SUCCESS == (rc = PMIx_Get(&wildcard, PMIX_LOCAL_SIZE, NULL, 0, &val))) {
+            PMIX_VALUE_GET_NUMBER(rc, val, ns->local_size, uint32_t);
+            PMIX_VALUE_RELEASE(val);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+	    }
+		/* fetch the number of apps */
+	    if (PMIX_SUCCESS == (rc = PMIx_Get(&wildcard, PMIX_JOB_NUM_APPS, NULL, 0, &val))) {
+            PMIX_VALUE_GET_NUMBER(rc, val, ns->num_apps, uint32_t);
+            PMIX_VALUE_RELEASE(val);
+            if (PMIX_SUCCESS != rc) {
+                return rc;
+            }
+	    }
+        if (NULL != ap) {
+    		/* fetch the number of procs in this app */
+    		PMIX_INFO_LOAD(&info[0], PMIX_APP_INFO, NULL, PMIX_BOOL);
+    		PMIX_INFO_LOAD(&info[1], PMIX_APPNUM, &ap->appnum, PMIX_UINT32);
+    	    if (PMIX_SUCCESS == (rc = PMIx_Get(&undef, PMIX_APP_SIZE, info, 2, &val))) {
+                PMIX_VALUE_GET_NUMBER(rc, val, ap->num_procs, uint32_t);
+                PMIX_VALUE_RELEASE(val);
+                if (PMIX_SUCCESS != rc) {
+                    PMIX_INFO_DESTRUCT(&info[0]);
+                    PMIX_INFO_DESTRUCT(&info[1]);
+                    return rc;
+                }
+    	    }
+    	    PMIX_INFO_DESTRUCT(&info[0]);
+    	    PMIX_INFO_DESTRUCT(&info[1]);
+        }
+	}
+
+    if (UINT32_MAX != ns->univ_size) {
+        if (0 > asprintf(&param, "%u", ns->univ_size)) {
+        	return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_UNIVERSE_SIZE", param, true, env);
+        free(param);
+    }
+
+    if (UINT32_MAX != ns->job_size) {
+        if (0 > asprintf(&param, "%u", ns->job_size)) {
+        	return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_COMM_WORLD_SIZE", param, true, env);
+        free(param);
+    }
+
+    if (UINT32_MAX != ns->local_size) {
+        if (0 > asprintf(&param, "%u", ns->local_size)) {
+        	return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_COMM_WORLD_LOCAL_SIZE", param, true, env);
+        free(param);
+    }
+
+    /* add the MPI-3 envars */
+    if (UINT32_MAX != ns->num_apps) {
+        if (0 > asprintf(&param, "%u", ns->num_apps)) {
+        	return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_NUM_APP_CTX", param, true, env);
+        free(param);
+    }
+
+    if (NULL != ap && UINT32_MAX != ap->num_procs) {
+        if (0 > asprintf(&param, "%u", ap->num_procs)) {
+        	return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_APP_CTX_NUM_PROCS", param, true, env);
+        free(param);
+    }
+
+    if (0 > asprintf(&param, "%lu", (unsigned long)proc->rank)) {
+    	return PMIX_ERR_NOMEM;
+    }
+    pmix_setenv("OMPI_COMM_WORLD_RANK", param, true, env);
+    free(param);  /* done with this now */
+
+    /* get the proc's local rank */
+    if (PMIX_SUCCESS == (rc = PMIx_Get(proc, PMIX_LOCAL_RANK, NULL, 0, &val))) {
+        PMIX_VALUE_GET_NUMBER(rc, val, u16, uint16_t);
+        PMIX_VALUE_RELEASE(val);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        if (0 > asprintf(&param, "%lu", (unsigned long)u16)) {
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_COMM_WORLD_LOCAL_RANK", param, true, env);
+        free(param);
+    }
+
+    /* get the proc's node rank */
+    if (PMIX_SUCCESS == (rc = PMIx_Get(proc, PMIX_NODE_RANK, NULL, 0, &val))) {
+        PMIX_VALUE_GET_NUMBER(rc, val, u16, uint16_t);
+        PMIX_VALUE_RELEASE(val);
+        if (PMIX_SUCCESS != rc) {
+            return rc;
+        }
+        if (0 > asprintf(&param, "%lu", (unsigned long)u16)) {
+            return PMIX_ERR_NOMEM;
+        }
+        pmix_setenv("OMPI_COMM_WORLD_NODE_RANK", param, true, env);
+        free(param);
+    }
+
+    /* pass an envar so the proc can find any files it had prepositioned */
+    if (PMIX_SUCCESS == (rc = PMIx_Get(proc, PMIX_PROCDIR, NULL, 0, &val))) {
+        pmix_setenv("OMPI_FILE_LOCATION", val->data.string, true, env);
+        PMIX_VALUE_RELEASE(val);
+    }
+
+    return PMIX_SUCCESS;
+}
+
+static void deregister_nspace(pmix_namespace_t *nptr)
+{
+	pmdl_nspace_t *ns;
+
+	/* find our tracker for this nspace */
+	PMIX_LIST_FOREACH(ns, &mynspaces, pmdl_nspace_t) {
+		if (PMIX_CHECK_NSPACE(ns->nspace, nptr->nspace)) {
+			pmix_list_remove_item(&mynspaces, &ns->super);
+			PMIX_RELEASE(ns);
+			return;
+		}
+	}
+}

--- a/src/mca/pmdl/ompi/pmdl_ompi.h
+++ b/src/mca/pmdl/ompi/pmdl_ompi.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2015-2019 Intel, Inc.  All rights reserved.
+ *
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef PMIX_PMDL_ompi_H
+#define PMIX_PMDL_ompi_H
+
+#include <src/include/pmix_config.h>
+
+
+#include "src/mca/pmdl/pmdl.h"
+
+BEGIN_C_DECLS
+
+/* the component must be visible data for the linker to find it */
+PMIX_EXPORT extern pmix_pmdl_base_component_t mca_pmdl_ompi_component;
+extern pmix_pmdl_module_t pmix_pmdl_ompi_module;
+
+END_C_DECLS
+
+#endif

--- a/src/mca/pmdl/ompi/pmdl_ompi_component.c
+++ b/src/mca/pmdl/ompi/pmdl_ompi_component.c
@@ -1,0 +1,66 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2004-2008 The Trustees of Indiana University and Indiana
+ *                         University Research and Technology
+ *                         Corporation.  All rights reserved.
+ * Copyright (c) 2004-2005 The University of Tennessee and The University
+ *                         of Tennessee Research Foundation.  All rights
+ *                         reserved.
+ * Copyright (c) 2004-2005 High Performance Computing Center Stuttgart,
+ *                         University of Stuttgart.  All rights reserved.
+ * Copyright (c) 2004-2005 The Regents of the University of California.
+ *                         All rights reserved.
+ * Copyright (c) 2015      Los Alamos National Security, LLC. All rights
+ *                         reserved.
+ * Copyright (c) 2016-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ *
+ * These symbols are in a file by themselves to provide nice linker
+ * semantics.  Since linkers generally pull in symbols by object
+ * files, keeping these symbols as the only symbols in this file
+ * prevents utility programs such as "ompi_info" from having to import
+ * entire components just to query their version and parameters.
+ */
+
+#include <src/include/pmix_config.h>
+#include "pmix_common.h"
+
+#include "src/mca/pmdl/pmdl.h"
+#include "pmdl_ompi.h"
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority);
+
+/*
+ * Instantiate the public struct with all of our public information
+ * and pointers to our public functions in it
+ */
+pmix_pmdl_base_component_t mca_pmdl_ompi_component = {
+    .base = {
+        PMIX_PMDL_BASE_VERSION_1_0_0,
+
+        /* Component name and version */
+        .pmix_mca_component_name = "ompi",
+        PMIX_MCA_BASE_MAKE_VERSION(component,
+                                   PMIX_MAJOR_VERSION,
+                                   PMIX_MINOR_VERSION,
+                                   PMIX_RELEASE_VERSION),
+
+        /* Component open and close functions */
+        .pmix_mca_query_component = component_query,
+    },
+    .data = {
+        /* The component is checkpoint ready */
+        PMIX_MCA_BASE_METADATA_PARAM_CHECKPOINT
+    }
+};
+
+static pmix_status_t component_query(pmix_mca_base_module_t **module, int *priority)
+{
+    *priority = 50;
+    *module = (pmix_mca_base_module_t *)&pmix_pmdl_ompi_module;
+    return PMIX_SUCCESS;
+}

--- a/src/mca/pmdl/pmdl.h
+++ b/src/mca/pmdl/pmdl.h
@@ -1,0 +1,143 @@
+/* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
+/*
+ * Copyright (c) 2007-2008 Cisco Systems, Inc.  All rights reserved.
+ *
+ * Copyright (c) 2015-2018 Research Organization for Information Science
+ *                         and Technology (RIST). All rights reserved.
+ * Copyright (c) 2018-2019 Intel, Inc.  All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+/**
+ * @file
+ *
+ * This interface is for use by PMIx servers to obtain network-related info
+ * such as security keys that need to be shared across applications, and to
+ * setup network support for applications prior to launch
+ *
+ * Available plugins may be defined at runtime via the typical MCA parameter
+ * syntax.
+ */
+
+#ifndef PMIX_PMDL_H
+#define PMIX_PMDL_H
+
+#include <src/include/pmix_config.h>
+#include <pmix_sched.h>
+
+#include "src/class/pmix_list.h"
+#include "src/mca/mca.h"
+#include "src/mca/base/pmix_mca_base_var.h"
+#include "src/mca/base/pmix_mca_base_framework.h"
+#include "src/include/pmix_globals.h"
+#include "src/server/pmix_server_ops.h"
+
+BEGIN_C_DECLS
+
+/******    MODULE DEFINITION    ******/
+
+/**
+ * Initialize the module. Returns an error if the module cannot
+ * run, success if it can and wants to be used.
+ */
+typedef pmix_status_t (*pmix_pmdl_base_module_init_fn_t)(void);
+
+/**
+ * Finalize the module. Tear down any allocated storage, disconnect
+ * from any system support (e.g., LDAP server)
+ */
+typedef void (*pmix_pmdl_base_module_fini_fn_t)(void);
+
+/* Harvest envars for this programming model so they can be forwarded
+ * to backend processes */
+typedef pmix_status_t (*pmix_pmdl_base_module_harvest_envars_fn_t)(pmix_namespace_t *nptr,
+                                                                   pmix_info_t info[], size_t ninfo,
+                                                                   pmix_list_t *ilist);
+/**
+ * Setup any programming model specific support for the given nspace
+ */
+typedef pmix_status_t (*pmix_pmdl_base_module_setup_ns_fn_t)(pmix_namespace_t *nptr,
+                                                             uint32_t appnum,
+                                                             pmix_info_t *info);
+typedef pmix_status_t (*pmix_pmdl_base_module_setup_ns_kv_fn_t)(pmix_namespace_t *nptr,
+                                                                uint32_t appnum,
+                                                                pmix_kval_t *kv);
+
+/**
+ * Setup any programming model specific support for the given client */
+typedef pmix_status_t (*pmix_pmdl_base_module_setup_client_fn_t)(pmix_namespace_t *nptr,
+                                                                 pmix_rank_t rank,
+                                                                 uint32_t apppnum);
+
+/**
+ * Give the plugins an opportunity to add any envars to the
+ * environment of a local application process prior to fork/exec
+ */
+typedef pmix_status_t (*pmix_pmdl_base_module_setup_fork_fn_t)(const pmix_proc_t *peer, char ***env);
+
+/**
+ * Provide an opportunity for the fabric components to cleanup any
+ * resources they may have created to track the nspace
+ */
+typedef void (*pmix_pmdl_base_module_dregister_nspace_fn_t)(pmix_namespace_t *nptr);
+
+/**
+ * Base structure for a PMDL module. Each component should malloc a
+ * copy of the module structure for each fabric plane they support.
+ */
+typedef struct {
+    char *name;
+    pmix_pmdl_base_module_init_fn_t                 init;
+    pmix_pmdl_base_module_fini_fn_t                 finalize;
+    pmix_pmdl_base_module_harvest_envars_fn_t       harvest_envars;
+    pmix_pmdl_base_module_setup_ns_fn_t             setup_nspace;
+    pmix_pmdl_base_module_setup_ns_kv_fn_t          setup_nspace_kv;
+    pmix_pmdl_base_module_setup_client_fn_t         setup_client;
+    pmix_pmdl_base_module_setup_fork_fn_t           setup_fork;
+    pmix_pmdl_base_module_dregister_nspace_fn_t     deregister_nspace;
+} pmix_pmdl_module_t;
+
+/* define a public API */
+
+typedef pmix_status_t (*pmix_pmdl_base_API_harvest_envars_fn_t)(char *nspace,
+                                                                pmix_info_t info[], size_t ninfo,
+                                                                pmix_list_t *ilist);
+typedef void (*pmix_pmdl_base_API_dregister_nspace_fn_t)(const char *nptr);
+typedef struct {
+    char *name;
+    pmix_pmdl_base_module_init_fn_t                 init;
+    pmix_pmdl_base_module_fini_fn_t                 finalize;
+    pmix_pmdl_base_API_harvest_envars_fn_t          harvest_envars;
+    pmix_pmdl_base_module_setup_ns_fn_t             setup_nspace;
+    pmix_pmdl_base_module_setup_ns_kv_fn_t          setup_nspace_kv;
+    pmix_pmdl_base_module_setup_client_fn_t         setup_client;
+    pmix_pmdl_base_module_setup_fork_fn_t           setup_fork;
+    pmix_pmdl_base_API_dregister_nspace_fn_t        deregister_nspace;
+} pmix_pmdl_API_module_t;
+
+
+/* declare the global APIs */
+PMIX_EXPORT extern pmix_pmdl_API_module_t pmix_pmdl;
+
+/*
+ * the standard component data structure
+ */
+struct pmix_pmdl_base_component_t {
+    pmix_mca_base_component_t                        base;
+    pmix_mca_base_component_data_t                   data;
+};
+typedef struct pmix_pmdl_base_component_t pmix_pmdl_base_component_t;
+
+/*
+ * Macro for use in components that are of type pmdl
+ */
+#define PMIX_PMDL_BASE_VERSION_1_0_0 \
+    PMIX_MCA_BASE_VERSION_1_0_0("pmdl", 1, 0, 0)
+
+END_C_DECLS
+
+#endif


### PR DESCRIPTION
Programming models often like to provide their applications with custom
environmental variables to help guide their execution. Making every
resource manager wishing to support direct launch of such apps write
their own code to provide those envars is burdensome, which means users
cannot rely on their presence.

Provide a mechanism by which programming models that want to can
contribute a plugin that allows any PMIx-enabled RM to supply the custom
environment without generating their own code, and can forward
model-specific envars from frontend to backend.

Signed-off-by: Ralph Castain <rhc@pmix.org>