### PR TITLE
Update blocking APIs to match standard

### DIFF
--- a/include/pmix.h
+++ b/include/pmix.h
@@ -576,8 +576,10 @@ PMIX_EXPORT pmix_status_t PMIx_Process_monitor_nb(const pmix_info_t *monitor, pm
  * will _not_ be called in such cases.
  */
 PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
-                                              pmix_credential_cbfunc_t cbfunc, void *cbdata);
+                                              pmix_byte_object_t *credential);
 
+PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_t ninfo,
+                                                 pmix_credential_cbfunc_t cbfunc, void *cbdata);
 
 /* Request validation of a credential by the PMIx server/SMS
  * Input values include:
@@ -610,7 +612,11 @@ PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t n
  */
 PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
                                                    const pmix_info_t info[], size_t ninfo,
-                                                   pmix_validation_cbfunc_t cbfunc, void *cbdata);
+                                                   pmix_info_t **results, size_t *nresults);
+
+PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *cred,
+                                                      const pmix_info_t info[], size_t ninfo,
+                                                      pmix_validation_cbfunc_t cbfunc, void *cbdata);
 
 /* Define a callback function for delivering forwarded IO to a process
  * This function will be called whenever data becomes available, or a
@@ -666,6 +672,11 @@ PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cre
  *             a non-success error if the registration cannot
  *             be submitted - in this case, the regcbfunc
  *             will _not_ be called.
+ *             If regcbfunc is NULL, then this will be treated
+ *             as a BLOCKING call - a positive return value
+ *             represents the reference ID for the request,
+ *             while negative values indicate the corresponding
+ *             error
  *
  * cbdata - pointer to object to be returned in regcbfunc
  */
@@ -688,7 +699,9 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
  * cbfunc - function to be called when deregistration has
  *          been completed. Note that any IO to be flushed
  *          may continue to be received after deregistration
- *          has completed.
+ *          has completed. If cbfunc is NULL, then this is
+ *          treated as a BLOCKING call and the result of
+ *          the operation will be provided in the returned status
  *
  * cbdata - pointer to object to be returned in cbfunc
  */
