### PR TITLE
Fix some double-free errors

### DIFF
--- a/src/common/pmix_iof.c
+++ b/src/common/pmix_iof.c
@@ -134,6 +134,7 @@ PMIX_EXPORT pmix_status_t PMIx_IOF_pull(const pmix_proc_t procs[], size_t nprocs
     }
     if (NULL == regcbfunc) {
         cd->cbfunc.hdlrregcbfn = mycbfn;
+        PMIX_RETAIN(cd);
         cd->cbdata = cd;
     } else {
         cd->cbfunc.hdlrregcbfn = regcbfunc;
@@ -463,6 +464,7 @@ pmix_status_t PMIx_IOF_push(const pmix_proc_t targets[], size_t ntargets,
         }
         if (NULL == cbfunc) {
             cd->cbfunc = myopcb;
+            PMIX_RETAIN(cd);
             cd->cbdata = cd;
         } else {
             cd->cbfunc = cbfunc;

--- a/src/event/pmix_event_registration.c
+++ b/src/event/pmix_event_registration.c
@@ -1143,6 +1143,7 @@ PMIX_EXPORT pmix_status_t PMIx_Deregister_event_handler(size_t event_hdlr_ref,
     cd = PMIX_NEW(pmix_shift_caddy_t);
     if (NULL == cbfunc) {
         cd->cbfunc.opcbfn = myopcb;
+        PMIX_RETAIN(cd);
         cd->cbdata = cd;
     } else {
         cd->cbfunc.opcbfn = cbfunc;


### PR DESCRIPTION
Some of the new blocking fn forms use a shortcut to resolve the thread
lock. Ensure the lock object doesn't get released too soon.

Signed-off-by: Ralph Castain <rhc@pmix.org>