### PR TITLE
Fix some Python bindings and avoid double-ref of list item

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -36,10 +36,11 @@ def main():
     procs = []
     info = [{'key': 'ARBITRARY', 'flags': PMIX_INFO_REQD, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.fence(procs, info)
-    print("Fence should be not supported", rc)
+    print("FENCE COMPLETE")
+    print("Fence should be not supported", foo.error_string(rc))
     info = [{'key': 'ARBITRARY', 'flags': None, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.publish(info)
-    print("Publish result: ", rc)
+    print("Publish result: ", foo.error_string(rc))
     # finalize
     info = []
     foo.finalize(info)

--- a/bindings/python/sched.py
+++ b/bindings/python/sched.py
@@ -19,15 +19,15 @@ class GracefulKiller:
 
 def clientconnected(proc:tuple is not None):
     print("CLIENT CONNECTED", proc)
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def clientfinalized(proc:tuple is not None):
     print("CLIENT FINALIZED", proc)
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def clientfence(args:dict is not None):
     print("SERVER FENCE", args)
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def main():
     try:

--- a/bindings/python/server.py
+++ b/bindings/python/server.py
@@ -19,11 +19,11 @@ class GracefulKiller:
 
 def clientconnected(proc:tuple is not None):
     print("CLIENT CONNECTED", proc)
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def clientfinalized(proc:tuple is not None):
     print("CLIENT FINALIZED", proc)
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def clientfence(procs:list, directives:list, data:bytearray):
     # check directives
@@ -40,7 +40,7 @@ def clientfence(procs:list, directives:list, data:bytearray):
                 except:
                     #it can be ignored
                     pass
-    return PMIX_SUCCESS
+    return PMIX_OPERATION_SUCCEEDED
 
 def main():
     try:

--- a/src/mca/gds/hash/gds_hash.c
+++ b/src/mca/gds/hash/gds_hash.c
@@ -380,7 +380,9 @@ static pmix_status_t process_node_array(pmix_value_t *val,
     }
     PMIX_LIST_DESTRUCT(&cache);
 
-    pmix_list_append(tgt, &nd->super);
+    if (!update) {
+        pmix_list_append(tgt, &nd->super);
+    }
     return PMIX_SUCCESS;
 }
 
@@ -399,7 +401,7 @@ static pmix_status_t process_app_array(pmix_value_t *val,
     pmix_status_t rc = PMIX_SUCCESS;
     uint32_t appnum;
     pmix_apptrkr_t *app = NULL, *apptr;
-    pmix_kval_t *kp2, *k1, *knext;
+    pmix_kval_t *kp2, *k1;
     pmix_nodeinfo_t *nd;
     bool update;
 
@@ -497,7 +499,7 @@ static pmix_status_t process_app_array(pmix_value_t *val,
         /* if this is an update, we have to ensure each data
          * item only appears once on the list */
         if (update) {
-            PMIX_LIST_FOREACH_SAFE(k1, knext, &app->appinfo, pmix_kval_t) {
+            PMIX_LIST_FOREACH(k1, &app->appinfo, pmix_kval_t) {
                 if (PMIX_CHECK_KEY(k1, kp2->key)) {
                     pmix_list_remove_item(&app->appinfo, &k1->super);
                     PMIX_RELEASE(k1);


### PR DESCRIPTION
Need to use "def" instead of "cdef" on Python class function
definitions. If we don't have a new object, then don't update the list
in gds_hash.

Fixes https://github.com/pmix/prrte/issues/252

Signed-off-by: Ralph Castain <rhc@pmix.org>