### PR TITLE
add python wrappers and server host functions

### DIFF
--- a/bindings/python/client.py
+++ b/bindings/python/client.py
@@ -25,7 +25,6 @@ def main():
     procs = []
     info = []
     rc = foo.fence(procs, info)
-    print("Fence result ", rc)
     print("GET")
     info = []
     rc, get_val = foo.get({'nspace':"testnspace", 'rank': 0}, "mykey", info)
@@ -41,6 +40,17 @@ def main():
     info = [{'key': 'ARBITRARY', 'flags': None, 'value':10, 'val_type':PMIX_INT}]
     rc = foo.publish(info)
     print("Publish result: ", foo.error_string(rc))
+    rc = foo.fence(procs, info)
+    #time.sleep(2)
+    pdata_key = [{'key':'ARBITRARY'}]
+    rc,pdata = foo.lookup(pdata_key, None)
+    #rc = foo.lookup(pdata_key, None)
+    print("rc lookup: ", rc)
+    print("pdata lookup: ", pdata)
+    pykeys = ['ARBITRARY']
+    info = []
+    rc = foo.unpublish(pykeys, info)
+    print("unpublish result: ", foo.error_string(rc))
     # finalize
     info = []
     foo.finalize(info)

--- a/bindings/python/sched.py
+++ b/bindings/python/sched.py
@@ -8,6 +8,9 @@ import subprocess
 
 global killer
 
+# where local data is published for testing
+pmix_locdata = []
+
 class GracefulKiller:
   kill_now = False
   def __init__(self):
@@ -25,9 +28,54 @@ def clientfinalized(proc:tuple is not None):
     print("CLIENT FINALIZED", proc)
     return PMIX_OPERATION_SUCCEEDED
 
-def clientfence(args:dict is not None):
-    print("SERVER FENCE", args)
+def clientfence(procs:list, directives:list, data:bytearray):
+    # check directives
+    print("CLIENTFENCE")
+    output = bytearray(0)
+    if directives is not None:
+        for d in directives:
+            # these are each an info dict
+            if "pmix" not in d['key']:
+                # we do not support such directives - see if
+                # it is required
+                try:
+                    if d['flags'] & PMIX_INFO_REQD:
+                        # return an error
+                        return PMIX_ERR_NOT_SUPPORTED, output
+                except:
+                    #it can be ignored
+                    pass
+    print("COMPLETE")
+    return PMIX_OPERATION_SUCCEEDED, output
+
+def clientpublish(proc:dict, directives:list):
+    print("SERVER: PUBLISH")
+    for d in directives:
+        pdata = {}
+        pdata['proc'] = proc
+        pdata['key']            = d['key']
+        pdata['value']          = d['value']
+        pdata['val_type']       = d['val_type']
+        pmix_locdata.append(pdata)
     return PMIX_OPERATION_SUCCEEDED
+
+def clientunpublish(proc:dict, pykeys:list, directives:list):
+    print("SERVER: UNPUBLISH")
+    for k in pykeys:
+        for d in pmix_locdata:
+            if k.decode('ascii') == d['key']:
+                pmix_locdata.remove(d)
+    return PMIX_OPERATION_SUCCEEDED
+
+def clientlookup(proc:dict, keys:list, directives:list):
+    print("SERVER: LOOKUP")
+    ret_pdata = []
+    for k in keys:
+        for d in pmix_locdata:
+            if k.decode('ascii') == d['key']:
+                ret_pdata.append(d)
+    # return rc and pdata
+    return ret_pdata, PMIX_SUCCESS
 
 def main():
     try:
@@ -39,7 +87,10 @@ def main():
     args = [{'key':PMIX_SERVER_SCHEDULER, 'value':'T', 'val_type':PMIX_BOOL}]
     map = {'clientconnected': clientconnected,
            'clientfinalized': clientfinalized,
-           'fencenb': clientfence}
+           'fencenb': clientfence,
+           'publish': clientpublish,
+           'unpublish': clientunpublish,
+           'lookup': clientlookup}
     my_result = foo.init(args, map)
     print("Testing PMIx_Initialized")
     rc = foo.initialized()


### PR DESCRIPTION
Server and client functions for publish, unpublish, and lookup. Also uses the thread shift example to call the lookup callback, but I think that maybe needs some work in terms of how to generalize it for the rest of the callback functions. 

  - Add client and server module functions
      publish, unpublish, and lookup
    - Add initial thread shifting with timer
      based on example in PR #1457 using
      lookup callback function
    - Add load and unload functions for pdata
      struct

Signed-off-by: Danielle Sikich (Intel) <danielle.sikich@intel.com>