@@ -715,7 +728,10 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_deregister(size_t iofhdlr,
  *
  * bo - pointer to a byte object containing the stdin data
  *
- * cbfunc - callback function when the data has been forwarded
+ * cbfunc - callback function when the data has been forwarded. If
+ *          cbfunc is NULL, then this is treated as a BLOCKING call
+ *          and the result of the operation will be provided in the
+ *          returned status
  *
  * cbdata - object to be returned in cbfunc
  */

--- a/include/pmix_common.h.in
+++ b/include/pmix_common.h.in
@@ -2434,20 +2434,24 @@ typedef void (*pmix_validation_cbfunc_t)(pmix_status_t status,
  * deregistering the current evhdlr, and then registering it
  * using a new set of info values.
  *
+ * If cbfunc is NULL, then this is treated as a BLOCKING call - a positive
+ * return value represents the reference ID for the request, while
+ * negative values indicate the corresponding error
+ *
  * See pmix_common.h for a description of the notification function */
-PMIX_EXPORT void PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
-                                             pmix_info_t info[], size_t ninfo,
-                                             pmix_notification_fn_t evhdlr,
-                                             pmix_hdlr_reg_cbfunc_t cbfunc,
-                                             void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Register_event_handler(pmix_status_t codes[], size_t ncodes,
+                                                      pmix_info_t info[], size_t ninfo,
+                                                      pmix_notification_fn_t evhdlr,
+                                                      pmix_hdlr_reg_cbfunc_t cbfunc,
+                                                      void *cbdata);
 
 /* Deregister an event handler
  * evhdlr_ref is the reference returned by PMIx from the call to
  * PMIx_Register_event_handler. If non-NULL, the provided cbfunc
  * will be called to confirm removal of the designated handler */
-PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
-                                               pmix_op_cbfunc_t cbfunc,
-                                               void *cbdata);
+PMIX_EXPORT pmix_status_t PMIx_Deregister_event_handler(size_t evhdlr_ref,
+                                                        pmix_op_cbfunc_t cbfunc,
+                                                        void *cbdata);
 
 /* Report an event for notification via any
  * registered evhdlr.
@@ -2486,6 +2490,9 @@ PMIX_EXPORT void PMIx_Deregister_event_handler(size_t evhdlr_ref,
  *          will have been queued, but may not have been transmitted
  *          by this time. Note that the caller is required to maintain
  *          the input data until the callback function has been executed!
+ *          If cbfunc is NULL, then this is treated as a BLOCKING call and
+ *          the result of the operation is provided in the returned
+ *          status
  *
  * cbdata - the caller's provided void* object
  */

--- a/src/common/pmix_security.c
+++ b/src/common/pmix_security.c
@@ -1,6 +1,6 @@
 /* -*- Mode: C; c-basic-offset:4 ; indent-tabs-mode:nil -*- */
 /*
- * Copyright (c) 2014-2018 Intel, Inc. All rights reserved.
+ * Copyright (c) 2014-2019 Intel, Inc.  All rights reserved.
  * Copyright (c) 2016      Mellanox Technologies, Inc.
  *                         All rights reserved.
  * Copyright (c) 2016      IBM Corporation.  All rights reserved.
@@ -110,8 +110,46 @@ static void getcbfunc(struct pmix_peer_t *peer,
     PMIX_RELEASE(cd);
 }
 
+static void mycdcb(pmix_status_t status,
+                   pmix_byte_object_t *credential,
+                   pmix_info_t info[], size_t ninfo,
+                   void *cbdata)
+{
+    pmix_query_caddy_t *cb = (pmix_query_caddy_t*)cbdata;
+
+    PMIX_ACQUIRE_OBJECT(cb);
+    cb->status = status;
+    if (PMIX_SUCCESS == status && NULL != credential) {
+        cb->bo.bytes = malloc(credential->size);
+        memcpy(cb->bo.bytes, credential->bytes, credential->size);
+        cb->bo.size = credential->size;
+    }
+    PMIX_RELEASE_THREAD(&cb->lock);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Get_credential(const pmix_info_t info[], size_t ninfo,
-                                              pmix_credential_cbfunc_t cbfunc, void *cbdata)
+                                              pmix_byte_object_t *credential)
+{
+    pmix_query_caddy_t cb;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);
+    rc = PMIx_Get_credential_nb(info, ninfo, mycdcb, &cb);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&cb.lock);
+        rc = cb.status;
+        if (NULL != cb.bo.bytes) {
+            credential->bytes = malloc(cb.bo.size);
+            memcpy(credential->bytes, cb.bo.bytes, cb.bo.size);
+            credential->size = cb.bo.size;
+        }
+    }
+    PMIX_DESTRUCT(&cb);
+    return rc;
+}
+
+PMIX_EXPORT pmix_status_t PMIx_Get_credential_nb(const pmix_info_t info[], size_t ninfo,
+                                                 pmix_credential_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_GET_CREDENTIAL_CMD;
@@ -296,9 +334,52 @@ static void valid_cbfunc(struct pmix_peer_t *peer,
     PMIX_RELEASE(cd);
 }
 
+static void myvalcb(pmix_status_t status,
+                    pmix_info_t info[], size_t ninfo,
+                    void *cbdata)
+{
+    pmix_query_caddy_t *cb = (pmix_query_caddy_t*)cbdata;
+    size_t n;
+
+    PMIX_ACQUIRE_OBJECT(cb);
+    cb->status = status;
+    if (PMIX_SUCCESS == status && NULL != info) {
+        cb->ninfo = ninfo;
+        PMIX_INFO_CREATE(cb->info, cb->ninfo);
+        for (n=0; n < ninfo; n++) {
+            PMIX_INFO_XFER(&cb->info[n], &info[n]);
+        }
+    }
+    PMIX_RELEASE_THREAD(&cb->lock);
+}
+
 PMIX_EXPORT pmix_status_t PMIx_Validate_credential(const pmix_byte_object_t *cred,
                                                    const pmix_info_t directives[], size_t ndirs,
-                                                   pmix_validation_cbfunc_t cbfunc, void *cbdata)
+                                                   pmix_info_t *results[], size_t *nresults)
+{
+    pmix_query_caddy_t cb;
+    pmix_status_t rc;
+
+    PMIX_CONSTRUCT(&cb, pmix_query_caddy_t);
+    rc = PMIx_Validate_credential_nb(cred, directives, ndirs, myvalcb, &cb);
+    if (PMIX_SUCCESS == rc) {
+        PMIX_WAIT_THREAD(&cb.lock);
+        rc = cb.status;
+        if (NULL != cb.info) {
+            *results = cb.info;
+            *nresults = cb.ninfo;
+            cb.info = NULL;
+            cb.ninfo = 0;
+        }
+    }
+    PMIX_DESTRUCT(&cb);
+    return rc;
+}
+
+
+PMIX_EXPORT pmix_status_t PMIx_Validate_credential_nb(const pmix_byte_object_t *cred,
+                                                      const pmix_info_t directives[], size_t ndirs,
+                                                      pmix_validation_cbfunc_t cbfunc, void *cbdata)
 {
     pmix_buffer_t *msg;
     pmix_cmd_t cmd = PMIX_VALIDATE_CRED_CMD;


### PR DESCRIPTION
Update the Job/Monitor blocking signatures. Update the event registration
signatures to return a status. Update behavior of IOF and credentials
functions to return status.

Signed-off-by: Ralph Castain <rhc@pmix.org>